### PR TITLE
App: handle console output on Windows

### DIFF
--- a/App/App.pro
+++ b/App/App.pro
@@ -30,11 +30,10 @@ VERSION = $$VERSION_23
 
 TEMPLATE = app
 win32 {
-	CONFIG += console
-	RC_FILE += ../Natron.rc
-} else {
-	CONFIG += app
+    RC_FILE += ../Natron.rc
 }
+CONFIG += app
+
 CONFIG += moc
 CONFIG += boost boost-serialization-lib opengl qt cairo python shiboken pyside 
 CONFIG += static-gui static-engine static-host-support static-breakpadclient static-libmv static-openmvg static-ceres static-qhttpserver static-libtess

--- a/App/NatronApp_main.cpp
+++ b/App/NatronApp_main.cpp
@@ -51,6 +51,8 @@
 NATRON_NAMESPACE_USING
 
 #ifdef Q_OS_WIN
+#include <QSettings> // for console settings
+
 // g++ knows nothing about wmain
 // https://sourceforge.net/p/mingw-w64/wiki2/Unicode%20apps/
 // If it fails to compile it means either UNICODE or _UNICODE is not defined (it should be in global.pri) and
@@ -67,6 +69,23 @@ int main(int argc, char *argv[])
                                                            boost_adaptbx::floating_point::exception_trapping::overflow);
     assert(boost_adaptbx::floating_point::is_invalid_trapped());
 #endif
+
+#ifdef Q_OS_WIN
+    // Setup Windows console output
+    bool hasConsole = false;
+    QSettings settings( QString::fromUtf8(NATRON_ORGANIZATION_NAME), QString::fromUtf8(NATRON_APPLICATION_NAME) );
+    bool enableConsoleWindow = settings.value( QString::fromUtf8("enableConsoleWindow"), false ).toBool();
+    if (enableConsoleWindow) { // output to console window
+        hasConsole = ( AttachConsole(ATTACH_PARENT_PROCESS) || AllocConsole() );
+    } else { // output to parent console
+        hasConsole = AttachConsole(ATTACH_PARENT_PROCESS);
+    }
+    if (hasConsole) {
+        freopen("CONOUT$", "w", stdout);
+        freopen("CONOUT$", "w", stderr);
+    }
+#endif
+
 #if defined(Q_OS_UNIX) && defined(RLIMIT_NOFILE)
     /*
      Avoid 'Too many open files' on Unix.

--- a/Engine/Settings.cpp
+++ b/Engine/Settings.cpp
@@ -618,6 +618,13 @@ Settings::initializeKnobsUserInterface()
     _loadProjectsWorkspace->setHintToolTip( tr("When checked, when loading a project, the workspace (windows layout) will also be loaded, otherwise it "
                                                "will use your current layout.") );
     _uiPage->addKnob(_loadProjectsWorkspace);
+
+#ifdef Q_OS_WIN
+    _enableConsoleWindow = AppManager::createKnob<KnobBool>( this, tr("Enable console window") );
+    _enableConsoleWindow->setName("enableConsoleWindow");
+    _enableConsoleWindow->setHintToolTip( tr("When checked show console window on Windows.") );
+    _uiPage->addKnob(_enableConsoleWindow);
+#endif
 } // Settings::initializeKnobsUserInterface
 
 void
@@ -1491,6 +1498,9 @@ Settings::setDefaultValues()
     _useCursorPositionIncrements->setDefaultValue(true);
     //_defaultLayoutFile
     _loadProjectsWorkspace->setDefaultValue(false);
+#ifdef Q_OS_WIN
+    _enableConsoleWindow->setDefaultValue(false);
+#endif
 
     // Color-Management
     //_ocioConfigKnob
@@ -3117,6 +3127,14 @@ Settings::getLoadProjectWorkspce() const
 {
     return _loadProjectsWorkspace->getValue();
 }
+
+#ifdef Q_OS_WIN
+bool
+Settings::getEnableConsoleWindow() const
+{
+    return _enableConsoleWindow->getValue();
+}
+#endif
 
 bool
 Settings::useCursorPositionIncrements() const

--- a/Engine/Settings.h
+++ b/Engine/Settings.h
@@ -231,6 +231,9 @@ public:
     std::string getDefaultLayoutFile() const;
 
     bool getLoadProjectWorkspce() const;
+#ifdef Q_OS_WIN
+    bool getEnableConsoleWindow() const;
+#endif
 
     bool useCursorPositionIncrements() const;
 
@@ -482,6 +485,9 @@ private:
     KnobBoolPtr _useCursorPositionIncrements;
     KnobFilePtr _defaultLayoutFile;
     KnobBoolPtr _loadProjectsWorkspace;
+#ifdef Q_OS_WIN
+    KnobBoolPtr _enableConsoleWindow;
+#endif
 
     // Color-Management
     KnobPagePtr _ocioTab;


### PR DESCRIPTION
Console output on Windows now behaves as on Linux/macOS (output to parent as default). A separate console window can be enabled in "Preferences"=>"User Interface"=>"Enable console window", this enables the old Windows console behavior present in 2.3.15 and older.

Test build: https://github.com/rodlie/Natron/releases/download/console1/Natron-console-202007181854-6593003-Windows-64-no-installer.zip