### PR TITLE
fix issue #568

### DIFF
--- a/Engine/EffectInstance.cpp
+++ b/Engine/EffectInstance.cpp
@@ -553,6 +553,12 @@ EffectInstance::getScriptName_mt_safe() const
     return getNode()->getScriptName_mt_safe();
 }
 
+std::string
+EffectInstance::getFullyQualifiedName() const
+{
+    return getNode()->getFullyQualifiedName();
+}
+
 int
 EffectInstance::getRenderViewsCount() const
 {

--- a/Engine/EffectInstance.h
+++ b/Engine/EffectInstance.h
@@ -291,6 +291,7 @@ public:
      **/
     const std::string & getScriptName() const WARN_UNUSED_RETURN;
     virtual std::string getScriptName_mt_safe() const OVERRIDE FINAL WARN_UNUSED_RETURN;
+    virtual std::string getFullyQualifiedName() const OVERRIDE FINAL WARN_UNUSED_RETURN;
     virtual void onScriptNameChanged(const std::string& /*fullyQualifiedName*/) {}
 
     /**

--- a/Engine/Knob.h
+++ b/Engine/Knob.h
@@ -1187,6 +1187,32 @@ public:
      * @param ignoreMasterPersistence If true the master will not be serialized.
      **/
     bool slaveTo(int dimension, const KnobIPtr & other, int otherDimension, bool ignoreMasterPersistence = false);
+
+
+    void storeLink(int dimension,
+                      const std::string& knobName,
+                      const std::string& nodeName,
+                      const std::string& trackName)
+    {
+        _links.push_back(Link({dimension, knobName, nodeName, trackName}));
+    }
+
+    void restoreLinks(const NodesList & allNodes,
+                      const std::map<std::string, std::string>& oldNewScriptNamesMapping,
+                      bool throwOnFailure);
+
+private:
+    struct Link {
+        int dimension; // -1 means alias
+        std::string knobName;
+        std::string nodeName;
+        std::string trackName;
+    };
+
+    std::vector<Link> _links;
+
+public:
+
     virtual bool isMastersPersistenceIgnored() const = 0;
     virtual KnobIPtr createDuplicateOnHolder(KnobHolder* otherHolder,
                                             const boost::shared_ptr<KnobPage>& page,
@@ -2839,6 +2865,8 @@ public:
     }
 
     virtual std::string getScriptName_mt_safe() const = 0;
+
+    virtual std::string getFullyQualifiedName() const = 0;
 };
 
 

--- a/Engine/KnobSerialization.cpp
+++ b/Engine/KnobSerialization.cpp
@@ -129,10 +129,10 @@ ValueSerialization::initForSave(const KnobIPtr & knob,
         TrackMarker* isMarker = dynamic_cast<TrackMarker*>(holder);
         if (isMarker) {
             _master.masterTrackName = isMarker->getScriptName_mt_safe();
-            _master.masterNodeName = isMarker->getContext()->getNode()->getScriptName_mt_safe();
+            _master.masterNodeName = isMarker->getContext()->getNode()->getFullyQualifiedName();
         } else {
             // coverity[dead_error_line]
-            _master.masterNodeName = holder ? holder->getScriptName_mt_safe() : "";
+            _master.masterNodeName = holder ? holder->getFullyQualifiedName() : "";
         }
         _master.masterKnobName = m.second->getName();
     } else {
@@ -193,68 +193,9 @@ KnobSerialization::createKnob(const std::string & typeName,
     return ret;
 }
 
-static KnobIPtr
-findMaster(const KnobIPtr & knob,
-           const NodesList & allNodes,
-           const std::string& masterKnobName,
-           const std::string& masterNodeName,
-           const std::string& masterTrackName,
-           const std::map<std::string, std::string>& oldNewScriptNamesMapping)
-{
-    ///we need to cycle through all the nodes of the project to find the real master
-    NodePtr masterNode;
-    std::string masterNodeNameToFind = masterNodeName;
-
-    /*
-       When copy pasting, the new node copied has a script-name different from what is inside the serialization because 2
-       nodes cannot co-exist with the same script-name. We keep in the map the script-names mapping
-     */
-    std::map<std::string, std::string>::const_iterator foundMapping = oldNewScriptNamesMapping.find(masterNodeName);
-
-    if ( foundMapping != oldNewScriptNamesMapping.end() ) {
-        masterNodeNameToFind = foundMapping->second;
-    }
-
-    for (NodesList::const_iterator it2 = allNodes.begin(); it2 != allNodes.end(); ++it2) {
-        if ( (*it2)->getScriptName() == masterNodeNameToFind ) {
-            masterNode = *it2;
-            break;
-        }
-    }
-    if (!masterNode) {
-        qDebug() << "Link slave/master for " << knob->getName().c_str() <<   " failed to restore the following linkage: " << masterNodeNameToFind.c_str();
-
-        return KnobIPtr();
-    }
-
-    if ( !masterTrackName.empty() ) {
-        TrackerContextPtr context = masterNode->getTrackerContext();
-        if (context) {
-            TrackMarkerPtr marker = context->getMarkerByName(masterTrackName);
-            if (marker) {
-                return marker->getKnobByName(masterKnobName);
-            }
-        }
-    } else {
-        ///now that we have the master node, find the corresponding knob
-        const std::vector<KnobIPtr> & otherKnobs = masterNode->getKnobs();
-        for (std::size_t j = 0; j < otherKnobs.size(); ++j) {
-            if ( (otherKnobs[j]->getName() == masterKnobName) && otherKnobs[j]->getIsPersistent() ) {
-                return otherKnobs[j];
-                break;
-            }
-        }
-    }
-
-    qDebug() << "Link slave/master for " << knob->getName().c_str() <<   " failed to restore the following linkage: " << masterNodeNameToFind.c_str();
-
-    return KnobIPtr();
-}
 
 void
-KnobSerialization::restoreKnobLinks(const KnobIPtr & knob,
-                                    const NodesList & allNodes,
-                                    const std::map<std::string, std::string>& oldNewScriptNamesMapping)
+KnobSerialization::storeKnobLinks(const KnobIPtr & knob)
 {
     int i = 0;
 
@@ -266,23 +207,19 @@ KnobSerialization::restoreKnobLinks(const KnobIPtr & knob,
             const std::string& aliasKnobName = _masters.front().masterKnobName;
             const std::string& aliasNodeName = _masters.front().masterNodeName;
             const std::string& masterTrackName  = _masters.front().masterTrackName;
-            KnobIPtr alias = findMaster(knob, allNodes, aliasKnobName, aliasNodeName, masterTrackName, oldNewScriptNamesMapping);
-            if (alias) {
-                knob->setKnobAsAliasOfThis(alias, true);
-            }
+            knob->storeLink(-1, aliasKnobName, aliasNodeName, masterTrackName);
         }
     } else {
         for (std::list<MasterSerialization>::iterator it = _masters.begin(); it != _masters.end(); ++it) {
             if (it->masterDimension != -1) {
-                KnobIPtr master = findMaster(knob, allNodes, it->masterKnobName, it->masterNodeName, it->masterTrackName, oldNewScriptNamesMapping);
-                if (master) {
-                    knob->slaveTo(i, master, it->masterDimension);
-                }
+                knob->storeLink(it->masterDimension, it->masterKnobName, it->masterNodeName, it->masterTrackName);
             }
             ++i;
         }
     }
 }
+
+
 
 void
 KnobSerialization::restoreExpressions(const KnobIPtr & knob,

--- a/Engine/KnobSerialization.h
+++ b/Engine/KnobSerialization.h
@@ -928,11 +928,9 @@ public:
     ~KnobSerialization() { delete _extraData; }
 
     /**
-     * @brief This function cannot be called until all knobs of the project have been created.
+     * @brief Store the links, which can be restored once all Nodes and Knobs have been created, using KnobI::restoreLinks()
      **/
-    void restoreKnobLinks(const KnobIPtr & knob,
-                          const NodesList & allNodes,
-                          const std::map<std::string, std::string>& oldNewScriptNamesMapping);
+    void storeKnobLinks(const KnobIPtr & knob);
 
     /**
      * @brief This function cannot be called until all knobs of the project have been created.

--- a/Engine/Node.h
+++ b/Engine/Node.h
@@ -165,9 +165,13 @@ public:
 
     ///This cannot be done in loadKnobs as to call this all the nodes in the project must have
     ///been loaded first.
-    void restoreKnobsLinks(const NodeSerialization & serialization,
-                           const NodesList & allNodes,
-                           const std::map<std::string, std::string>& oldNewScriptNamesMapping);
+    void storeKnobsLinks(const NodeSerialization & serialization,
+                         const std::map<std::string, std::string>& oldNewScriptNamesMapping);
+
+    // Once all nodes are created, we can restore the links that were previously saved by storeKnobsLinks()
+    void restoreKnobsLinks(const NodesList & allNodes,
+                           const std::map<std::string, std::string>& oldNewScriptNamesMapping,
+                           bool throwOnFailure);
 
     void restoreUserKnobs(const NodeSerialization& serialization);
 

--- a/Engine/NodeGroupSerialization.cpp
+++ b/Engine/NodeGroupSerialization.cpp
@@ -395,11 +395,6 @@ NodeCollectionSerialization::restoreFromSerialization(const std::list<NodeSerial
     } // for (std::list<NodeSerializationPtr>::const_iterator it = serializedNodes.begin(); it != serializedNodes.end(); ++it) {
 
     ///Now that the graph is setup, restore expressions
-    NodesList nodes = group->getNodes();
-    if (isNodeGroup) {
-        nodes.push_back( isNodeGroup->getNode() );
-    }
-
     {
         std::map<std::string, std::string> oldNewScriptNamesMapping;
         for (std::map<NodePtr, NodeSerializationPtr>::const_iterator it = createdNodes.begin(); it != createdNodes.end(); ++it) {
@@ -407,7 +402,8 @@ NodeCollectionSerialization::restoreFromSerialization(const std::list<NodeSerial
                 //ignore viewers on background mode
                 continue;
             }
-            it->first->restoreKnobsLinks(*it->second, nodes, oldNewScriptNamesMapping);
+            it->first->storeKnobsLinks(*it->second, oldNewScriptNamesMapping);
+            // restoreKnobsLinks() is called on all nodes at the end of ProjectPrivate::restoreFromSerialization()
         }
     }
 

--- a/Engine/NodeMain.cpp
+++ b/Engine/NodeMain.cpp
@@ -654,9 +654,8 @@ Node::Implementation::restoreUserKnobsRecursive(const std::list<KnobSerializatio
 
 
 void
-Node::Implementation::restoreKnobLinksRecursive(const GroupKnobSerialization* group,
-                                                const NodesList & allNodes,
-                                                const std::map<std::string, std::string>& oldNewScriptNamesMapping)
+Node::Implementation::storeKnobLinksRecursive(const GroupKnobSerialization* group,
+                                              const std::map<std::string, std::string>& oldNewScriptNamesMapping)
 {
     const std::list<KnobSerializationBasePtr>&  children = group->getChildren();
 
@@ -665,7 +664,7 @@ Node::Implementation::restoreKnobLinksRecursive(const GroupKnobSerialization* gr
         KnobSerialization* isRegular = dynamic_cast<KnobSerialization*>( it->get() );
         assert(isGrp || isRegular);
         if (isGrp) {
-            restoreKnobLinksRecursive(isGrp, allNodes, oldNewScriptNamesMapping);
+            storeKnobLinksRecursive(isGrp, oldNewScriptNamesMapping);
         } else if (isRegular) {
             KnobIPtr knob =  _publicInterface->getKnobByName( isRegular->getName() );
             if (!knob) {
@@ -678,16 +677,16 @@ Node::Implementation::restoreKnobLinksRecursive(const GroupKnobSerialization* gr
                 appPTR->writeToErrorLog_mt_safe(QString::fromUtf8( _publicInterface->getScriptName_mt_safe().c_str() ), QDateTime::currentDateTime(), err, false, c);
                 continue;
             }
-            isRegular->restoreKnobLinks(knob, allNodes, oldNewScriptNamesMapping);
+            isRegular->storeKnobLinks(knob);
             isRegular->restoreExpressions(knob, oldNewScriptNamesMapping);
         }
     }
 }
 
+
 void
-Node::restoreKnobsLinks(const NodeSerialization & serialization,
-                        const NodesList & allNodes,
-                        const std::map<std::string, std::string>& oldNewScriptNamesMapping)
+Node::storeKnobsLinks(const NodeSerialization & serialization,
+                      const std::map<std::string, std::string>& oldNewScriptNamesMapping)
 {
     ////Only called by the main-thread
     assert( QThread::currentThread() == qApp->thread() );
@@ -706,13 +705,50 @@ Node::restoreKnobsLinks(const NodeSerialization & serialization,
             appPTR->writeToErrorLog_mt_safe(QString::fromUtf8( getScriptName_mt_safe().c_str() ), QDateTime::currentDateTime(), err, false, c);
             continue;
         }
-        (*it)->restoreKnobLinks(knob, allNodes, oldNewScriptNamesMapping);
+        (*it)->storeKnobLinks(knob);
         (*it)->restoreExpressions(knob, oldNewScriptNamesMapping);
     }
 
     const std::list<GroupKnobSerializationPtr>& userKnobs = serialization.getUserPages();
     for (std::list<GroupKnobSerializationPtr>::const_iterator it = userKnobs.begin(); it != userKnobs.end(); ++it) {
-        _imp->restoreKnobLinksRecursive( (*it).get(), allNodes, oldNewScriptNamesMapping );
+        _imp->storeKnobLinksRecursive( (*it).get(), oldNewScriptNamesMapping );
+    }
+}
+
+
+void
+Node::Implementation::restoreKnobLinksRecursive(const NodesList & allNodes,
+                                                const KnobGroupPtr& group,
+                                                const std::map<std::string, std::string>& oldNewScriptNamesMapping,
+                                                bool throwOnFailure)
+{
+    const std::vector<KnobIPtr>& children = group->getChildren();
+
+    for (std::vector<KnobIPtr>::const_iterator it = children.begin(); it != children.end(); ++it) {
+        (*it)->restoreLinks(allNodes, oldNewScriptNamesMapping, throwOnFailure);
+        KnobGroupPtr isGroup = boost::dynamic_pointer_cast<KnobGroup>(*it);
+        if (isGroup) {
+            restoreKnobLinksRecursive(allNodes, isGroup, oldNewScriptNamesMapping, throwOnFailure);
+        }
+    }
+}
+
+
+void
+Node::restoreKnobsLinks(const NodesList & allNodes,
+                        const std::map<std::string, std::string>& oldNewScriptNamesMapping,
+                        bool throwOnFailure)
+{
+    ////Only called by the main-thread
+    assert( QThread::currentThread() == qApp->thread() );
+
+    std::vector<KnobIPtr> knobs = getKnobs();
+    for (std::vector<KnobIPtr>::iterator it = knobs.begin(); it != knobs.end(); ++it) {
+        (*it)->restoreLinks(allNodes, oldNewScriptNamesMapping, throwOnFailure);
+        KnobGroupPtr group = boost::dynamic_pointer_cast<KnobGroup>(*it);
+        if (group) {
+            _imp->restoreKnobLinksRecursive(allNodes, group, oldNewScriptNamesMapping, throwOnFailure);
+        }
     }
 }
 

--- a/Engine/NodePrivate.h
+++ b/Engine/NodePrivate.h
@@ -277,9 +277,13 @@ public:
                                    const KnobGroupPtr& group,
                                    const KnobPagePtr& page);
 
-    void restoreKnobLinksRecursive(const GroupKnobSerialization* group,
-                                   const NodesList & allNodes,
-                                   const std::map<std::string, std::string>& oldNewScriptNamesMapping);
+    void storeKnobLinksRecursive(const GroupKnobSerialization* group,
+                                 const std::map<std::string, std::string>& oldNewScriptNamesMapping);
+
+    void restoreKnobLinksRecursive(const NodesList & allNodes,
+                                   const KnobGroupPtr& group,
+                                   const std::map<std::string, std::string>& oldNewScriptNamesMapping,
+                                   bool throwOnFailure);
 
     void ifGroupForceHashChangeOfInputs();
 

--- a/Engine/Project.cpp
+++ b/Engine/Project.cpp
@@ -335,6 +335,15 @@ Project::loadProjectInternal(const QString & path,
         if (!bgProject) {
             getApp()->loadProjectGui(isAutoSave, iArchive);
         }
+    } catch (const std::exception &e) {
+        const ProjectBeingLoadedInfo& pInfo = getApp()->getProjectBeingLoadedInfo();
+        if (pInfo.vMajor > NATRON_VERSION_MAJOR ||
+            (pInfo.vMajor == NATRON_VERSION_MAJOR && pInfo.vMinor > NATRON_VERSION_MINOR) ||
+            (pInfo.vMajor == NATRON_VERSION_MAJOR && pInfo.vMinor == NATRON_VERSION_MINOR && pInfo.vRev > NATRON_VERSION_REVISION)) {
+            QString message = tr("This project was saved with a more recent version (%1.%2.%3) of %4. Projects are not forward compatible and may only be opened in a version of %4 equal or more recent than the version that saved it.").arg(pInfo.vMajor).arg(pInfo.vMinor).arg(pInfo.vRev).arg(QString::fromUtf8(NATRON_APPLICATION_NAME));
+            throw std::runtime_error(message.toStdString());
+        }
+        throw std::runtime_error( tr("Unrecognized or damaged project file:").toStdString() + ' ' + e.what());
     } catch (...) {
         const ProjectBeingLoadedInfo& pInfo = getApp()->getProjectBeingLoadedInfo();
         if (pInfo.vMajor > NATRON_VERSION_MAJOR ||

--- a/Engine/TrackMarker.h
+++ b/Engine/TrackMarker.h
@@ -131,6 +131,7 @@ public:
 
     bool setScriptName(const std::string& name);
     virtual std::string getScriptName_mt_safe() const OVERRIDE FINAL WARN_UNUSED_RETURN;
+    virtual std::string getFullyQualifiedName() const OVERRIDE FINAL WARN_UNUSED_RETURN;
 
     void setLabel(const std::string& label);
     std::string getLabel() const;

--- a/Gui/MultiInstancePanel.cpp
+++ b/Gui/MultiInstancePanel.cpp
@@ -452,6 +452,12 @@ MultiInstancePanel::getScriptName_mt_safe() const
     return _imp->getMainInstance()->getScriptName_mt_safe();
 }
 
+std::string
+MultiInstancePanel::getFullyQualifiedName() const
+{
+    return _imp->getMainInstance()->getFullyQualifiedName();
+}
+
 void
 MultiInstancePanel::initializeKnobs()
 {

--- a/Gui/MultiInstancePanel.h
+++ b/Gui/MultiInstancePanel.h
@@ -77,6 +77,7 @@ public:
 
     const std::list<std::pair<NodeWPtr, bool > > & getInstances() const;
     virtual std::string getScriptName_mt_safe() const OVERRIDE FINAL;
+    virtual std::string getFullyQualifiedName() const OVERRIDE FINAL;
     NodePtr getMainInstance() const;
 
     NodeGuiPtr getMainInstanceGui() const;

--- a/Gui/NodeGraph40.cpp
+++ b/Gui/NodeGraph40.cpp
@@ -321,13 +321,13 @@ NodeGraph::cloneSelectedNodes(const QPointF& scenePos)
 
 
     NodesList allNodes;
-    getGui()->getApp()->getProject()->getActiveNodes(&allNodes);
-
+    getGui()->getApp()->getProject()->getActiveNodesExpandGroups(&allNodes);
 
     //Restore links once all children are created for alias knobs/expressions
     std::list<NodeSerializationPtr>::iterator itS = serializations.begin();
     for (std::list<NodeGuiPtr> ::iterator it = newNodesList.begin(); it != newNodesList.end(); ++it, ++itS) {
-        (*it)->getNode()->restoreKnobsLinks(**itS, allNodes, oldNewScriptNameMapping);
+        (*it)->getNode()->storeKnobsLinks(**itS, oldNewScriptNameMapping);
+        (*it)->getNode()->restoreKnobsLinks(allNodes, oldNewScriptNameMapping, true); // clone should never fail
     }
 
 

--- a/Gui/NodeGraph45.cpp
+++ b/Gui/NodeGraph45.cpp
@@ -676,16 +676,12 @@ NodeGraph::copyNodesAndCreateInGroup(const NodesGuiList& nodes,
 
         //Restore links once all children are created for alias knobs/expressions
         NodesList allNodes;
-        group->getActiveNodes(&allNodes);
-        // If the group is a Group node, append to all nodes reachable through links
-        NodeGroup* isGroupNode = dynamic_cast<NodeGroup*>(group.get());
-        if (isGroupNode) {
-            allNodes.push_back(isGroupNode->getNode());
-        }
+        getGui()->getApp()->getProject()->getActiveNodesExpandGroups(&allNodes);
 
         std::list<NodeSerializationPtr>::const_iterator itSerialization = clipboard.nodes.begin();
         for (std::list<std::pair<std::string, NodeGuiPtr> > ::iterator it = createdNodes.begin(); it != createdNodes.end(); ++it, ++itSerialization) {
-            it->second->getNode()->restoreKnobsLinks(**itSerialization, allNodes, oldNewScriptNamesMapping);
+            it->second->getNode()->storeKnobsLinks(**itSerialization, oldNewScriptNamesMapping);
+            it->second->getNode()->restoreKnobsLinks(allNodes, oldNewScriptNamesMapping, true); // may not fail
         }
 
     }

--- a/Gui/NodeGraphPrivate10.cpp
+++ b/Gui/NodeGraphPrivate10.cpp
@@ -119,15 +119,14 @@ NodeGraphPrivate::pasteNodesInternal(const NodeClipBoard & clipboard,
             restoreConnections(internalNodesClipBoard, *newNodes, oldNewScriptNamesMap);
 
             NodesList allNodes;
-            _publicInterface->getGui()->getApp()->getProject()->getActiveNodes(&allNodes);
-
+            _publicInterface->getGui()->getApp()->getProject()->getActiveNodesExpandGroups(&allNodes);
 
             //Restore links once all children are created for alias knobs/expressions
             for (std::list<std::pair<NodeSerializationPtr, NodePtr> > ::iterator it = newNodesMap.begin(); it != newNodesMap.end(); ++it) {
-                it->second->restoreKnobsLinks(*(it->first), allNodes, oldNewScriptNamesMap);
+                it->second->storeKnobsLinks(*(it->first), oldNewScriptNamesMap);
+                it->second->restoreKnobsLinks(allNodes, oldNewScriptNamesMap, false); // may fail
             }
         }
-
 
         if (newNodesList.size() > 1) {
             ///Only compute datas if we're pasting more than 1 node
@@ -211,15 +210,7 @@ NodeGraphPrivate::pasteNode(const NodeSerializationPtr & internalSerialization,
 
     //All nodes that are reachable via expressions
     NodesList allNodes;
-    n->getGroup()->getActiveNodes(&allNodes);
-
-    ///Add the node group itself
-    {
-        NodeGroup* isContainerGroup = dynamic_cast<NodeGroup*>( n->getGroup().get() );
-        if (isContainerGroup) {
-            allNodes.push_back( isContainerGroup->getNode() );
-        }
-    }
+    _publicInterface->getGui()->getApp()->getProject()->getActiveNodesExpandGroups(&allNodes);
 
     //We don't want the clone to have the same hash as the original
     n->incrementKnobsAge();
@@ -285,12 +276,10 @@ NodeGraphPrivate::pasteNode(const NodeSerializationPtr & internalSerialization,
 
         //Restore links once all children are created for alias knobs/expressions
         for (std::list<std::pair<NodeSerializationPtr, NodePtr> > ::iterator it = newNodesMap.begin(); it != newNodesMap.end(); ++it) {
-            it->second->restoreKnobsLinks(*(it->first), allNodes, *oldNewScriptNameMapping);
+            it->second->storeKnobsLinks(*(it->first), *oldNewScriptNameMapping);
+            it->second->restoreKnobsLinks(allNodes, *oldNewScriptNameMapping, false); // may fail
         }
-
-
     }
-
 
     return gui;
 } // NodeGraphPrivate::pasteNode

--- a/Gui/NodeGraphUndoRedo.cpp
+++ b/Gui/NodeGraphUndoRedo.cpp
@@ -1217,13 +1217,11 @@ LoadNodePresetsCommand::redo()
     }
 
     NodesList allNodes;
-    internalNode->getGroup()->getActiveNodes(&allNodes);
-    NodeGroup* isGroup = internalNode->isEffectGroup();
-    if (isGroup) {
-        isGroup->getActiveNodes(&allNodes);
-    }
+    internalNode->getApp()->getProject()->getActiveNodesExpandGroups(&allNodes);
+
     std::map<std::string, std::string> oldNewScriptNames;
-    internalNode->restoreKnobsLinks(*_newSerializations.front(), allNodes, oldNewScriptNames);
+    internalNode->storeKnobsLinks(*_newSerializations.front(), oldNewScriptNames);
+    internalNode->restoreKnobsLinks(allNodes, oldNewScriptNames, true); // may not fail
     internalNode->getEffectInstance()->incrHashAndEvaluate(true, true);
     internalNode->getApp()->triggerAutoSave();
     _firstRedoCalled = true;

--- a/Gui/PythonPanels.cpp
+++ b/Gui/PythonPanels.cpp
@@ -84,6 +84,12 @@ DialogParamHolder::getScriptName_mt_safe() const
     return _imp->uniqueID;
 }
 
+std::string
+DialogParamHolder::getFullyQualifiedName() const
+{
+    return _imp->uniqueID;
+}
+
 void
 DialogParamHolder::setParamChangedCallback(const QString& callback)
 {

--- a/Gui/PythonPanels.h
+++ b/Gui/PythonPanels.h
@@ -67,6 +67,8 @@ public:
 
     virtual std::string getScriptName_mt_safe() const OVERRIDE FINAL;
 
+    virtual std::string getFullyQualifiedName() const OVERRIDE FINAL;
+
     void setParamChangedCallback(const QString& callback);
 
 private:


### PR DESCRIPTION
Restoring links is now done in two passes:
1. Save the links during deserialization in the KnobI
2. Restore the links once all nodes were created
