### PR TITLE
fix #279: fix ticks computation

### DIFF
--- a/Gui/ticks.cpp
+++ b/Gui/ticks.cpp
@@ -50,7 +50,7 @@ ticks_size_10(double xmin,
     // first, compute the size of min_tick_size_units
     double min_tick_size = min_tick_size_units * (xmax - xmin) / range_units;
     int next_p10 = std::ceil( std::log10(min_tick_size) );
-    double tick_size = std::pow(10., next_p10);
+    double tick_size = std::pow(10, next_p10);
 
     assert(tick_size / 10 < min_tick_size);
     assert(tick_size >= min_tick_size);
@@ -75,7 +75,7 @@ ticks_size(double xmin,
     double min_tick_size = min_tick_size_units * (xmax - xmin) / range_units;
     int next_p10 = std::ceil( std::log10(min_tick_size) );
 
-    *t_size = std::pow(10., next_p10);
+    *t_size = std::pow(10, next_p10);
     assert(*t_size / 10 < min_tick_size);
     assert(*t_size >= min_tick_size);
     if (*t_size / 2 >= min_tick_size) {


### PR DESCRIPTION
In -Ofast compilation mode the computation of std::pow(10., x)
is not perfect and not gives an exact number due to floating
point number approximations.
This result in wrong behaviour later as in timeline ticks drawing.

As we only need to compute an integer computation, replace
the double 10. per the integer 10 to obtain a correct value.

Signed-off-by: Guillaume Roguez <yomgui1@gmail.com>
