### PR TITLE
SequenceFileDialog (UX) changes

### DIFF
--- a/Gui/SequenceFileDialog.cpp
+++ b/Gui/SequenceFileDialog.cpp
@@ -473,7 +473,7 @@ SequenceFileDialog::SequenceFileDialog( QWidget* parent, // necessary to transmi
         _selectionLayout->addWidget(_fileExtensionCombo);
         QObject::connect( _fileExtensionCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(onFileExtensionComboChanged(int)) );
         if (isSequenceDialog) {
-            int idx = _fileExtensionCombo->itemIndex( QString::fromUtf8("jpg") );
+            int idx = _fileExtensionCombo->itemIndex( QString::fromUtf8("exr") );
             if (idx >= 0) {
                 _fileExtensionCombo->setCurrentIndex(idx);
             }

--- a/Gui/SequenceFileDialog.h
+++ b/Gui/SequenceFileDialog.h
@@ -414,9 +414,8 @@ public Q_SLOTS:
 
     ///apply a filter
     ///and refreshes the current directory.
-    void dotStarFilterSlot();
-    void starSlashFilterSlot();
-    void emptyFilterSlot();
+    void handleFilterSlot();
+    void setDefaultFilter();
     void applyFilter(QString filter);
 
     ///show hidden files slot


### PR DESCRIPTION
Some minor UX changes to SequenceFileDialog.

I moved the file type combo box beside the filename and the open/save button beside the cancel button, as this makes more sense IMHO. I also added the extensions to the filter, and set the default filter on init (if you for example open/save a project file your filter is set to *.ntp as default).

![SequenceFileDialog01](https://user-images.githubusercontent.com/34516798/106384877-8e31b580-63cd-11eb-96bc-6ff3a63bdc07.png)
![SequenceFileDialogFilter](https://user-images.githubusercontent.com/34516798/106384880-938f0000-63cd-11eb-8bd8-8ec6195e1efe.png)
![SequenceFileDialog02](https://user-images.githubusercontent.com/34516798/106384909-b02b3800-63cd-11eb-9fab-fef7c91e01fb.png)
![SequenceFileDialog03](https://user-images.githubusercontent.com/34516798/106384913-b3bebf00-63cd-11eb-95ec-88bce6ba0c95.png)

