### PR TITLE
Engine/Project: update default format after load

### DIFF
--- a/Engine/Project.cpp
+++ b/Engine/Project.cpp
@@ -349,6 +349,17 @@ Project::loadProjectInternal(const QString & path,
     getProjectDefaultFormat(&f);
     Q_EMIT formatChanged(f);
 
+    // set new default format (if needed)
+    const std::vector<Format> & appFormats = appPTR->getFormats();
+    for (U32 i = 0; i < appFormats.size(); ++i) {
+        if (f == appFormats[i]) {
+            if (_imp->formatKnob->getDefaultValue(0) != i) {
+                _imp->formatKnob->setDefaultValue(i, 0);
+            }
+            break;
+        }
+    }
+
     _imp->natronVersion->setValue( generateUserFriendlyNatronVersionName() );
     if (isAutoSave) {
         _imp->autoSetProjectFormat = false;


### PR DESCRIPTION
Issue #439

This updates the output format knob to match the current loaded project. I was a bit unsure where to actual do this, I hope it's ok.