### PR TITLE
Gui: restore minimize button checked state

### DIFF
--- a/Gui/DockablePanel.cpp
+++ b/Gui/DockablePanel.cpp
@@ -1199,6 +1199,16 @@ DockablePanel::restoreHideUnmodifiedState(bool hideUnmodified)
     onHideUnmodifiedButtonClicked(hideUnmodified);
 }
 
+void
+DockablePanel::restoreMinimizedState(bool minimized)
+{
+    if (!_imp->_minimize) {
+        return;
+    }
+    _imp->_minimize->setChecked(minimized);
+    minimizeOrMaximize(minimized);
+}
+
 FloatingWidget*
 DockablePanel::floatPanel()
 {

--- a/Gui/DockablePanel.h
+++ b/Gui/DockablePanel.h
@@ -140,6 +140,7 @@ public:
     FloatingWidget* getFloatingWindow() const;
 
     void restoreHideUnmodifiedState(bool hideUnmodified);
+    void restoreMinimizedState(bool minimized);
 
 public:
 

--- a/Gui/Gui15.cpp
+++ b/Gui/Gui15.cpp
@@ -437,7 +437,7 @@ Gui::setVisibleProjectSettingsPanel(bool minimized)
         addVisibleDockablePanel( _imp->_projectGui->getPanel() );
     }
     if (minimized) {
-        _imp->_projectGui->getPanel()->minimizeOrMaximize(true);
+        _imp->_projectGui->getPanel()->restoreMinimizedState(true);
     }
     if ( !_imp->_projectGui->isVisible() ) {
         _imp->_projectGui->setVisible(true);

--- a/Gui/NodeGui.cpp
+++ b/Gui/NodeGui.cpp
@@ -475,7 +475,7 @@ NodeGui::ensurePanelCreated(bool minimized, bool hideUnmodified)
     }
 
     if (minimized) {
-        _settingsPanel->minimizeOrMaximize(true);
+        _settingsPanel->restoreMinimizedState(true);
     }
 
     const std::list<ViewerTab*>& viewers = getDagGui()->getGui()->getViewersList();


### PR DESCRIPTION
Restore minimize button checked state on project load.

Related to PR #603, I didn't notice that the checked state of the minimized button was not set.