### PR TITLE
Update contributor templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,115 +1,116 @@
 name: New issue for bug report
 description: Got a glitch, crash, or some other problem? If you're sure your issue is reproducible, feel free to report the issue to Natron's development team.
 title: "(Bug): <title>"
-labels: bug
+labels: "type: bug"
+issue_body: true
 body:
-# Greeter message
-- type: markdown
-  attributes:
-      value: |
-          Thank you for reporting a bug! Please first check the boxes below to ensure that your bug report meets our requirements.
-# Requirements checks
-- type: checkboxes
-  attributes:
-      options:
-          - label: I'm using the latest version of Natron (not required but recommended)
-          - label: I've restarted Natron and the issue persists
-            required: true
-          - label: I've run Natron via the [command line](https://natron.readthedocs.io/en/rb-2.4/devel/natronexecution.html) and the issue persists
-            required: true
-          - label: I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md) to the best of my understanding
-            required: true
-          - label: My issue is not on the [issue tracker](https://github.com/NatronGitHub/Natron/issues?q=is%3Aissue+type%3Abug) and is not a duplicate of a forum thread
-            required: true
-          - label: This bug is reproducible
-            required: true
-          - label: This issue is not a feature request or a pull request
-            required: true
-# Natron & OS versions
-- type: input
-  id: natron-version
-  attributes:
-      label: Natron version
-      description: Natron version/commit (they can be retrieved from the about window or with `natron --about`)
-      placeholder: e.g. Natron 2.4.0
-  validations:
-      required: true
-- type: input
-  id: os-version
-  attributes:
-      label: Operating system version
-      description: The type and version of your operating system
-      placeholder: e.g. Manjaro Linux 21.0 Ornara with Linux 5.10.42-1
-# System (hardware) info
-- type: markdown
-  attributes:
-      label: System specs
-      value: |
-          Please input the following:
-              * The output of `uname -a && sudo lshw -short` for Mac/Linux, OR the output of `Get-CimInstance Win32_OperatingSystem | FL *` command for Windows
-              * Your system's RAM, 
-              * The number, model, and type of your CPU(s) and GPU
-- type: textarea
-  id: sysinfo
-  attributes:
-      description: "Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in."
-      render: shell
-  validations:
+  # Greeter message
+  - type: markdown
+    attributes:
+        value: |
+            Thank you for reporting a bug! Please first check the boxes below to ensure that your bug report meets our requirements.
+  # Requirements checks
+  - type: checkboxes
+    attributes:
+        options:
+            - label: I'm using the latest version of Natron (not required but recommended)
+            - label: I've restarted Natron and the issue persists
+              required: true
+            - label: I've run Natron via the [command line](https://natron.readthedocs.io/en/rb-2.4/devel/natronexecution.html) and the issue persists
+              required: true
+            - label: I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md) to the best of my understanding
+              required: true
+            - label: My issue is not on the [issue tracker](https://github.com/NatronGitHub/Natron/issues?q=is%3Aissue+type%3Abug) and is not a duplicate of a forum thread
+              required: true
+            - label: This bug is reproducible
+              required: true
+            - label: This issue is not a feature request or a pull request
+              required: true
+  # Natron & OS versions
+  - type: input
+    id: natron-version
+    attributes:
+        label: Natron version
+        description: Natron version/commit (they can be retrieved from the about window or with `natron --about`)
+        placeholder: e.g. Natron 2.4.0
+    validations:
         required: true
-# Did the user install via the official installer?
-- type: checkboxes
-  attributes:
-      label: Did you install Natron using the official installer?
-      options:
-          - Yes
-          - No
-  validations:
-      required: true
-# At which location did the user install Natron?
-- type: textarea
-  attributes:
-      label: At which location did you install Natron?
-      render: markdown
-  validations:
+  - type: input
+    id: os-version
+    attributes:
+        label: Operating system version
+        description: The type and version of your operating system
+        placeholder: e.g. Manjaro Linux 21.0 Ornara with Linux 5.10.42-1
+  # System (hardware) info
+  - type: markdown
+    attributes:
+        label: System specs
+        value: |
+            Please input the following:
+                * The output of `uname -a && sudo lshw -short` for Mac/Linux, OR the output of `Get-CimInstance Win32_OperatingSystem | FL *` command for Windows
+                * Your system's RAM, 
+                * The number, model, and type of your CPU(s) and GPU
+  - type: textarea
+    id: sysinfo
+    attributes:
+        description: "Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in."
+        render: shell
+    validations:
+          required: true
+  # Did the user install via the official installer?
+  - type: checkboxes
+    attributes:
+        label: Did you install Natron using the official installer?
+        options:
+            - Yes
+            - No
+    validations:
         required: true
-# What was the user trying to do?
-- type: textarea
-  attributes:
-      label: What were you trying to do?
-      render: markdown
-  validations:
-      required: true
-# What did the user expect to happen? What was the actual behavior?
-- type: markdown
-  attributes:
-      label: What were you trying to do?
-      value: |
-          * If your problem can be reproduced using a Natron project, please include a link to the project on a file sharing service, or attach the project as a zip file to this issue, if possible.
-          * If your problem is a crash in an official release/snapshot, please include verbose output from the application from a terminal if possible.  If you also submitted a crash report, indicate the Crash ID if possible.
-          * If you need to report a compilation issue, please create a [gist](https://gist.github.com) that contains the _full_ verbose build log.
-          * If your problem is a crash in a build that you made yourself, please create a [gist](https://gist.github.com) that contains a _full_ backtrace.
-- type: textarea
-  attributes:
-      description: You may submit a link to any screenshots/videos that can be used to understand how to reproduce the issue
-      render: markdown
-  validations:
-      required: true
-# Step-by-step reproduction instructions
-- type: textarea
-  attributes:
-      label: Step-by-step reproduction instructions
-      render: markdown
-      placeholder: |
-          1. Open Natron...
-          2. Open attached project...
-          3. Run "..."
-          4. See error...
-  validations:
-      required: true
-# Additional details
-- type: textarea
-  attributes:
-      label: Additional details
-      render: markdown
-  validations:
-      required: false
+  # At which location did the user install Natron?
+  - type: textarea
+    attributes:
+        label: At which location did you install Natron?
+        render: markdown
+    validations:
+          required: true
+  # What was the user trying to do?
+  - type: textarea
+    attributes:
+        label: What were you trying to do?
+        render: markdown
+    validations:
+        required: true
+  # What did the user expect to happen? What was the actual behavior?
+  - type: markdown
+    attributes:
+        label: What were you trying to do?
+        value: |
+            * If your problem can be reproduced using a Natron project, please include a link to the project on a file sharing service, or attach the project as a zip file to this issue, if possible.
+            * If your problem is a crash in an official release/snapshot, please include verbose output from the application from a terminal if possible.  If you also submitted a crash report, indicate the Crash ID if possible.
+            * If you need to report a compilation issue, please create a [gist](https://gist.github.com) that contains the _full_ verbose build log.
+            * If your problem is a crash in a build that you made yourself, please create a [gist](https://gist.github.com) that contains a _full_ backtrace.
+  - type: textarea
+    attributes:
+        description: You may submit a link to any screenshots/videos that can be used to understand how to reproduce the issue
+        render: markdown
+    validations:
+        required: true
+  # Step-by-step reproduction instructions
+  - type: textarea
+    attributes:
+        label: Step-by-step reproduction instructions
+        render: markdown
+        placeholder: |
+            1. Open Natron...
+            2. Open attached project...
+            3. Run "..."
+            4. See error...
+    validations:
+        required: true
+  # Additional details
+  - type: textarea
+    attributes:
+        label: Additional details
+        render: markdown
+    validations:
+        required: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -51,7 +51,7 @@ body:
     - type: textarea
       id: sysinfo
       attributes:
-          description: Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+          description: "Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in."
           render: shell
       validations:
             required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,114 @@
+name: New issue for bug report
+description: "Got a glitch, crash, or some other problem? If you're sure your issue is reproducible, feel free to report the issue to Natron's development team."
+title: "(Bug): <title>"
+labels: bug
+body:
+    # Greeter message
+    - type: markdown
+      attributes:
+          value: Thank you for reporting a bug! Please first check the boxes below to ensure that your bug report meets our requirements.
+    # Requirements checks
+    - type: checkboxes
+      attributes:
+          options:
+              - label: I'm using the latest version of Natron (not required but recommended)
+              - label: I've restarted Natron and the issue persists
+                required: true
+              - label: I've run Natron via the [command line](https://natron.readthedocs.io/en/rb-2.4/devel/natronexecution.html) and the issue persists
+                required: true
+              - label: I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md) to the best of my understanding
+                required: true
+              - label: My issue is not on the [issue tracker](https://github.com/NatronGitHub/Natron/issues?q=is%3Aissue+type%3Abug) and is not a duplicate of a forum thread
+                required: true
+              - label: This bug is reproducible
+                required: true
+              - label: This issue is not a feature request or a pull request
+                required: true
+    # Natron & OS versions
+    - type: input
+      id: natron-version
+      attributes:
+          label: Natron version
+          description: Natron version/commit (they can be retrieved from the about window or with `natron --about`)
+          placeholder: e.g. Natron 2.4.0
+      validations:
+          required: ture
+    - type: input
+      id: os-version
+      attributes:
+          label: Operating system version
+          description: The type and version of your operating system
+          placeholder: e.g. Manjaro Linux 21.0 Ornara with Linux 5.10.42-1
+    # System (hardware) info
+    - type: markdown
+      attributes:
+          label: System specs
+          value: |
+              Please input the following:
+                  * The output of `uname -a && sudo lshw -short` for Mac/Linux, OR the output of `Get-CimInstance Win32_OperatingSystem | FL *` command for Windows
+                  * Your system's RAM, 
+                  * The number, model, and type of your CPU(s) and GPU
+    - type: textarea
+      id: sysinfo
+      attributes:
+          description: Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+          render: shell
+      validations:
+            required: true
+    # Did the user install via the official installer?
+    - type: checkboxes
+      attributes:
+          label: Did you install Natron using the official installer?
+          options:
+              - Yes
+              - No
+        validations:
+            required: true
+    # At which location did the user install Natron?
+    - type: textarea
+      attributes:
+          label: At which location did you install Natron?
+          render: markdown
+      validations:
+            required: true
+    # What was the user trying to do?
+    - type: textarea
+      attributes:
+          label: What were you trying to do?
+          render: markdown
+      validations:
+          required: true
+    # What did the user expect to happen? What was the actual behavior?
+    - type: markdown
+      attributes:
+          label: What were you trying to do?
+          value: |
+              * If your problem can be reproduced using a Natron project, please include a link to the project on a file sharing service, or attach the project as a zip file to this issue, if possible.
+              * If your problem is a crash in an official release/snapshot, please include verbose output from the application from a terminal if possible.  If you also submitted a crash report, indicate the Crash ID if possible.
+              * If you need to report a compilation issue, please create a [gist](https://gist.github.com) that contains the _full_ verbose build log.
+              * If your problem is a crash in a build that you made yourself, please create a [gist](https://gist.github.com) that contains a _full_ backtrace.
+    - type: textarea
+      attributes:
+          description: You may submit a link to any screenshots/videos that can be used to understand how to reproduce the issue
+          render: markdown
+      validations:
+          required: true
+    # Step-by-step reproduction instructions
+    - type: textarea
+      attributes:
+          label: Step-by-step reproduction instructions
+          render: markdown
+          placeholder: |
+              1. Open Natron...
+              2. Open attached project...
+              3. Run "..."
+              4. See error...
+      validations:
+          required: true
+    # Additional details
+    - type: textarea
+      attributes:
+          label: Additional details
+          render: markdown
+      validations:
+          required: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,114 +1,115 @@
 name: New issue for bug report
-description: "Got a glitch, crash, or some other problem? If you're sure your issue is reproducible, feel free to report the issue to Natron's development team."
+description: Got a glitch, crash, or some other problem? If you're sure your issue is reproducible, feel free to report the issue to Natron's development team.
 title: "(Bug): <title>"
 labels: bug
 body:
-    # Greeter message
-    - type: markdown
-      attributes:
-          value: Thank you for reporting a bug! Please first check the boxes below to ensure that your bug report meets our requirements.
-    # Requirements checks
-    - type: checkboxes
-      attributes:
-          options:
-              - label: I'm using the latest version of Natron (not required but recommended)
-              - label: I've restarted Natron and the issue persists
-                required: true
-              - label: I've run Natron via the [command line](https://natron.readthedocs.io/en/rb-2.4/devel/natronexecution.html) and the issue persists
-                required: true
-              - label: I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md) to the best of my understanding
-                required: true
-              - label: My issue is not on the [issue tracker](https://github.com/NatronGitHub/Natron/issues?q=is%3Aissue+type%3Abug) and is not a duplicate of a forum thread
-                required: true
-              - label: This bug is reproducible
-                required: true
-              - label: This issue is not a feature request or a pull request
-                required: true
-    # Natron & OS versions
-    - type: input
-      id: natron-version
-      attributes:
-          label: Natron version
-          description: Natron version/commit (they can be retrieved from the about window or with `natron --about`)
-          placeholder: e.g. Natron 2.4.0
-      validations:
-          required: ture
-    - type: input
-      id: os-version
-      attributes:
-          label: Operating system version
-          description: The type and version of your operating system
-          placeholder: e.g. Manjaro Linux 21.0 Ornara with Linux 5.10.42-1
-    # System (hardware) info
-    - type: markdown
-      attributes:
-          label: System specs
-          value: |
-              Please input the following:
-                  * The output of `uname -a && sudo lshw -short` for Mac/Linux, OR the output of `Get-CimInstance Win32_OperatingSystem | FL *` command for Windows
-                  * Your system's RAM, 
-                  * The number, model, and type of your CPU(s) and GPU
-    - type: textarea
-      id: sysinfo
-      attributes:
-          description: "Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in."
-          render: shell
-      validations:
+# Greeter message
+- type: markdown
+  attributes:
+      value: |
+          Thank you for reporting a bug! Please first check the boxes below to ensure that your bug report meets our requirements.
+# Requirements checks
+- type: checkboxes
+  attributes:
+      options:
+          - label: I'm using the latest version of Natron (not required but recommended)
+          - label: I've restarted Natron and the issue persists
             required: true
-    # Did the user install via the official installer?
-    - type: checkboxes
-      attributes:
-          label: Did you install Natron using the official installer?
-          options:
-              - Yes
-              - No
-        validations:
+          - label: I've run Natron via the [command line](https://natron.readthedocs.io/en/rb-2.4/devel/natronexecution.html) and the issue persists
             required: true
-    # At which location did the user install Natron?
-    - type: textarea
-      attributes:
-          label: At which location did you install Natron?
-          render: markdown
-      validations:
+          - label: I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md) to the best of my understanding
             required: true
-    # What was the user trying to do?
-    - type: textarea
-      attributes:
-          label: What were you trying to do?
-          render: markdown
-      validations:
-          required: true
-    # What did the user expect to happen? What was the actual behavior?
-    - type: markdown
-      attributes:
-          label: What were you trying to do?
-          value: |
-              * If your problem can be reproduced using a Natron project, please include a link to the project on a file sharing service, or attach the project as a zip file to this issue, if possible.
-              * If your problem is a crash in an official release/snapshot, please include verbose output from the application from a terminal if possible.  If you also submitted a crash report, indicate the Crash ID if possible.
-              * If you need to report a compilation issue, please create a [gist](https://gist.github.com) that contains the _full_ verbose build log.
-              * If your problem is a crash in a build that you made yourself, please create a [gist](https://gist.github.com) that contains a _full_ backtrace.
-    - type: textarea
-      attributes:
-          description: You may submit a link to any screenshots/videos that can be used to understand how to reproduce the issue
-          render: markdown
-      validations:
-          required: true
-    # Step-by-step reproduction instructions
-    - type: textarea
-      attributes:
-          label: Step-by-step reproduction instructions
-          render: markdown
-          placeholder: |
-              1. Open Natron...
-              2. Open attached project...
-              3. Run "..."
-              4. See error...
-      validations:
-          required: true
-    # Additional details
-    - type: textarea
-      attributes:
-          label: Additional details
-          render: markdown
-      validations:
-          required: false
+          - label: My issue is not on the [issue tracker](https://github.com/NatronGitHub/Natron/issues?q=is%3Aissue+type%3Abug) and is not a duplicate of a forum thread
+            required: true
+          - label: This bug is reproducible
+            required: true
+          - label: This issue is not a feature request or a pull request
+            required: true
+# Natron & OS versions
+- type: input
+  id: natron-version
+  attributes:
+      label: Natron version
+      description: Natron version/commit (they can be retrieved from the about window or with `natron --about`)
+      placeholder: e.g. Natron 2.4.0
+  validations:
+      required: true
+- type: input
+  id: os-version
+  attributes:
+      label: Operating system version
+      description: The type and version of your operating system
+      placeholder: e.g. Manjaro Linux 21.0 Ornara with Linux 5.10.42-1
+# System (hardware) info
+- type: markdown
+  attributes:
+      label: System specs
+      value: |
+          Please input the following:
+              * The output of `uname -a && sudo lshw -short` for Mac/Linux, OR the output of `Get-CimInstance Win32_OperatingSystem | FL *` command for Windows
+              * Your system's RAM, 
+              * The number, model, and type of your CPU(s) and GPU
+- type: textarea
+  id: sysinfo
+  attributes:
+      description: "Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in."
+      render: shell
+  validations:
+        required: true
+# Did the user install via the official installer?
+- type: checkboxes
+  attributes:
+      label: Did you install Natron using the official installer?
+      options:
+          - Yes
+          - No
+  validations:
+      required: true
+# At which location did the user install Natron?
+- type: textarea
+  attributes:
+      label: At which location did you install Natron?
+      render: markdown
+  validations:
+        required: true
+# What was the user trying to do?
+- type: textarea
+  attributes:
+      label: What were you trying to do?
+      render: markdown
+  validations:
+      required: true
+# What did the user expect to happen? What was the actual behavior?
+- type: markdown
+  attributes:
+      label: What were you trying to do?
+      value: |
+          * If your problem can be reproduced using a Natron project, please include a link to the project on a file sharing service, or attach the project as a zip file to this issue, if possible.
+          * If your problem is a crash in an official release/snapshot, please include verbose output from the application from a terminal if possible.  If you also submitted a crash report, indicate the Crash ID if possible.
+          * If you need to report a compilation issue, please create a [gist](https://gist.github.com) that contains the _full_ verbose build log.
+          * If your problem is a crash in a build that you made yourself, please create a [gist](https://gist.github.com) that contains a _full_ backtrace.
+- type: textarea
+  attributes:
+      description: You may submit a link to any screenshots/videos that can be used to understand how to reproduce the issue
+      render: markdown
+  validations:
+      required: true
+# Step-by-step reproduction instructions
+- type: textarea
+  attributes:
+      label: Step-by-step reproduction instructions
+      render: markdown
+      placeholder: |
+          1. Open Natron...
+          2. Open attached project...
+          3. Run "..."
+          4. See error...
+  validations:
+      required: true
+# Additional details
+- type: textarea
+  attributes:
+      label: Additional details
+      render: markdown
+  validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,18 @@
+# This file is a template generator for Natron's issue tracker system
+
+# The blank template uses the old issue template
+blank_issues_enabled: true
+
+contact_links:
+  - name: Read the Code of Conduct
+    url: https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md
+    about: Before creating any issue, please read Natron's code of conduct and follow it to the best of your understanding.
+  - name: Read the contributing guidelines
+    url: https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md
+    about: Not sure of how to contribute? Read the contributing guidelines to get started.
+  - name: View the troubleshooting docs
+    url: http://natron.readthedocs.io/en/rb-2.4/guide/getstarted-troubleshooting.html
+    about: You can find many easy solutions to common questions on the troubleshooting docs, without needing to create an issue!
+  - name: Get help on Natron's forum
+    url: https://discuss.pixls.us/c/software/natron/27
+    about: Have a ("how do I...?") question? Not sure if your issue is reproducible? The quickest way to get help is on Natron's community forum!

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -3,51 +3,49 @@ description: "Have a feature suggestion? Share your idea with a feature request.
 title: "(Feature): <title>"
 labels: "type: feature"
 body:
-# Greeter message
-- type: markdown
-  attributes:
-      value: Thank you for suggesting a feature! Please first check the boxes below to ensure that your feature request meets our requirements.
-# Requirements checks
-- type: checkboxes
-  attributes:
-      options:
-          - label: I have read the [feature request guidelines](https://hackmd.io/@natron-dev-awesome/B1SW6Hbau)
-            required: true
-          - label: I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md) to the best of my understanding
-            required: true
-          - label: My issue is not on the [issue tracker](https://github.com/NatronGitHub/Natron/issues?q=is%3Abug+type%3Afeature+type%3Aidea) and is not a duplicate
-            required: true
-# Feature request description
-- type: textarea
-  attributes:
-      label: Provide a description of your feature request
-      render: markdown
-  validations:
-      required: true
-# Realistically implementable or not?
-- type: checkboxes
-  attributes:
-      label: Is this a realistically implementable feature?
-      description: |
-          A feature is realistically implementable if you can reasonably expect yourself to implement the feature within 1 month of the request. A feature can still be added if it is not realistically implementable, but it will be tagged as an *idea* and relegated to be added in the indefinite future.
-      options:
-          - label: My feature is realistically implementable
-            required: true
-          - label: My feature is NOT realistically implementable
-            required: true
-# Contributable or not?
-- type: checkboxes
-  attributes:
-      label: Can you contribute in creating this feature?
-      options:
-          - label: I am unable, incapable, or not willing to contribute in creating this feature
-            required: true
-          - label: I am able and willing to contribute in creating this feature
-            required: true
-# Additional details
-- type: textarea
-  attributes:
-      label: Additional details
-      render: markdown
-  validations:
-      required: false
+  # Greeter message
+  - type: markdown
+    attributes:
+        value: Thank you for suggesting a feature! Please first check the boxes below to ensure that your feature request meets our requirements.
+  # Requirements checks
+  - type: checkboxes
+    attributes:
+        options:
+            - label: I have read the [feature request guidelines](https://hackmd.io/@natron-dev-awesome/B1SW6Hbau)
+              required: true
+            - label: I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md) to the best of my understanding
+              required: true
+            - label: My issue is not on the [issue tracker](https://github.com/NatronGitHub/Natron/issues?q=is%3Abug+type%3Afeature+type%3Aidea) and is not a duplicate
+              required: true
+  # Feature request description
+  - type: textarea
+    attributes:
+        label: Provide a description of your feature request
+        render: markdown
+    validations:
+        required: true
+  # Realistically implementable or not?
+  - type: checkboxes
+    attributes:
+        label: Is this a realistically implementable feature?
+        description: |
+            A feature is realistically implementable if you can reasonably expect yourself to implement the feature within 1 month of the request. A feature can still be added if it is not realistically implementable, but it will be tagged as an *idea* and relegated to be added in the indefinite future.
+        options:
+            - label: My feature is realistically implementable
+            - label: My feature is NOT realistically implementable
+  # Contributable or not?
+  - type: checkboxes
+    attributes:
+        label: Can you contribute in creating this feature?
+        options:
+            - label: I am unable, incapable, or not willing to contribute in creating this feature
+            - label: I am able and willing to contribute in creating this feature
+  # Additional details
+  - type: textarea
+    attributes:
+        label: Additional details
+        description: |
+          You do not have to fill this out but more details are always helpful
+        render: markdown
+    validations:
+        required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,53 @@
+name: New issue for feature request
+description: "Have a feature suggestion? Share your idea with a feature request."
+title: "(Feature): <title>"
+labels: feature
+body:
+    # Greeter message
+    - type: markdown
+      attributes:
+          value: Thank you for suggesting a feature! Please first check the boxes below to ensure that your feature request meets our requirements.
+    # Requirements checks
+    - type: checkboxes
+      attributes:
+          options:
+              - label: I have read the [feature request guidelines](https://hackmd.io/@natron-dev-awesome/B1SW6Hbau)
+                required: true
+              - label: I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md) to the best of my understanding
+                required: true
+              - label: My issue is not on the [issue tracker](https://github.com/NatronGitHub/Natron/issues?q=is%3Abug+type%3Afeature+type%3Aidea) and is not a duplicate
+                required: true
+    # Feature request description
+    - type: textarea
+      attributes:
+          label: Provide a description of your feature request
+          render: markdown
+      attributes:
+          required: true
+    # Realistically implementable or not?
+    - type: checkboxes
+      attributes:
+          label: Is this a realistically implementable feature?
+          description: |
+              A feature is realistically implementable if you can reasonably expect yourself to implement the feature within 1 month of the request. A feature can still be added if it is not realistically implementable, but it will be tagged as an *idea* and relegated to be added in the indefinite future.
+          options:
+              - label: My feature is realistically implementable
+                required: true
+              - label: My feature is NOT realistically implementable
+                required: true
+    # Contributable or not?
+    - type: checkboxes
+      attributes:
+          label: Can you contribute in creating this feature?
+          options:
+              - label: I am unable, incapable, or not willing to contribute in creating this feature
+                required: true
+              - label: I am able and willing to contribute in creating this feature
+                required: true
+    # Additional details
+    - type: textarea
+      attributes:
+          label: Additional details
+          render: markdown
+      validations:
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,7 +1,7 @@
 name: New issue for feature request
 description: "Have a feature suggestion? Share your idea with a feature request."
 title: "(Feature): <title>"
-labels: feature
+labels: "type: feature"
 body:
 # Greeter message
 - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -3,51 +3,51 @@ description: "Have a feature suggestion? Share your idea with a feature request.
 title: "(Feature): <title>"
 labels: feature
 body:
-    # Greeter message
-    - type: markdown
-      attributes:
-          value: Thank you for suggesting a feature! Please first check the boxes below to ensure that your feature request meets our requirements.
-    # Requirements checks
-    - type: checkboxes
-      attributes:
-          options:
-              - label: I have read the [feature request guidelines](https://hackmd.io/@natron-dev-awesome/B1SW6Hbau)
-                required: true
-              - label: I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md) to the best of my understanding
-                required: true
-              - label: My issue is not on the [issue tracker](https://github.com/NatronGitHub/Natron/issues?q=is%3Abug+type%3Afeature+type%3Aidea) and is not a duplicate
-                required: true
-    # Feature request description
-    - type: textarea
-      attributes:
-          label: Provide a description of your feature request
-          render: markdown
-      attributes:
-          required: true
-    # Realistically implementable or not?
-    - type: checkboxes
-      attributes:
-          label: Is this a realistically implementable feature?
-          description: |
-              A feature is realistically implementable if you can reasonably expect yourself to implement the feature within 1 month of the request. A feature can still be added if it is not realistically implementable, but it will be tagged as an *idea* and relegated to be added in the indefinite future.
-          options:
-              - label: My feature is realistically implementable
-                required: true
-              - label: My feature is NOT realistically implementable
-                required: true
-    # Contributable or not?
-    - type: checkboxes
-      attributes:
-          label: Can you contribute in creating this feature?
-          options:
-              - label: I am unable, incapable, or not willing to contribute in creating this feature
-                required: true
-              - label: I am able and willing to contribute in creating this feature
-                required: true
-    # Additional details
-    - type: textarea
-      attributes:
-          label: Additional details
-          render: markdown
-      validations:
-          required: false
+# Greeter message
+- type: markdown
+  attributes:
+      value: Thank you for suggesting a feature! Please first check the boxes below to ensure that your feature request meets our requirements.
+# Requirements checks
+- type: checkboxes
+  attributes:
+      options:
+          - label: I have read the [feature request guidelines](https://hackmd.io/@natron-dev-awesome/B1SW6Hbau)
+            required: true
+          - label: I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md) to the best of my understanding
+            required: true
+          - label: My issue is not on the [issue tracker](https://github.com/NatronGitHub/Natron/issues?q=is%3Abug+type%3Afeature+type%3Aidea) and is not a duplicate
+            required: true
+# Feature request description
+- type: textarea
+  attributes:
+      label: Provide a description of your feature request
+      render: markdown
+  validations:
+      required: true
+# Realistically implementable or not?
+- type: checkboxes
+  attributes:
+      label: Is this a realistically implementable feature?
+      description: |
+          A feature is realistically implementable if you can reasonably expect yourself to implement the feature within 1 month of the request. A feature can still be added if it is not realistically implementable, but it will be tagged as an *idea* and relegated to be added in the indefinite future.
+      options:
+          - label: My feature is realistically implementable
+            required: true
+          - label: My feature is NOT realistically implementable
+            required: true
+# Contributable or not?
+- type: checkboxes
+  attributes:
+      label: Can you contribute in creating this feature?
+      options:
+          - label: I am unable, incapable, or not willing to contribute in creating this feature
+            required: true
+          - label: I am able and willing to contribute in creating this feature
+            required: true
+# Additional details
+- type: textarea
+  attributes:
+      label: Additional details
+      render: markdown
+  validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,37 @@
-Please read the [contribution guidelines](https://github.com/NatronGitHub/Natron/blob/master/CONTRIBUTING.md).
+Thanks for submitting a pull request! Please provide enough information so that others can review your pull request:
 
-## Description
+[Please check the applicable box(es) below and delete this line]
 
-Please provide a description of what this PR is meant to fix,
-and how it works (if it's not going to be very clear from the code).
+- [ ] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
+- [ ] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
+- [ ] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
+- [ ] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate
+
+## PR Description
+
+**What type of PR is this? (Check one of the boxes below)**
+
+[Please check the applicable box(es) below and delete this line]
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] My change requires a change to the documentation
+    - [ ] I have updated the documentation accordingly
+
+**Explain the motivation for making this change. What does the pull request do?**
+
+[Please replace this with your answer]
+
+**Show a few screenshots (if this is a visual change)**
+
+[Please replace this with your answer]
+
+**Have you tested your changes (if applicable)? If so, how?**
+
+[Please replace this with your answer]
+
+**Futher details of this pull request**
+
+[Please replace this with your answer]


### PR DESCRIPTION
## PR Description

![image](https://user-images.githubusercontent.com/61605733/124590666-684f8780-de29-11eb-8020-fbf3b398ebf9.png)

This PR aims to do these things:

* Update the PR template to a more intuitive and complete form, with set fields for content and checklists to follow
* Split the issues template to 2 separate templates, consistent with most other open-source projects:
   * The `feature.yml` template is a form-based template that leverages the [newest issue form system](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) to make both managing and creating new issues easier and more standardized
   * The `bugs.yml` template is also form-based and adds more accurate fields for filling out a bug report

**Warning: this is very much not ready as GitHub shows an error page when trying to load the issue template (but not the PR template for some reason), which probably has to do with the fact that the form issue feature is itself beta-quality.** For this reason, I'll probably make a clean PR from another branch, but in the extraordinary case these changes actually work, I'll submit the PR for review.