### PR TITLE
Provide WORKSPACE variable if it doesn't exist

### DIFF
--- a/tools/jenkins/common.sh
+++ b/tools/jenkins/common.sh
@@ -24,9 +24,8 @@ fi
 
 # Set common paths used across scripts
 if [ -z "${WORKSPACE:-}" ]; then
-    defaultWorkspace="/tmp/natron_build"
-    echo "Info: Setting WORKSPACE=${defaultWorkspace}"
-    WORKSPACE=${defaultWorkspace}
+    echo "Error: 'WORKSPACE' env is not defined -- required for build"
+    exit 1
 fi
 TMP_PATH="${WORKSPACE:-}/tmp"
 SRC_PATH="${WORKSPACE:-}/src"

--- a/tools/jenkins/common.sh
+++ b/tools/jenkins/common.sh
@@ -23,6 +23,11 @@ if [ -z "${CWD:-}" ]; then
 fi
 
 # Set common paths used across scripts
+if [ -z "${WORKSPACE:-}" ]; then
+    defaultWorkspace="/tmp/natron_build"
+    echo "Info: Setting WORKSPACE=${defaultWorkspace}"
+    WORKSPACE=${defaultWorkspace}
+fi
 TMP_PATH="${WORKSPACE:-}/tmp"
 SRC_PATH="${WORKSPACE:-}/src"
 INC_PATH="$CWD/include"


### PR DESCRIPTION
## Description

While trying to build Natron, I noticed it deleted every single file in /tmp that wasn't system protected. 

This is caused by the "rm -rf" line in build-Linux-sdk.sh, where TMP_PATH is set to /tmp. I tracked this down to common.sh assuming WORKSPACE is defined. When it isn't, TMP_PATH resolves to /tmp. To resolve this I provided a default workspace. 

Where "rm -rf" is called: 
https://github.com/NatronGitHub/Natron/blob/RB-2.3/tools/jenkins/include/scripts/build-Linux-sdk.sh#L432

