### PR TITLE
LinuxSDKBuildScriptFix-335

### DIFF
--- a/tools/jenkins/include/scripts/build-Linux-sdk.sh
+++ b/tools/jenkins/include/scripts/build-Linux-sdk.sh
@@ -316,6 +316,9 @@ ISL_VERSION=0.20
 if [ "$GCC_VERSION" = 4.8.5 ]; then
     ISL_VERSION=0.14.1
 fi
+if [ "$GCC_VERSION" = 8.2.0 ]; then
+    ISL_VERSION=0.19
+fi
 ISL_TAR="isl-${ISL_VERSION}.tar.bz2"
 ISL_SITE="http://isl.gforge.inria.fr"
 


### PR DESCRIPTION
Please read the [contribution guidelines](https://github.com/MrKepzie/Natron/blob/master/CONTRIBUTING.md), and be sure we have a [Contributor License Agreement](http://natron.fr/cla) on record with the project.

## Description

LinuxSDKBuildScriptFix-335

Since GCC 8.2.0 will not build with ISL 0.20, this fix sets the ISL version to 0.19 instead when GCC is version 8.2.0.
