### PR TITLE
update linux build instruction

### DIFF
--- a/INSTALL_LINUX.md
+++ b/INSTALL_LINUX.md
@@ -57,6 +57,7 @@ LIBRAW="$SDK/libraw-gpl2"
 PATH="$SDK/bin:$QTDIR/bin:$GCC/bin:$FFMPEG/bin:$LIBRAW_PATH:$PATH"
 LIBRARY_PATH="$SDK/lib:$QTDIR/lib:$GCC/lib64:$GCC/lib:$FFMPEG/lib:$LIBRAW/lib"
 LD_LIBRARY_PATH="$SDK/lib:$QTDIR/lib:$GCC/lib64:$GCC/lib:$FFMPEG/lib:$LIBRAW/lib"
+export PYTHONPATH="$QTDIR/lib/python2.7/site-packages/"
 LD_RUN_PATH="$SDK/lib:$QTDIR/lib:$GCC/lib:$FFMPEG/lib:$LIBRAW/lib"
 CPATH="$SDK/include:$QTDIR/include:$GCC/include:$FFMPEG/include:$LIBRAW/include"
 export PKG_CONFIG_PATH="$SDK/lib/pkgconfig:$SDK/osmesa/lib/pkgconfig:$QTDIR/lib/pkgconfig:$GCC/lib/pkgconfig:$FFMPEG/lib/pkgconfig:$LIBRAW/lib/pkgconfig"
@@ -129,10 +130,26 @@ git submodule update -i --recursive
 ### Download OpenColorIO-Configs
 
 In the past, OCIO configs were a submodule, though due to the size of the repository, we have chosen instead
-to make a tarball release and let you download it [here](https://github.com/NatronGitHub/OpenColorIO-Configs/archive/Natron-v2.1.tar.gz).
-Place it at the root of Natron repository.
+to make a tarball release and let you download it [here](https://github.com/NatronGitHub/OpenColorIO-Configs/archive/Natron-v3.0.tar.gz).
 
-***note:*** *If it is name something like: `OpenColorIO-Configs-Natron-v2.0` rename it to `OpenColorIO-Configs`*
+Create a 'Resources' folder at the root of Natron repository and place it there.
+
+***note:*** *If it is name something like: `OpenColorIO-Configs-Natron-v3.0` rename it to `OpenColorIO-Configs`*
+
+```
+wget https://github.com/NatronGitHub/OpenColorIO-Configs/archive/Natron-v3.0.tar.gz
+mkdir Resources
+tar -xvzf Natron-v3.0.tar.gz -C Resources
+mv Resources/OpenColorIO-Configs-Natron-v3.0 Resources/OpenColorIO-Configs
+```
+
+***note:*** In order to reclaim disk space, you may keep only the following subfolder : blender*, natron, nuke-default
+
+```
+cd Resources/OpenColorIO-Configs
+rm -v !("blender"|"blender-cycles"|"natron"|"nuke-default") -R
+```
+
 
 ### config.pri
 
@@ -180,13 +197,16 @@ Natron's nodes are contained in separate repositories. To use the default nodes,
 You'll find installation instructions in the README of both these repositories. Both openfx-misc and openfx-io have submodules as well.
 
 Plugins must be installed in /usr/OFX/Plugins on Linux
-Or in a directory named "Plugins" located in the parent directory where the binary lies, e.g.:
+Or in a directory named "Plugins/OFX/Natron" located in the parent directory where the binary lies, e.g.:
 
 
-    bin/
+    App/
         Natron
     Plugins/
-        IO.ofx.bundle
+        OFX/
+            Natron/
+                IO.ofx.bundle
+                Misc.ofx.bundle
 
 
 # Build


### PR DESCRIPTION
-Add missing PYTHONPATH to environment.
-OpenColorIO-Configs :
    - Fix tar.gz http path to use latest.
    - It should go in a "Resources" sub-folder.
    - Add note on how to reclaim disk space by deleting unneeded Configs
    - Add code block to do the above
-openfx-io and openfx-misc should go in Plugins/OFX/Natron in order to be detected
