### PR TITLE
Fix some build errors

### DIFF
--- a/Engine/AppManager.cpp
+++ b/Engine/AppManager.cpp
@@ -462,6 +462,7 @@ AppManager::getGILLockedCount() const
     assert(_imp->pythonGILRCount > 0);
     return _imp->pythonGILRCount;
 }
+#endif
 
 void
 AppManager::loadProjectFromFileFunction(std::istream& ifile, const std::string& filename, const AppInstancePtr& /*app*/, SERIALIZATION_NAMESPACE::ProjectSerialization* obj)
@@ -473,7 +474,6 @@ AppManager::loadProjectFromFileFunction(std::istream& ifile, const std::string& 
     }
 
 }
-#endif
 
 void
 StrUtils::ensureLastPathSeparator(QString& path)

--- a/Engine/NodeDocumentation.cpp
+++ b/Engine/NodeDocumentation.cpp
@@ -453,8 +453,8 @@ OUTPUT:
         // See Documentation/templates for how to grab header/footer from the latest Sphinx version
 
         QString groupString; // %2 in plugin_head
-        if ( !pluginGroup.isEmpty() ) {
-            QString group = pluginGroup.at(0);
+        if ( !pluginGroup.empty() ) {
+            QString group = QString::fromStdString(pluginGroup.at(0));
             if (!group.isEmpty()) {
                 groupString = QString::fromUtf8("<li><a href=\"../_group.html?id=%1\">%1 nodes</a> &raquo;</li>").arg(group);
             }


### PR DESCRIPTION
Fixes the following errors
- undefined reference to Natron::AppManager::loadProjectFromFileFunction() in AppManager.cpp
- no member named 'isEmpty' in NodeDocumentation.cpp
- no viable conversion to 'QString' in NodeDocumentation.cpp