### PR TITLE
BezierCP: Set default keyframe interpolation to "Smooth" instead of "Linear"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@
 - Tabs UI adjustments. #564
 - Do not allow Python keywords as node name or scriptname. #588
 - Always serialize nodes with an expression or a link, even if they have the default value. #585
-- Support cloned group nodes or hard links between groups #568 #579 #594 #598
+- Support cloned group nodes or hard links between groups. #568 #579 #594 #598
+- Default keyframe interpolation method for strokes and shapes is now "Smooth" (was "Linear"). #597
 
 ### Plugins
 

--- a/Engine/BezierCP.cpp
+++ b/Engine/BezierCP.cpp
@@ -44,6 +44,8 @@
 
 NATRON_NAMESPACE_ENTER
 
+// Was eKeyframeTypeLinear until Natron 2.3.15.
+#define BEZIER_KEYFRAME_INTERPOLATION_TYPE eKeyframeTypeSmooth
 
 ////////////////////////////////////ControlPoint////////////////////////////////////
 
@@ -112,7 +114,7 @@ BezierCP::setPositionAtTime(bool useGuiCurves,
 {
     {
         KeyFrame k(time, x);
-        k.setInterpolation(eKeyframeTypeLinear);
+        k.setInterpolation(BEZIER_KEYFRAME_INTERPOLATION_TYPE);
         if (!useGuiCurves) {
             _imp->curveX->addKeyFrame(k);
         }
@@ -120,7 +122,7 @@ BezierCP::setPositionAtTime(bool useGuiCurves,
     }
     {
         KeyFrame k(time, y);
-        k.setInterpolation(eKeyframeTypeLinear);
+        k.setInterpolation(BEZIER_KEYFRAME_INTERPOLATION_TYPE);
         if (!useGuiCurves) {
             _imp->curveY->addKeyFrame(k);
         }
@@ -267,7 +269,7 @@ BezierCP::setLeftBezierPointAtTime(bool useGuiCurves,
 {
     {
         KeyFrame k(time, x);
-        k.setInterpolation(eKeyframeTypeLinear);
+        k.setInterpolation(BEZIER_KEYFRAME_INTERPOLATION_TYPE);
         if (!useGuiCurves) {
             _imp->curveLeftBezierX->addKeyFrame(k);
         } else {
@@ -276,7 +278,7 @@ BezierCP::setLeftBezierPointAtTime(bool useGuiCurves,
     }
     {
         KeyFrame k(time, y);
-        k.setInterpolation(eKeyframeTypeLinear);
+        k.setInterpolation(BEZIER_KEYFRAME_INTERPOLATION_TYPE);
         if (!useGuiCurves) {
             _imp->curveLeftBezierY->addKeyFrame(k);
         } else {
@@ -293,7 +295,7 @@ BezierCP::setRightBezierPointAtTime(bool useGuiCurves,
 {
     {
         KeyFrame k(time, x);
-        k.setInterpolation(eKeyframeTypeLinear);
+        k.setInterpolation(BEZIER_KEYFRAME_INTERPOLATION_TYPE);
         if (!useGuiCurves) {
             _imp->curveRightBezierX->addKeyFrame(k);
         }
@@ -301,7 +303,7 @@ BezierCP::setRightBezierPointAtTime(bool useGuiCurves,
     }
     {
         KeyFrame k(time, y);
-        k.setInterpolation(eKeyframeTypeLinear);
+        k.setInterpolation(BEZIER_KEYFRAME_INTERPOLATION_TYPE);
         if (!useGuiCurves) {
             _imp->curveRightBezierY->addKeyFrame(k);
         }

--- a/Engine/RotoStrokeItem.cpp
+++ b/Engine/RotoStrokeItem.cpp
@@ -384,55 +384,6 @@ RotoStrokeItem::appendPoint(bool newStroke,
         _imp->lastTimestamp = t;
         qDebug("t[%d]=%g", nk, t);
 
-#if 0   // the following was disabled because it creates oscillations.
-
-        // if it's at least the 3rd point in curve, add intermediate point if
-        // the time since last keyframe is larger that the time to the previous one...
-        // This avoids overshooting when the pen suddenly stops, and restarts much later
-        if (nk >= 2) {
-            KeyFrame xp, xpp;
-            bool valid;
-            valid = _imp->xCurve.getKeyFrameWithIndex(nk - 1, &xp);
-            assert(valid);
-            valid = _imp->xCurve.getKeyFrameWithIndex(nk - 2, &xpp);
-            assert(valid);
-
-            double tp = xp.getTime();
-            double tpp = xpp.getTime();
-            if ( (t != tp) && (tp != tpp) && ( (t - tp) > (tp - tpp) ) ) {
-                //printf("adding extra keyframe, %g > %g\n", t - tp, tp - tpp);
-                // add a keyframe to avoid overshoot when the pen stops suddenly and starts again much later
-                KeyFrame yp, ypp;
-                valid = _imp->yCurve.getKeyFrameWithIndex(nk - 1, &yp);
-                assert(valid);
-                valid = _imp->yCurve.getKeyFrameWithIndex(nk - 2, &ypp);
-                assert(valid);
-                KeyFrame pp, ppp;
-                valid = _imp->pressureCurve.getKeyFrameWithIndex(nk - 1, &pp);
-                assert(valid);
-                valid = _imp->pressureCurve.getKeyFrameWithIndex(nk - 2, &ppp);
-                assert(valid);
-                double tn = tp + (tp - tpp);
-                KeyFrame xn, yn, pn;
-                double alpha = (tp - tpp) / (t - tp);
-                assert(0 < alpha && alpha < 1);
-                xn.setTime(tn);
-                yn.setTime(tn);
-                pn.setTime(tn);
-                xn.setValue(xp.getValue() * (1 - alpha) + p.pos.x * alpha);
-                yn.setValue(yp.getValue() * (1 - alpha) + p.pos.y * alpha);
-                pn.setValue(pp.getValue() * (1 - alpha) + p.pressure * alpha);
-                _imp->xCurve.addKeyFrame(xn);
-                _imp->xCurve.setKeyFrameInterpolation(eKeyframeTypeCatmullRom, nk);
-                _imp->yCurve.addKeyFrame(yn);
-                _imp->yCurve.setKeyFrameInterpolation(eKeyframeTypeCatmullRom, nk);
-                _imp->pressureCurve.addKeyFrame(pn);
-                _imp->pressureCurve.setKeyFrameInterpolation(eKeyframeTypeCatmullRom, nk);
-                ++nk;
-            }
-        }
-#endif
-
         bool addKeyFrameOk; // did we add a new keyframe (normally yes, but just in case)
         int ki; // index of the new keyframe (normally nk, but just in case)
         {


### PR DESCRIPTION
 Fixes #597

The origin of linear interpolation dates from https://github.com/NatronGitHub/Natron/commit/ce48afc43f37fa93ae6f96e13d3200a7de8714d5 (which first appeared in Natron 0.9.3!)

This only affects new keyframes. Existing projects will keep the same interpolation.

Nuke seems to use "Smooth" too, or maybe "Catmull-Rom", but certainly not "Linear".