### PR TITLE
Natron sdk linux fixes

### DIFF
--- a/tools/jenkins/include/patches/bison/0001-fflush-adjust-to-glibc-2.28-libio.h-removal.patch
+++ b/tools/jenkins/include/patches/bison/0001-fflush-adjust-to-glibc-2.28-libio.h-removal.patch
@@ -1,0 +1,50 @@
+From 4af4a4a71827c0bc5e0ec67af23edef4f15cee8e Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Mon, 5 Mar 2018 10:56:29 -0800
+Subject: [PATCH 1/1] fflush: adjust to glibc 2.28 libio.h removal
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Problem reported by Daniel P. Berrangé in:
+https://lists.gnu.org/r/bug-gnulib/2018-03/msg00000.html
+* lib/fbufmode.c (fbufmode):
+* lib/fflush.c (clear_ungetc_buffer_preserving_position)
+(disable_seek_optimization, rpl_fflush):
+* lib/fpending.c (__fpending):
+* lib/fpurge.c (fpurge):
+* lib/freadable.c (freadable):
+* lib/freadahead.c (freadahead):
+* lib/freading.c (freading):
+* lib/freadptr.c (freadptr):
+* lib/freadseek.c (freadptrinc):
+* lib/fseeko.c (fseeko):
+* lib/fseterr.c (fseterr):
+* lib/fwritable.c (fwritable):
+* lib/fwriting.c (fwriting):
+Check _IO_EOF_SEEN instead of _IO_ftrylockfile.
+* lib/stdio-impl.h (_IO_IN_BACKUP) [_IO_EOF_SEEN]:
+Define if not already defined.
+---
+ lib/fseterr.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+[yann.morin.1998@free.fr: partially backport from upstream gnulib]
+Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
+
+diff --git a/lib/fseterr.c b/lib/fseterr.c
+index 82649c3ac..adb637256 100644
+--- a/lib/fseterr.c
++++ b/lib/fseterr.c
+@@ -29,7 +29,7 @@ fseterr (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_flags |= _IO_ERR_SEEN;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+   /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Minix 3, Android */
+-- 
+2.14.1
+

--- a/tools/jenkins/include/patches/bison/0002-fflush-be-more-paranoid-about-libio.h-change.patch
+++ b/tools/jenkins/include/patches/bison/0002-fflush-be-more-paranoid-about-libio.h-change.patch
@@ -1,0 +1,46 @@
+From 74d9d6a293d7462dea8f83e7fc5ac792e956a0ad Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Thu, 8 Mar 2018 16:42:45 -0800
+Subject: [PATCH 2/2] fflush: be more paranoid about libio.h change
+
+Suggested by Eli Zaretskii in:
+https://lists.gnu.org/r/emacs-devel/2018-03/msg00270.html
+* lib/fbufmode.c (fbufmode):
+* lib/fflush.c (clear_ungetc_buffer_preserving_position)
+(disable_seek_optimization, rpl_fflush):
+* lib/fpending.c (__fpending):
+* lib/fpurge.c (fpurge):
+* lib/freadable.c (freadable):
+* lib/freadahead.c (freadahead):
+* lib/freading.c (freading):
+* lib/freadptr.c (freadptr):
+* lib/freadseek.c (freadptrinc):
+* lib/fseeko.c (fseeko):
+* lib/fseterr.c (fseterr):
+* lib/fwritable.c (fwritable):
+* lib/fwriting.c (fwriting):
+Look at _IO_ftrylockfile as well as at _IO_EOF_SEEN.
+---
+ lib/fseterr.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+[yann.morin.1998@free.fr: partially backport from upstream gnulib]
+Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
+
+diff --git a/lib/fseterr.c b/lib/fseterr.c
+index adb637256..fd9da6338 100644
+--- a/lib/fseterr.c
++++ b/lib/fseterr.c
+@@ -29,7 +29,8 @@ fseterr (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1
++  /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_flags |= _IO_ERR_SEEN;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+   /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Minix 3, Android */
+-- 
+2.14.1
+

--- a/tools/jenkins/include/patches/breakpad/0002-Replace-remaining-references-to-struct-ucontext-with.patch
+++ b/tools/jenkins/include/patches/breakpad/0002-Replace-remaining-references-to-struct-ucontext-with.patch
@@ -1,0 +1,257 @@
+From 7975a962e1d6dbad5a46792a54e647abd7caf5f1 Mon Sep 17 00:00:00 2001
+From: Mark Mentovai <mark@chromium.org>
+Date: Tue, 19 Sep 2017 22:48:30 -0400
+Subject: [PATCH] Replace remaining references to 'struct ucontext' with
+ 'ucontext_t'
+
+This relands
+https://chromium.googlesource.com/breakpad/breakpad/src/+/e3035bc406cee8a4d765e59ad46eb828705f17f4,
+which was accidentally committed to breakpad/breakpad/src, the read-only
+mirror of src in breakpad/breakpad. (Well, it should have been
+read-only.) See https://crbug.com/766164.
+
+This fixes issues with glibc-2.26.
+
+See https://bugs.gentoo.org/show_bug.cgi?id=628782 ,
+https://sourceware.org/git/?p=glibc.git;h=251287734e89a52da3db682a8241eb6bccc050c9 , and
+https://sourceware.org/ml/libc-alpha/2017-08/msg00010.html for context.
+Change-Id: Id66f474d636dd2afa450bab925c5514a800fdd6f
+Reviewed-on: https://chromium-review.googlesource.com/674304
+Reviewed-by: Mark Mentovai <mark@chromium.org>
+
+(cherry picked from commit bddcc58860f522a0d4cbaa7e9d04058caee0db9d)
+[Romain: backport from upstream]
+Signed-off-by: Romain Naour <romain.naour@gmail.com>
+---
+ .../linux/dump_writer_common/ucontext_reader.cc    | 32 +++++++++++-----------
+ .../linux/dump_writer_common/ucontext_reader.h     | 14 +++++-----
+ src/client/linux/handler/exception_handler.cc      | 10 +++----
+ src/client/linux/handler/exception_handler.h       |  6 ++--
+ .../linux/microdump_writer/microdump_writer.cc     |  2 +-
+ .../linux/minidump_writer/minidump_writer.cc       |  2 +-
+ 6 files changed, 33 insertions(+), 33 deletions(-)
+
+diff --git a/src/client/linux/dump_writer_common/ucontext_reader.cc b/src/client/linux/dump_writer_common/ucontext_reader.cc
+index c80724d..052ce37 100644
+--- a/src/client/linux/dump_writer_common/ucontext_reader.cc
++++ b/src/client/linux/dump_writer_common/ucontext_reader.cc
+@@ -36,19 +36,19 @@ namespace google_breakpad {
+ 
+ // Minidump defines register structures which are different from the raw
+ // structures which we get from the kernel. These are platform specific
+-// functions to juggle the ucontext and user structures into minidump format.
++// functions to juggle the ucontext_t and user structures into minidump format.
+ 
+ #if defined(__i386__)
+ 
+-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.gregs[REG_ESP];
+ }
+ 
+-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.gregs[REG_EIP];
+ }
+ 
+-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
++void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
+                                     const struct _libc_fpstate* fp) {
+   const greg_t* regs = uc->uc_mcontext.gregs;
+ 
+@@ -88,15 +88,15 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
+ 
+ #elif defined(__x86_64)
+ 
+-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.gregs[REG_RSP];
+ }
+ 
+-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.gregs[REG_RIP];
+ }
+ 
+-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
++void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
+                                     const struct _libc_fpstate* fpregs) {
+   const greg_t* regs = uc->uc_mcontext.gregs;
+ 
+@@ -145,15 +145,15 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
+ 
+ #elif defined(__ARM_EABI__)
+ 
+-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.arm_sp;
+ }
+ 
+-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.arm_pc;
+ }
+ 
+-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc) {
++void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc) {
+   out->context_flags = MD_CONTEXT_ARM_FULL;
+ 
+   out->iregs[0] = uc->uc_mcontext.arm_r0;
+@@ -184,15 +184,15 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc) {
+ 
+ #elif defined(__aarch64__)
+ 
+-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.sp;
+ }
+ 
+-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.pc;
+ }
+ 
+-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
++void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
+                                     const struct fpsimd_context* fpregs) {
+   out->context_flags = MD_CONTEXT_ARM64_FULL;
+ 
+@@ -210,15 +210,15 @@ void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc,
+ 
+ #elif defined(__mips__)
+ 
+-uintptr_t UContextReader::GetStackPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetStackPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.gregs[MD_CONTEXT_MIPS_REG_SP];
+ }
+ 
+-uintptr_t UContextReader::GetInstructionPointer(const struct ucontext* uc) {
++uintptr_t UContextReader::GetInstructionPointer(const ucontext_t* uc) {
+   return uc->uc_mcontext.pc;
+ }
+ 
+-void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext *uc) {
++void UContextReader::FillCPUContext(RawContextCPU *out, const ucontext_t *uc) {
+ #if _MIPS_SIM == _ABI64
+   out->context_flags = MD_CONTEXT_MIPS64_FULL;
+ #elif _MIPS_SIM == _ABIO32
+diff --git a/src/client/linux/dump_writer_common/ucontext_reader.h b/src/client/linux/dump_writer_common/ucontext_reader.h
+index b6e77b4..2de80b7 100644
+--- a/src/client/linux/dump_writer_common/ucontext_reader.h
++++ b/src/client/linux/dump_writer_common/ucontext_reader.h
+@@ -39,23 +39,23 @@
+ 
+ namespace google_breakpad {
+ 
+-// Wraps platform-dependent implementations of accessors to ucontext structs.
++// Wraps platform-dependent implementations of accessors to ucontext_t structs.
+ struct UContextReader {
+-  static uintptr_t GetStackPointer(const struct ucontext* uc);
++  static uintptr_t GetStackPointer(const ucontext_t* uc);
+ 
+-  static uintptr_t GetInstructionPointer(const struct ucontext* uc);
++  static uintptr_t GetInstructionPointer(const ucontext_t* uc);
+ 
+-  // Juggle a arch-specific ucontext into a minidump format
++  // Juggle a arch-specific ucontext_t into a minidump format
+   //   out: the minidump structure
+   //   info: the collection of register structures.
+ #if defined(__i386__) || defined(__x86_64)
+-  static void FillCPUContext(RawContextCPU *out, const ucontext *uc,
++  static void FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
+                              const struct _libc_fpstate* fp);
+ #elif defined(__aarch64__)
+-  static void FillCPUContext(RawContextCPU *out, const ucontext *uc,
++  static void FillCPUContext(RawContextCPU *out, const ucontext_t *uc,
+                              const struct fpsimd_context* fpregs);
+ #else
+-  static void FillCPUContext(RawContextCPU *out, const ucontext *uc);
++  static void FillCPUContext(RawContextCPU *out, const ucontext_t *uc);
+ #endif
+ };
+ 
+diff --git a/src/client/linux/handler/exception_handler.cc b/src/client/linux/handler/exception_handler.cc
+index b63f973..3d809b8 100644
+--- a/src/client/linux/handler/exception_handler.cc
++++ b/src/client/linux/handler/exception_handler.cc
+@@ -439,9 +439,9 @@ bool ExceptionHandler::HandleSignal(int sig, siginfo_t* info, void* uc) {
+   // Fill in all the holes in the struct to make Valgrind happy.
+   memset(&g_crash_context_, 0, sizeof(g_crash_context_));
+   memcpy(&g_crash_context_.siginfo, info, sizeof(siginfo_t));
+-  memcpy(&g_crash_context_.context, uc, sizeof(struct ucontext));
++  memcpy(&g_crash_context_.context, uc, sizeof(ucontext_t));
+ #if defined(__aarch64__)
+-  struct ucontext* uc_ptr = (struct ucontext*)uc;
++  ucontext_t* uc_ptr = (ucontext_t*)uc;
+   struct fpsimd_context* fp_ptr =
+       (struct fpsimd_context*)&uc_ptr->uc_mcontext.__reserved;
+   if (fp_ptr->head.magic == FPSIMD_MAGIC) {
+@@ -450,9 +450,9 @@ bool ExceptionHandler::HandleSignal(int sig, siginfo_t* info, void* uc) {
+   }
+ #elif !defined(__ARM_EABI__) && !defined(__mips__)
+   // FP state is not part of user ABI on ARM Linux.
+-  // In case of MIPS Linux FP state is already part of struct ucontext
++  // In case of MIPS Linux FP state is already part of ucontext_t
+   // and 'float_state' is not a member of CrashContext.
+-  struct ucontext* uc_ptr = (struct ucontext*)uc;
++  ucontext_t* uc_ptr = (ucontext_t*)uc;
+   if (uc_ptr->uc_mcontext.fpregs) {
+     memcpy(&g_crash_context_.float_state, uc_ptr->uc_mcontext.fpregs,
+            sizeof(g_crash_context_.float_state));
+@@ -476,7 +476,7 @@ bool ExceptionHandler::SimulateSignalDelivery(int sig) {
+   // ExceptionHandler::HandleSignal().
+   siginfo.si_code = SI_USER;
+   siginfo.si_pid = getpid();
+-  struct ucontext context;
++  ucontext_t context;
+   getcontext(&context);
+   return HandleSignal(sig, &siginfo, &context);
+ }
+diff --git a/src/client/linux/handler/exception_handler.h b/src/client/linux/handler/exception_handler.h
+index 591c310..42f4055 100644
+--- a/src/client/linux/handler/exception_handler.h
++++ b/src/client/linux/handler/exception_handler.h
+@@ -191,11 +191,11 @@ class ExceptionHandler {
+   struct CrashContext {
+     siginfo_t siginfo;
+     pid_t tid;  // the crashing thread.
+-    struct ucontext context;
++    ucontext_t context;
+ #if !defined(__ARM_EABI__) && !defined(__mips__)
+     // #ifdef this out because FP state is not part of user ABI for Linux ARM.
+-    // In case of MIPS Linux FP state is already part of struct
+-    // ucontext so 'float_state' is not required.
++    // In case of MIPS Linux FP state is already part of ucontext_t so
++    // 'float_state' is not required.
+     fpstate_t float_state;
+ #endif
+   };
+diff --git a/src/client/linux/microdump_writer/microdump_writer.cc b/src/client/linux/microdump_writer/microdump_writer.cc
+index 6f5b435..a508667 100644
+--- a/src/client/linux/microdump_writer/microdump_writer.cc
++++ b/src/client/linux/microdump_writer/microdump_writer.cc
+@@ -571,7 +571,7 @@ class MicrodumpWriter {
+ 
+   void* Alloc(unsigned bytes) { return dumper_->allocator()->Alloc(bytes); }
+ 
+-  const struct ucontext* const ucontext_;
++  const ucontext_t* const ucontext_;
+ #if !defined(__ARM_EABI__) && !defined(__mips__)
+   const google_breakpad::fpstate_t* const float_state_;
+ #endif
+diff --git a/src/client/linux/minidump_writer/minidump_writer.cc b/src/client/linux/minidump_writer/minidump_writer.cc
+index 86009b9..f2aec73 100644
+--- a/src/client/linux/minidump_writer/minidump_writer.cc
++++ b/src/client/linux/minidump_writer/minidump_writer.cc
+@@ -1248,7 +1248,7 @@ class MinidumpWriter {
+   const int fd_;  // File descriptor where the minidum should be written.
+   const char* path_;  // Path to the file where the minidum should be written.
+ 
+-  const struct ucontext* const ucontext_;  // also from the signal handler
++  const ucontext_t* const ucontext_;  // also from the signal handler
+ #if !defined(__ARM_EABI__) && !defined(__mips__)
+   const google_breakpad::fpstate_t* const float_state_;  // ditto
+ #endif
+-- 
+2.9.5
+

--- a/tools/jenkins/include/patches/gdb/gdb-Fix-ia64-defining-TRAP_HWBKPT-before-including-g.patch
+++ b/tools/jenkins/include/patches/gdb/gdb-Fix-ia64-defining-TRAP_HWBKPT-before-including-g.patch
@@ -1,0 +1,56 @@
+From b033a9663053eed87cb572397176747b88e9a699 Mon Sep 17 00:00:00 2001
+From: James Clarke <jrtc27@jrtc27.com>
+Date: Fri, 19 Jan 2018 17:22:49 +0000
+Subject: [PATCH] gdb: Fix ia64 defining TRAP_HWBKPT before including
+ gdb_wait.h
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+On ia64, gdb_wait.h eventually includes siginfo-consts-arch.h, which
+contains an enum with TRAP_HWBKPT, along with a #define. Thus we cannot
+define TRAP_HWBKPT to 4 beforehand, and so gdb_wait.h must be included
+earlier; include it from linux-ptrace.h so it can never come afterwards.
+
+gdb/ChangeLog:
+
+	* nat/linux-ptrace.c: Remove unnecessary reinclusion of
+	gdb_ptrace.h, and move including gdb_wait.h ...
+	* nat/linux-ptrace.h: ... to here.
+
+Upstream-Status: Accepted [https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=commit;h=5a6c3296a7a90694ad4042f6256f3da6d4fa4ee8]
+
+Signed-off-by: Daniel Díaz <daniel.diaz@linaro.org>
+---
+ gdb/nat/linux-ptrace.c | 2 --
+ gdb/nat/linux-ptrace.h | 1 +
+ 2 files changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/gdb/nat/linux-ptrace.c b/gdb/nat/linux-ptrace.c
+index 3265b16..559c2de 100644
+--- a/gdb/nat/linux-ptrace.c
++++ b/gdb/nat/linux-ptrace.c
+@@ -21,8 +21,6 @@
+ #include "linux-procfs.h"
+ #include "linux-waitpid.h"
+ #include "buffer.h"
+-#include "gdb_wait.h"
+-#include "gdb_ptrace.h"
+ #ifdef HAVE_SYS_PROCFS_H
+ #include <sys/procfs.h>
+ #endif
+diff --git a/gdb/nat/linux-ptrace.h b/gdb/nat/linux-ptrace.h
+index 5954945..6faa89b 100644
+--- a/gdb/nat/linux-ptrace.h
++++ b/gdb/nat/linux-ptrace.h
+@@ -21,6 +21,7 @@
+ struct buffer;
+ 
+ #include "nat/gdb_ptrace.h"
++#include "gdb_wait.h"
+ 
+ #ifdef __UCLIBC__
+ #if !(defined(__UCLIBC_HAS_MMU__) || defined(__ARCH_HAS_MMU__))
+-- 
+2.7.4
+

--- a/tools/jenkins/include/patches/m4/m4-1.4.18-glibc-change-work-around.patch
+++ b/tools/jenkins/include/patches/m4/m4-1.4.18-glibc-change-work-around.patch
@@ -1,0 +1,129 @@
+update for glibc libio.h removal in 2.28+
+
+see
+https://src.fedoraproject.org/rpms/m4/c/814d592134fad36df757f9a61422d164ea2c6c9b?branch=master
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Index: m4-1.4.18/lib/fflush.c
+===================================================================
+--- m4-1.4.18.orig/lib/fflush.c
++++ m4-1.4.18/lib/fflush.c
+@@ -33,7 +33,7 @@
+ #undef fflush
+ 
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+ /* Clear the stream's ungetc buffer, preserving the value of ftello (fp).  */
+ static void
+@@ -72,7 +72,7 @@ clear_ungetc_buffer (FILE *fp)
+ 
+ #endif
+ 
+-#if ! (defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */)
++#if ! (defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */)
+ 
+ # if (defined __sferror || defined __DragonFly__ || defined __ANDROID__) && defined __SNPT
+ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+@@ -148,7 +148,7 @@ rpl_fflush (FILE *stream)
+   if (stream == NULL || ! freading (stream))
+     return fflush (stream);
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+   clear_ungetc_buffer_preserving_position (stream);
+ 
+Index: m4-1.4.18/lib/fpending.c
+===================================================================
+--- m4-1.4.18.orig/lib/fpending.c
++++ m4-1.4.18/lib/fpending.c
+@@ -32,7 +32,7 @@ __fpending (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   return fp->_IO_write_ptr - fp->_IO_write_base;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+   /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+Index: m4-1.4.18/lib/fpurge.c
+===================================================================
+--- m4-1.4.18.orig/lib/fpurge.c
++++ m4-1.4.18/lib/fpurge.c
+@@ -62,7 +62,7 @@ fpurge (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_IO_read_end = fp->_IO_read_ptr;
+   fp->_IO_write_ptr = fp->_IO_write_base;
+   /* Avoid memory leak when there is an active ungetc buffer.  */
+Index: m4-1.4.18/lib/freadahead.c
+===================================================================
+--- m4-1.4.18.orig/lib/freadahead.c
++++ m4-1.4.18/lib/freadahead.c
+@@ -25,7 +25,7 @@
+ size_t
+ freadahead (FILE *fp)
+ {
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_write_ptr > fp->_IO_write_base)
+     return 0;
+   return (fp->_IO_read_end - fp->_IO_read_ptr)
+Index: m4-1.4.18/lib/freading.c
+===================================================================
+--- m4-1.4.18.orig/lib/freading.c
++++ m4-1.4.18/lib/freading.c
+@@ -31,7 +31,7 @@ freading (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   return ((fp->_flags & _IO_NO_WRITES) != 0
+           || ((fp->_flags & (_IO_NO_READS | _IO_CURRENTLY_PUTTING)) == 0
+               && fp->_IO_read_base != NULL));
+Index: m4-1.4.18/lib/fseeko.c
+===================================================================
+--- m4-1.4.18.orig/lib/fseeko.c
++++ m4-1.4.18/lib/fseeko.c
+@@ -47,7 +47,7 @@ fseeko (FILE *fp, off_t offset, int when
+ #endif
+ 
+   /* These tests are based on fpurge.c.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_read_end == fp->_IO_read_ptr
+       && fp->_IO_write_ptr == fp->_IO_write_base
+       && fp->_IO_save_base == NULL)
+@@ -123,7 +123,7 @@ fseeko (FILE *fp, off_t offset, int when
+           return -1;
+         }
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+       fp->_flags &= ~_IO_EOF_SEEN;
+       fp->_offset = pos;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+Index: m4-1.4.18/lib/stdio-impl.h
+===================================================================
+--- m4-1.4.18.orig/lib/stdio-impl.h
++++ m4-1.4.18/lib/stdio-impl.h
+@@ -18,6 +18,12 @@
+    the same implementation of stdio extension API, except that some fields
+    have different naming conventions, or their access requires some casts.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
+ 
+ /* BSD stdio derived implementations.  */
+ 

--- a/tools/jenkins/include/patches/nasm/0001-Remove-invalid-pure_func-qualifiers.patch
+++ b/tools/jenkins/include/patches/nasm/0001-Remove-invalid-pure_func-qualifiers.patch
@@ -1,0 +1,27 @@
+From d0dabb46a821b2506681f882af0d5696d2c2bade Mon Sep 17 00:00:00 2001
+From: Michael Simacek <msimacek@redhat.com>
+Date: Thu, 8 Feb 2018 14:47:08 +0100
+Subject: [PATCH] Remove invalid pure_func qualifiers
+
+---
+ include/nasmlib.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/nasmlib.h b/include/nasmlib.h
+index 79e866b..c93cef0 100644
+--- a/include/nasmlib.h
++++ b/include/nasmlib.h
+@@ -191,8 +191,8 @@ int64_t readstrnum(char *str, int length, bool *warn);
+  * seg_init: Initialise the segment-number allocator.
+  * seg_alloc: allocate a hitherto unused segment number.
+  */
+-void pure_func seg_init(void);
+-int32_t pure_func seg_alloc(void);
++void seg_init(void);
++int32_t seg_alloc(void);
+ 
+ /*
+  * many output formats will be able to make use of this: a standard
+-- 
+2.14.3
+

--- a/tools/jenkins/include/scripts/build-Linux-sdk.sh
+++ b/tools/jenkins/include/scripts/build-Linux-sdk.sh
@@ -604,6 +604,9 @@ if [ ! -s "$SDK_HOME/bin/nasm" ]; then
     download "$NASM_SITE" "$NASM_TAR"
     untar "$SRC_PATH/$NASM_TAR"
     pushd "nasm-${NASM_VERSION}"
+    if [ "${GCC_VERSION:0:2}" = 8. ]; then
+        patch -Np1 -i "$INC_PATH"/patches/nasm/0001-Remove-invalid-pure_func-qualifiers.patch
+    fi
     env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$SDK_HOME" --disable-static --enable-shared
     make -j${MKJOBS}
     make install

--- a/tools/jenkins/include/scripts/build-Linux-sdk.sh
+++ b/tools/jenkins/include/scripts/build-Linux-sdk.sh
@@ -1789,7 +1789,7 @@ fi
 # Install pixman
 # see http://www.at.linuxfromscratch.org/blfs/view/cvs/general/pixman.html
 PIX_VERSION=0.34.0
-PIX_TAR="pixman-${PIX_VERSION}.tar.bz2"
+PIX_TAR="pixman-${PIX_VERSION}.tar.gz"
 PIX_SITE="https://www.cairographics.org/releases"
 if [ "${REBUILD_PIXMAN:-}" = "1" ]; then
     rm -rf "$SDK_HOME"/{lib,include}/*pixman* || true

--- a/tools/jenkins/include/scripts/build-Linux-sdk.sh
+++ b/tools/jenkins/include/scripts/build-Linux-sdk.sh
@@ -451,6 +451,9 @@ if [ ! -s "$SDK_HOME/bin/bison" ]; then
     download "$BISON_SITE" "$BISON_TAR"
     untar "$SRC_PATH/$BISON_TAR"
     pushd "bison-${BISON_VERSION}"
+    # 2 patches for use with glibc 2.28 and up.
+    patch -Np1 -i "$INC_PATH"/patches/bison/0001-fflush-adjust-to-glibc-2.28-libio.h-removal.patch
+    patch -Np1 -i "$INC_PATH"/patches/bison/0002-fflush-be-more-paranoid-about-libio.h-change.patch
     env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$SDK_HOME"
     make -j${MKJOBS}
     make install

--- a/tools/jenkins/include/scripts/build-Linux-sdk.sh
+++ b/tools/jenkins/include/scripts/build-Linux-sdk.sh
@@ -369,6 +369,8 @@ if [ ! -s "$SDK_HOME/bin/m4" ]; then
     download "$M4_SITE" "$M4_TAR"
     untar "$SRC_PATH/$M4_TAR"
     pushd "m4-${M4_VERSION}"
+    # Patch for use with glibc 2.28 and up.
+    patch -Np1 -i "$INC_PATH"/patches/m4/m4-1.4.18-glibc-change-work-around.patch
     env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$SDK_HOME" --enable-static --enable-shared
     make -j${MKJOBS}
     make install

--- a/tools/jenkins/include/scripts/build-Linux-sdk.sh
+++ b/tools/jenkins/include/scripts/build-Linux-sdk.sh
@@ -2932,6 +2932,10 @@ if [ ! -s "$SDK_HOME/bin/gdb" ]; then
     download "$GDB_SITE" "$GDB_TAR"
     untar "$SRC_PATH/$GDB_TAR"
     pushd "gdb-${GDB_VERSION}"
+
+    # Patch issue with header ordering for TRAP_HWBKPT
+    patch -Np1 -i "$INC_PATH"/patches/gdb/gdb-Fix-ia64-defining-TRAP_HWBKPT-before-including-g.patch
+
     env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$SDK_HOME" --enable-tui --with-system-readline --without-guile
     make -j${MKJOBS}
     make install

--- a/tools/jenkins/include/scripts/build-Linux-sdk.sh
+++ b/tools/jenkins/include/scripts/build-Linux-sdk.sh
@@ -1332,29 +1332,6 @@ env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$SDK_HOME" --disable-stati
     end_build "$FTYPE_TAR"
 fi
 
-# Install fontconfig
-# see http://www.linuxfromscratch.org/blfs/view/cvs/general/fontconfig.html
-FONTCONFIG_VERSION=2.13.0
-FONTCONFIG_TAR="fontconfig-${FONTCONFIG_VERSION}.tar.gz"
-FONTCONFIG_SITE="https://www.freedesktop.org/software/fontconfig/release"
-if [ "${REBUILD_FONTCONFIG:-}" = "1" ]; then
-    rm -f "$SDK_HOME"/lib/libfontconfig* || true
-    rm -rf "$SDK_HOME"/include/fontconfig || true
-    rm -f "$SDK_HOME"/lib/pkgconfig/fontconfig.pc || true
-fi
-if [ ! -s "$SDK_HOME/lib/pkgconfig/fontconfig.pc" ] || [ "$(pkg-config --modversion fontconfig)" != "$FONTCONFIG_VERSION" ]; then
-    start_build "$FONTCONFIG_TAR"
-    download "$FONTCONFIG_SITE" "$FONTCONFIG_TAR"
-    untar "$SRC_PATH/$FONTCONFIG_TAR"
-    pushd "fontconfig-${FONTCONFIG_VERSION}"
-    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$SDK_HOME" --disable-docs --disable-static --enable-shared
-    make -j${MKJOBS}
-    make install
-    popd
-    rm -rf "fontconfig-${FONTCONFIG_VERSION}"
-    end_build "$FONTCONFIG_TAR"
-fi
-
 # Install libmount (required by glib)
 # see http://www.linuxfromscratch.org/lfs/view/development/chapter06/util-linux.html
 if [ "${RHEL_MAJOR:-7}" -le 6 ]; then
@@ -1393,6 +1370,30 @@ if [ ! -s "$SDK_HOME/lib/pkgconfig/mount.pc" ] || [ "$(pkg-config --modversion m
     rm -rf "util-linux-${UTILLINUX_VERSION}"
     end_build "$UTILLINUX_TAR"
 fi
+
+# Install fontconfig
+# see http://www.linuxfromscratch.org/blfs/view/cvs/general/fontconfig.html
+FONTCONFIG_VERSION=2.13.0
+FONTCONFIG_TAR="fontconfig-${FONTCONFIG_VERSION}.tar.gz"
+FONTCONFIG_SITE="https://www.freedesktop.org/software/fontconfig/release"
+if [ "${REBUILD_FONTCONFIG:-}" = "1" ]; then
+    rm -f "$SDK_HOME"/lib/libfontconfig* || true
+    rm -rf "$SDK_HOME"/include/fontconfig || true
+    rm -f "$SDK_HOME"/lib/pkgconfig/fontconfig.pc || true
+fi
+if [ ! -s "$SDK_HOME/lib/pkgconfig/fontconfig.pc" ] || [ "$(pkg-config --modversion fontconfig)" != "$FONTCONFIG_VERSION" ]; then
+    start_build "$FONTCONFIG_TAR"
+    download "$FONTCONFIG_SITE" "$FONTCONFIG_TAR"
+    untar "$SRC_PATH/$FONTCONFIG_TAR"
+    pushd "fontconfig-${FONTCONFIG_VERSION}"
+    env CFLAGS="$BF" CXXFLAGS="$BF" ./configure --prefix="$SDK_HOME" --disable-docs --disable-static --enable-shared
+    make -j${MKJOBS}
+    make install
+    popd
+    rm -rf "fontconfig-${FONTCONFIG_VERSION}"
+    end_build "$FONTCONFIG_TAR"
+fi
+
 
 # Install Texinfo (for gdb)
 # see http://www.linuxfromscratch.org/lfs/view/development/chapter06/texinfo.html

--- a/tools/jenkins/include/scripts/build-Linux-sdk.sh
+++ b/tools/jenkins/include/scripts/build-Linux-sdk.sh
@@ -2891,6 +2891,10 @@ if [ ! -s "${SDK_HOME}/bin/dump_syms" ]; then
     git_clone_commit "$GIT_BREAKPAD" "$GIT_BREAKPAD_COMMIT"
     pushd breakpad
     git submodule update -i
+
+    # Patch bug due to fix of glibc
+    patch -Np1 -i "$INC_PATH"/patches/breakpad/0002-Replace-remaining-references-to-struct-ucontext-with.patch
+
     env CFLAGS="$BF" CXXFLAGS="$BF" ./configure -prefix "$SDK_HOME"
     make
     cp src/tools/linux/dump_syms/dump_syms "$SDK_HOME/bin/"


### PR DESCRIPTION
4 Fixes for the NatronSDK Linux build script:

m4: The gnulib bundled with m4 does not detect glibc version 2.28 and up properly.
Patch added to fix m4 build.

Bison: does not detect glibc version 2.28 and up properly.
2 patches added to fix bison build.

nasm: patch to fix building nasm with GCC 8.x.x.
Patch found here: https://github.com/spack/spack/pull/8307

fontconfig: fontconfig did not build due to a missing uuid, which is part of util-linux, which is only built AFTER fontconfig. Switching the build order of fontconfig and util-linux in the script fixes this issue.
