### PR TITLE
#404 Added signal itemGloballyActivatedChanged on RotoContext

### DIFF
--- a/Engine/RotoContext.cpp
+++ b/Engine/RotoContext.cpp
@@ -2005,6 +2005,12 @@ RotoContext::onItemLockedChanged(const RotoItemPtr& item,
 }
 
 void
+RotoContext::onItemGloballyActivatedChanged(const RotoItemPtr& item)
+{
+    Q_EMIT itemGloballyActivatedChanged(item);
+}
+
+void
 RotoContext::onItemScriptNameChanged(const RotoItemPtr& item)
 {
     Q_EMIT itemScriptNameChanged(item);

--- a/Engine/RotoContext.h
+++ b/Engine/RotoContext.h
@@ -355,6 +355,7 @@ public:
      **/
     std::string getRotoNodeName() const;
 
+    void onItemGloballyActivatedChanged(const RotoItemPtr& item);
     void onItemScriptNameChanged(const RotoItemPtr& item);
     void onItemLabelChanged(const RotoItemPtr& item);
 
@@ -437,6 +438,7 @@ Q_SIGNALS:
 
     void itemLockedChanged(int reason);
 
+    void itemGloballyActivatedChanged(const RotoItemPtr&);
     void itemScriptNameChanged(const RotoItemPtr&);
     void itemLabelChanged(const RotoItemPtr&);
 

--- a/Engine/RotoItem.cpp
+++ b/Engine/RotoItem.cpp
@@ -197,6 +197,7 @@ RotoItem::setGloballyActivated(bool a,
             isDrawable->incrementNodesAge();
         }
         c->evaluateChange();
+        c->onItemGloballyActivatedChanged(shared_from_this());
     }
 }
 

--- a/Gui/RotoPanel.h
+++ b/Gui/RotoPanel.h
@@ -172,6 +172,7 @@ public Q_SLOTS:
 
     void onItemColorDialogEdited(const QColor & color);
 
+    void onItemGloballyActivatedChanged(const RotoItemPtr& item);
     void onItemLabelChanged(const RotoItemPtr& item);
     void onItemScriptNameChanged(const RotoItemPtr& item);
 


### PR DESCRIPTION
#404 Added signal itemGloballyActivatedChanged on RotoContext, triggered when RotoItem has globallyActivated changed, so UI can update when changed via Python
