### PR TITLE
Updates properties panel max panels tooltip

### DIFF
--- a/Gui/GuiPrivate.cpp
+++ b/Gui/GuiPrivate.cpp
@@ -374,10 +374,8 @@ GuiPrivate::createPropertiesBinGui()
     _maxPanelsOpenedSpinBox->setMaximumSize(smallButtonSize);
     _maxPanelsOpenedSpinBox->setMinimum(1);
     _maxPanelsOpenedSpinBox->setMaximum(100);
-    _maxPanelsOpenedSpinBox->setToolTip( NATRON_NAMESPACE::convertFromPlainText(tr("Set the maximum of panels that can be opened at the same time "
-                                                                           "in the properties bin pane. The special value of 0 indicates "
-                                                                           "that an unlimited number of panels can be opened."),
-                                                                        NATRON_NAMESPACE::WhiteSpaceNormal) );
+    _maxPanelsOpenedSpinBox->setToolTip( NATRON_NAMESPACE::convertFromPlainText(tr("Sets the maximum number of panels that can be open at once"),
+    NATRON_NAMESPACE::WhiteSpaceNormal) );
     _maxPanelsOpenedSpinBox->setValue( appPTR->getCurrentSettings()->getMaxPanelsOpened() );
     QObject::connect( _maxPanelsOpenedSpinBox, SIGNAL(valueChanged(double)), _gui, SLOT(onMaxPanelsSpinBoxValueChanged(double)) );
 

--- a/Gui/GuiPrivate.cpp
+++ b/Gui/GuiPrivate.cpp
@@ -374,7 +374,7 @@ GuiPrivate::createPropertiesBinGui()
     _maxPanelsOpenedSpinBox->setMaximumSize(smallButtonSize);
     _maxPanelsOpenedSpinBox->setMinimum(1);
     _maxPanelsOpenedSpinBox->setMaximum(100);
-    _maxPanelsOpenedSpinBox->setToolTip( NATRON_NAMESPACE::convertFromPlainText(tr("Sets the maximum number of panels that can be open at once"),
+    _maxPanelsOpenedSpinBox->setToolTip( NATRON_NAMESPACE::convertFromPlainText(tr("Sets the maximum number of panels that can be open at once."),
     NATRON_NAMESPACE::WhiteSpaceNormal) );
     _maxPanelsOpenedSpinBox->setValue( appPTR->getCurrentSettings()->getMaxPanelsOpened() );
     QObject::connect( _maxPanelsOpenedSpinBox, SIGNAL(valueChanged(double)), _gui, SLOT(onMaxPanelsSpinBoxValueChanged(double)) );


### PR DESCRIPTION
You can't set a value of 0 because of the minimum set on line 375.  I don't think this tooltip needs to specify the maximum of 100 but it _could_...  Anyone who wants to figure that out could do so pretty quickly though.

Additionally I'd like to change the default value from 10 to 2 (or possibly 3 if people think 2 is too few).  I've seen a lot of new users overlook this value early on in learning the program and when they find out about it most people switch it to 1.  Having more than 2 open by default causes the node properties to become scollable and having 10 open by default is kind of too many for new users to understand that value is actually related to something in the interface (which is quite dense, there's lots to take in at first like any piece of professional software).  Figuring out that there are 10 windows there actually requires you to scroll through and count them.  I believe by setting it to 2 by default the link between that number and the amount of properties in the panel will be much clearer to those learning the program and they'll set it to 1 like everybody else while learning that they can set it to 2 or more if they need to copy values or expression link later when they learn about those parts.

Couldn't find where to set that value though... If everyone agrees with my rationale I'm happy to include that change in this PR, just need to know where it lives!