### PR TITLE
Rotopaint error when working with multiple layers

### DIFF
--- a/Engine/RotoContext.h
+++ b/Engine/RotoContext.h
@@ -250,6 +250,7 @@ public:
      * @brief This must be called by the GUI whenever an item is selected. This is recursive for layers.
      **/
     void select(const RotoItemPtr & b, RotoItem::SelectionReasonEnum reason);
+    void selectFromLayer(const RotoItemPtr & b, RotoItem::SelectionReasonEnum reason);
 
     ///for convenience
     void select(const std::list<RotoDrawableItemPtr> & beziers, RotoItem::SelectionReasonEnum reason);
@@ -455,7 +456,7 @@ private:
 
     NodePtr getOrCreateGlobalMergeNode(int *availableInputIndex);
 
-    void selectInternal(const RotoItemPtr& b);
+    void selectInternal(const RotoItemPtr& b, bool slaveKnobs = true);
     void deselectInternal(RotoItemPtr b);
 
     void removeItemRecursively(const RotoItemPtr& item, RotoItem::SelectionReasonEnum reason);

--- a/Engine/RotoDrawableItem.cpp
+++ b/Engine/RotoDrawableItem.cpp
@@ -465,7 +465,7 @@ findPreviousOfItemInLayer(RotoLayer* layer,
     }
     assert( found != greatParentItems.end() );
     RotoDrawableItem* ret = findPreviousOfItemInLayer(parentLayer.get(), layer);
-    assert(ret != item);
+    //assert(ret != item); // This assert will pop up when creating 2 layers in a row (one parent and child)
 
     return ret;
 } // findPreviousOfItemInLayer

--- a/Gui/RotoPanel.cpp
+++ b/Gui/RotoPanel.cpp
@@ -1797,7 +1797,7 @@ RotoPanelPrivate::insertSelectionRecursively(const RotoLayerPtr & layer)
         RotoLayerPtr l = boost::dynamic_pointer_cast<RotoLayer>(*it);
         SelectedItems::iterator found = std::find(selectedItems.begin(), selectedItems.end(), *it);
         if ( found == selectedItems.end() ) {
-            context->select(*it, RotoItem::eSelectionReasonSettingsPanel);
+            context->selectFromLayer(*it, RotoItem::eSelectionReasonSettingsPanel);
             selectedItems.push_back(*it);
         }
         if (l) {


### PR DESCRIPTION
(issues #420 and #205) :
* Prevent slaving knobs when the selection is a layer
* commented out (and add this explanation) an assert that
  popup in debug when creating 2 layers in a row

I made a docker release with this fix. That folder contain 2 natron file that now work correctly when clicking on layer
https://github.com/Ivanohe73/Natron/releases/tag/v2.3.15-rc7-roto
