### PR TITLE
compilation instruction for linux mint and better hidden input behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## Version 2.3.15
 
+- Inputs of the selected nodes are now always visible
 
 ## Version 2.3.14
 

--- a/Gui/Edge.cpp
+++ b/Gui/Edge.cpp
@@ -321,8 +321,9 @@ Edge::computeVisibility(bool hovered) const
     }
 
     ///Determine whether the edge should be visible or not
+    bool isSelected = dst->getIsSelected();
     bool hideInputsKnobValue = dst ? dst->getNode()->getHideInputsKnobValue() : false;
-    if ( (_imp->isRotoMask || hideInputsKnobValue) && !_imp->isOutputEdge ) {
+    if ( (_imp->isRotoMask || (hideInputsKnobValue && !isSelected)) && !_imp->isOutputEdge ) {
         return false;
     } else {
         if (_imp->isOutputEdge) {
@@ -334,7 +335,6 @@ Edge::computeVisibility(bool hovered) const
             bool isViewer = effect ? dynamic_cast<ViewerInstance*>( effect.get() ) != 0 : false;
             bool isReader = effect ? effect->isReader() : false;
             bool autoHide = areOptionalInputsAutoHidden();
-            bool isSelected = dst->getIsSelected();
 
             /*
              * Hide the inputs if it is NOT hovered and NOT selected and auto-hide is enabled and if the node is either

--- a/INSTALL_LINUX.md
+++ b/INSTALL_LINUX.md
@@ -175,6 +175,10 @@ To build, go into the Natron directory and type:
     make
 
 If everything has been installed and configured correctly, it should build without errors.
+if you have both QT4 and QT5 installed qmake can generate errors, you can try
+
+    QT_SELECT=4 qmake -r
+    make
 
 If you want to build in DEBUG mode change the qmake call to this line:
 
@@ -258,6 +262,17 @@ boost: LIBS += -lboost_thread -lboost_system
 expat: LIBS += -lexpat
 expat: PKGCONFIG -= expat
 cairo: PKGCONFIG -= cairo
+```
+
+for linux mint you will need to add:
+
+```
+pyside {
+        PYSIDE_PKG_CONFIG_PATH = $$system($$PYTHON_CONFIG --prefix)/lib/pkgconfig:$$(PKG_CONFIG_PATH)
+        PKGCONFIG += pyside
+        INCLUDEPATH += $$system(env PKG_CONFIG_PATH=$$PYSIDE_PKG_CONFIG_PATH pkg-config --variable=includedir pyside)/QtCore
+        INCLUDEPATH += $$system(env PKG_CONFIG_PATH=$$PYSIDE_PKG_CONFIG_PATH pkg-config --variable=includedir pyside)/QtGui
+}
 ```
 
 ## CentOS7


### PR DESCRIPTION
## Description
add compilation instruction for mint distribution
add qmake issue fix
make hidden inputs visible when a node is selected (even if "hide inputs" is checked in properties panel as nuke does)

this is my first PR on github so tell me if i did anything wrong