### PR TITLE
Restores tab close PNG files

### DIFF
--- a/Gui/GuiResources.qrc
+++ b/Gui/GuiResources.qrc
@@ -149,9 +149,7 @@
         <file>Resources/Images/cliptoprojectEnabled.png</file>
         <file>Resources/Images/close.png</file>
         <file>Resources/Images/closePanel.png</file>
-        <file>Resources/Images/closeTab.svg</file>
         <file>Resources/Images/closeTab.png</file>
-        <file>Resources/Images/closeTab_hovered.svg</file>
         <file>Resources/Images/closeTab_hovered.png</file>
         <file>Resources/Images/color_picker.png</file>
         <file>Resources/Images/colorwheel.png</file>

--- a/Gui/Resources/Stylesheets/mainstyle.qss
+++ b/Gui/Resources/Stylesheets/mainstyle.qss
@@ -506,12 +506,12 @@ QTabBar::tab:only-one {
     margin: 0; /* if there is only one tab, we don't want overlapping margins */
 }
 QTabBar::close-button {
-    image: url(:/Resources/Images/closeTab.svg);
+    image: url(:/Resources/Images/closeTab.png);
     subcontrol-position: right;
 }
 
 QTabBar::close-button:hover {
-    image: url(:/Resources/Images/closeTab_hovered.svg);
+    image: url(:/Resources/Images/closeTab_hovered.png);
     subcontrol-position: right;
 }
 


### PR DESCRIPTION
No longer uses SVG because it turns out it doesn't work properly in macOS when compiled.  Doesn't remove source SVG files from the folder.

Hopefully fixes #590.