### PR TITLE
Engine: fix taskFinished connects that uses WatcherCallerArgsPtr

### DIFF
--- a/Engine/GenericSchedulerThread.cpp
+++ b/Engine/GenericSchedulerThread.cpp
@@ -248,7 +248,7 @@ GenericSchedulerThread::waitForThreadToQuitQueued_main_thread(bool allowRestart)
     assert( QThread::currentThread() == qApp->thread() );
     // scoped_ptr
     _imp->blockingOperationWatcher.reset( new GenericSchedulerThreadWatcher(this) );
-    QObject::connect( _imp->blockingOperationWatcher.get(), SIGNAL(taskFinished(int,WatcherCallerArgsPtr)), this, SLOT(onWatcherTaskFinishedEmitted()) );
+    QObject::connect( _imp->blockingOperationWatcher.get(), SIGNAL(taskFinished(int,GenericWatcherCallerArgsPtr)), this, SLOT(onWatcherTaskFinishedEmitted()) );
     GenericSchedulerThreadWatcher::BlockingTaskEnum task = allowRestart ? GenericSchedulerThreadWatcher::eBlockingTaskWaitForQuitAllowRestart : GenericSchedulerThreadWatcher::eBlockingTaskWaitForQuitDisallowRestart;
     _imp->blockingOperationWatcher->scheduleBlockingTask(task);
 }
@@ -420,7 +420,7 @@ GenericSchedulerThread::waitForAbortToCompleteQueued_main_thread()
 {
     assert( QThread::currentThread() == qApp->thread() );
     _imp->blockingOperationWatcher.reset( new GenericSchedulerThreadWatcher(this) );
-    QObject::connect( _imp->blockingOperationWatcher.get(), SIGNAL(taskFinished(int,WatcherCallerArgsPtr)), this, SLOT(onWatcherTaskAbortedEmitted()) );
+    QObject::connect( _imp->blockingOperationWatcher.get(), SIGNAL(taskFinished(int,GenericWatcherCallerArgsPtr)), this, SLOT(onWatcherTaskAbortedEmitted()) );
     _imp->blockingOperationWatcher->scheduleBlockingTask(GenericSchedulerThreadWatcher::eBlockingTaskWaitForAbort);
 }
 

--- a/Engine/NodeMain.cpp
+++ b/Engine/NodeMain.cpp
@@ -847,7 +847,7 @@ Node::destroyNode(bool blockingDestroy, bool autoReconnect)
             isGrp->getNodes_recursive(nodesToWatch, false);
         }
         _imp->renderWatcher = boost::make_shared<NodeRenderWatcher>(nodesToWatch);
-        QObject::connect( _imp->renderWatcher.get(), SIGNAL(taskFinished(int,WatcherCallerArgsPtr)), this, SLOT(onProcessingQuitInDestroyNodeInternal(int,WatcherCallerArgsPtr)) );
+        QObject::connect( _imp->renderWatcher.get(), SIGNAL(taskFinished(int,GenericWatcherCallerArgsPtr)), this, SLOT(onProcessingQuitInDestroyNodeInternal(int,GenericWatcherCallerArgsPtr)) );
         NodeDestroyNodeInternalArgsPtr args = boost::make_shared<NodeDestroyNodeInternalArgs>();
         args->autoReconnect = autoReconnect;
         _imp->renderWatcher->scheduleBlockingTask(NodeRenderWatcher::eBlockingTaskQuitAnyProcessing, args);

--- a/Engine/OutputSchedulerThread.cpp
+++ b/Engine/OutputSchedulerThread.cpp
@@ -3190,7 +3190,7 @@ RenderEngine::waitForEngineToQuit_main_thread(bool allowRestart)
     assert( QThread::currentThread() == qApp->thread() );
     assert(!_imp->engineWatcher);
     _imp->engineWatcher.reset( new RenderEngineWatcher(this) );
-    QObject::connect( _imp->engineWatcher.get(), SIGNAL(taskFinished(int,WatcherCallerArgsPtr)), this, SLOT(onWatcherEngineQuitEmitted()) );
+    QObject::connect( _imp->engineWatcher.get(), SIGNAL(taskFinished(int,GenericWatcherCallerArgsPtr)), this, SLOT(onWatcherEngineQuitEmitted()) );
     _imp->engineWatcher->scheduleBlockingTask(allowRestart ? RenderEngineWatcher::eBlockingTaskWaitForQuitAllowRestart : RenderEngineWatcher::eBlockingTaskWaitForQuitDisallowRestart);
 }
 
@@ -3296,7 +3296,7 @@ RenderEngine::waitForAbortToComplete_main_thread()
     assert( QThread::currentThread() == qApp->thread() );
     assert(!_imp->engineWatcher);
     _imp->engineWatcher.reset( new RenderEngineWatcher(this) );
-    QObject::connect( _imp->engineWatcher.get(), SIGNAL(taskFinished(int,WatcherCallerArgsPtr)), this, SLOT(onWatcherEngineAbortedEmitted()) );
+    QObject::connect( _imp->engineWatcher.get(), SIGNAL(taskFinished(int,GenericWatcherCallerArgsPtr)), this, SLOT(onWatcherEngineAbortedEmitted()) );
     _imp->engineWatcher->scheduleBlockingTask(RenderEngineWatcher::eBlockingTaskWaitForAbort);
 }
 


### PR DESCRIPTION
I noticed failing connects while running Natron, switched WatcherCallerArgsPtr to GenericWatcherCallerArgsPtr.