### PR TITLE
Gui/DockablePanel: connect to returnPressed instead of editingFinished for _nameLineEdit

### DIFF
--- a/Gui/DockablePanel.cpp
+++ b/Gui/DockablePanel.cpp
@@ -385,7 +385,7 @@ DockablePanel::DockablePanel(Gui* gui,
                 QObject::connect( node.get(), SIGNAL(scriptNameChanged(QString)), this, SLOT(onNodeScriptChanged(QString)) );
             }
             _imp->_nameLineEdit->setText(initialName);
-            QObject::connect( _imp->_nameLineEdit, SIGNAL(editingFinished()), this, SLOT(onLineEditNameEditingFinished()) );
+            QObject::connect( _imp->_nameLineEdit, SIGNAL(returnPressed()), this, SLOT(onLineEditNameEditingFinished()) );
             _imp->_headerLayout->addWidget(_imp->_nameLineEdit);
         } else {
             _imp->_nameLabel = new Label(initialName, _imp->_headerWidget);


### PR DESCRIPTION
QLineEdit triggers editingFinished when focus changes, this creates issues when we open a dialog based on this signal and return focus to the widget when done.

https://bugreports.qt.io/browse/QTBUG-40

Example: The node rename error dialog is triggered twice and after that focus is returned to the QLineEdit, on Windows this will trigger editingFinished again, resulting in an (almost) endless loop.


https://user-images.githubusercontent.com/34516798/112739504-1c14c180-8f75-11eb-90b9-b49d5120ea01.mp4

