### PR TITLE
Fix missing libraw

### DIFF
--- a/tools/jenkins/include/scripts/build-Linux-sdk.sh
+++ b/tools/jenkins/include/scripts/build-Linux-sdk.sh
@@ -501,6 +501,7 @@ build lcms2
 build librevenge
 build libcdr
 build openjpeg
+build libraw
 build ilmbase
 build openexr
 build pixman


### PR DESCRIPTION
Build of _libraw_ is missing from tools/jenkins/include/scripts/build-Linux-sdk.sh, causing the build of Natron to fail.

Added 'build libraw' to the script.