### PR TITLE
SplashScreen: remove window flags

### DIFF
--- a/Gui/SplashScreen.cpp
+++ b/Gui/SplashScreen.cpp
@@ -41,7 +41,7 @@ CLANG_DIAG_ON(deprecated)
 NATRON_NAMESPACE_ENTER
 
 SplashScreen::SplashScreen(const QString & filePath)
-    : QWidget(0, Qt::ToolTip | Qt::FramelessWindowHint | Qt::X11BypassWindowManagerHint)
+    : QWidget(0, Qt::FramelessWindowHint)
     , _pixmap()
     , _text()
     , _versionString()


### PR DESCRIPTION
Removed ``Qt::ToolTip`` and ``Qt::X11BypassWindowManagerHint`` from window flags on the SplashScreen since they force always on top.

This is related to issue #303 and has been tested on Linux and Windows.

*Totaly forgot about this commit, sorry :)*