### PR TITLE
Shiboken2 postmerge fixes in Engine

### DIFF
--- a/Engine/Engine.pro
+++ b/Engine/Engine.pro
@@ -25,6 +25,12 @@ CONFIG += boost boost-serialization-lib qt cairo python shiboken pyside
 QT += core network
 greaterThan(QT_MAJOR_VERSION, 4): QT += concurrent
 
+greaterThan(QT_MAJOR_VERSION, 4) {
+    ENGINE_WRAPPER_DIR = NatronEngine$${QT_MAJOR_VERSION}
+} else {
+    ENGINE_WRAPPER_DIR = NatronEngine
+}
+
 !noexpat: CONFIG += expat
 
 # Do not uncomment the following: pyside requires QtGui, because PySide/QtCore/pyside_qtcore_python.h includes qtextdocument.h
@@ -208,54 +214,7 @@ SOURCES += \
     ../Global/PythonUtils.cpp \
     ../Global/StrUtils.cpp \
     ../libs/SequenceParsing/SequenceParsing.cpp \
-    NatronEngine/animatedparam_wrapper.cpp \
-    NatronEngine/app_wrapper.cpp \
-    NatronEngine/appsettings_wrapper.cpp \
-    NatronEngine/beziercurve_wrapper.cpp \
-    NatronEngine/booleanparam_wrapper.cpp \
-    NatronEngine/boolnodecreationproperty_wrapper.cpp \
-    NatronEngine/buttonparam_wrapper.cpp \
-    NatronEngine/choiceparam_wrapper.cpp \
-    NatronEngine/colorparam_wrapper.cpp \
-    NatronEngine/colortuple_wrapper.cpp \
-    NatronEngine/double2dparam_wrapper.cpp \
-    NatronEngine/double2dtuple_wrapper.cpp \
-    NatronEngine/double3dparam_wrapper.cpp \
-    NatronEngine/double3dtuple_wrapper.cpp \
-    NatronEngine/doubleparam_wrapper.cpp \
-    NatronEngine/effect_wrapper.cpp \
-    NatronEngine/exprutils_wrapper.cpp \
-    NatronEngine/fileparam_wrapper.cpp \
-    NatronEngine/floatnodecreationproperty_wrapper.cpp \
-    NatronEngine/group_wrapper.cpp \
-    NatronEngine/groupparam_wrapper.cpp \
-    NatronEngine/imagelayer_wrapper.cpp \
-    NatronEngine/int2dparam_wrapper.cpp \
-    NatronEngine/int2dtuple_wrapper.cpp \
-    NatronEngine/int3dparam_wrapper.cpp \
-    NatronEngine/int3dtuple_wrapper.cpp \
-    NatronEngine/intnodecreationproperty_wrapper.cpp \
-    NatronEngine/intparam_wrapper.cpp \
-    NatronEngine/itembase_wrapper.cpp \
-    NatronEngine/layer_wrapper.cpp \
-    NatronEngine/natronengine_module_wrapper.cpp \
-    NatronEngine/nodecreationproperty_wrapper.cpp \
-    NatronEngine/outputfileparam_wrapper.cpp \
-    NatronEngine/pageparam_wrapper.cpp \
-    NatronEngine/param_wrapper.cpp \
-    NatronEngine/parametricparam_wrapper.cpp \
-    NatronEngine/pathparam_wrapper.cpp \
-    NatronEngine/pycoreapplication_wrapper.cpp \
-    NatronEngine/rectd_wrapper.cpp \
-    NatronEngine/recti_wrapper.cpp \
-    NatronEngine/roto_wrapper.cpp \
-    NatronEngine/separatorparam_wrapper.cpp \
-    NatronEngine/stringnodecreationproperty_wrapper.cpp \
-    NatronEngine/stringparam_wrapper.cpp \
-    NatronEngine/stringparambase_wrapper.cpp \
-    NatronEngine/track_wrapper.cpp \
-    NatronEngine/tracker_wrapper.cpp \
-    NatronEngine/userparamholder_wrapper.cpp \
+    $${ENGINE_WRAPPER_DIR}/natronengine_module_wrapper.cpp \
 
 HEADERS += \
     AbortableRenderInfo.h \
@@ -472,54 +431,68 @@ HEADERS += \
     ../libs/OpenFX/include/nuke/fnPublicOfxExtensions.h \
     ../libs/OpenFX/include/tuttle/ofxReadWrite.h \
     ../libs/OpenFX_extensions/ofxhParametricParam.h \
-    NatronEngine/animatedparam_wrapper.h \
-    NatronEngine/app_wrapper.h \
-    NatronEngine/appsettings_wrapper.h \
-    NatronEngine/beziercurve_wrapper.h \
-    NatronEngine/booleanparam_wrapper.h \
-    NatronEngine/boolnodecreationproperty_wrapper.h \
-    NatronEngine/buttonparam_wrapper.h \
-    NatronEngine/choiceparam_wrapper.h \
-    NatronEngine/colorparam_wrapper.h \
-    NatronEngine/colortuple_wrapper.h \
-    NatronEngine/double2dparam_wrapper.h \
-    NatronEngine/double2dtuple_wrapper.h \
-    NatronEngine/double3dparam_wrapper.h \
-    NatronEngine/double3dtuple_wrapper.h \
-    NatronEngine/doubleparam_wrapper.h \
-    NatronEngine/effect_wrapper.h \
-    NatronEngine/exprutils_wrapper.h \
-    NatronEngine/fileparam_wrapper.h \
-    NatronEngine/floatnodecreationproperty_wrapper.h \
-    NatronEngine/group_wrapper.h \
-    NatronEngine/groupparam_wrapper.h \
-    NatronEngine/imagelayer_wrapper.h \
-    NatronEngine/int2dparam_wrapper.h \
-    NatronEngine/int2dtuple_wrapper.h \
-    NatronEngine/int3dparam_wrapper.h \
-    NatronEngine/int3dtuple_wrapper.h \
-    NatronEngine/intnodecreationproperty_wrapper.h \
-    NatronEngine/intparam_wrapper.h \
-    NatronEngine/itembase_wrapper.h \
-    NatronEngine/layer_wrapper.h \
-    NatronEngine/natronengine_python.h \
-    NatronEngine/nodecreationproperty_wrapper.h \
-    NatronEngine/outputfileparam_wrapper.h \
-    NatronEngine/pageparam_wrapper.h \
-    NatronEngine/param_wrapper.h \
-    NatronEngine/parametricparam_wrapper.h \
-    NatronEngine/pathparam_wrapper.h \
-    NatronEngine/pycoreapplication_wrapper.h \
-    NatronEngine/rectd_wrapper.h \
-    NatronEngine/recti_wrapper.h \
-    NatronEngine/roto_wrapper.h \
-    NatronEngine/separatorparam_wrapper.h \
-    NatronEngine/stringnodecreationproperty_wrapper.h \
-    NatronEngine/stringparam_wrapper.h \
-    NatronEngine/stringparambase_wrapper.h \
-    NatronEngine/track_wrapper.h \
-    NatronEngine/tracker_wrapper.h \
-    NatronEngine/userparamholder_wrapper.h \
+    $${ENGINE_WRAPPER_DIR}/natronengine_python.h \
+
+ENGINE_GENERATED_SOURCES = \
+    animatedparam_wrapper \
+    app_wrapper \
+    appsettings_wrapper \
+    beziercurve_wrapper \
+    booleanparam_wrapper \
+    boolnodecreationproperty_wrapper \
+    buttonparam_wrapper \
+    choiceparam_wrapper \
+    colorparam_wrapper \
+    colortuple_wrapper \
+    double2dparam_wrapper \
+    double2dtuple_wrapper \
+    double3dparam_wrapper \
+    double3dtuple_wrapper \
+    doubleparam_wrapper \
+    effect_wrapper \
+    exprutils_wrapper \
+    fileparam_wrapper \
+    floatnodecreationproperty_wrapper \
+    group_wrapper \
+    groupparam_wrapper \
+    imagelayer_wrapper \
+    int2dparam_wrapper \
+    int2dtuple_wrapper \
+    int3dparam_wrapper \
+    int3dtuple_wrapper \
+    intnodecreationproperty_wrapper \
+    intparam_wrapper \
+    itembase_wrapper \
+    layer_wrapper \
+    nodecreationproperty_wrapper \
+    outputfileparam_wrapper \
+    pageparam_wrapper \
+    param_wrapper \
+    parametricparam_wrapper \
+    pathparam_wrapper \
+    pycoreapplication_wrapper \
+    rectd_wrapper \
+    recti_wrapper \
+    roto_wrapper \
+    separatorparam_wrapper \
+    stringnodecreationproperty_wrapper \
+    stringparam_wrapper \
+    stringparambase_wrapper \
+    track_wrapper \
+    tracker_wrapper \
+    userparamholder_wrapper \
+
+for(name, ENGINE_GENERATED_SOURCES) {
+    SOURCES += $${ENGINE_WRAPPER_DIR}/$${name}.cpp
+    HEADERS += $${ENGINE_WRAPPER_DIR}/$${name}.h
+}
+
+greaterThan(QT_MAJOR_VERSION, 4) {
+    SOURCES += $${ENGINE_WRAPPER_DIR}/natron_wrapper.cpp
+    HEADERS += $${ENGINE_WRAPPER_DIR}/natron_wrapper.h
+} else {
+    SOURCES += $${ENGINE_WRAPPER_DIR}/natron_namespace_wrapper.cpp
+}
 
 OTHER_FILES += \
     typesystem_engine.xml

--- a/Engine/Plugin.h
+++ b/Engine/Plugin.h
@@ -44,6 +44,10 @@
 #include "Engine/EngineFwd.h"
 #include "Engine/PluginActionShortcut.h"
 
+#ifdef SBK_RUN
+NATRON_NAMESPACE_USING
+#endif
+
 NATRON_NAMESPACE_ENTER
 
 class PluginGroupNode

--- a/Engine/PyParameter.h
+++ b/Engine/PyParameter.h
@@ -430,6 +430,9 @@ public:
     Int2DTuple get(double frame) const;
     void set(int x, int y);
     void set(int x, int y, double frame);
+
+private:
+    void set(int x);
 };
 
 class Int3DParam
@@ -446,6 +449,10 @@ public:
     Int3DTuple get(double frame) const;
     void set(int x, int y, int z);
     void set(int x, int y, int z, double frame);
+
+private:
+    void set(int x);
+    void set(int x, int y);
 };
 
 

--- a/Engine/typesystem_engine.xml
+++ b/Engine/typesystem_engine.xml
@@ -212,8 +212,8 @@
         </conversion-rule>
     </container-type>
 
-     <!--Natron global enums
-    <namespace-type name="NATRON_NAMESPACE">-->
+     <!--Natron global enums-->
+    <namespace-type name="Natron">
     <enum-type name="StatusEnum"/>
     <enum-type name="MergingFunctionEnum"/>
     <enum-type name="StandardButtonEnum" flags="StandardButtons"/>
@@ -228,7 +228,7 @@
     <enum-type name="OrientationEnum"/>
     <enum-type name="PlaybackModeEnum"/>
     <enum-type name="DisplayChannelsEnum"/>
-    <!--</namespace-type>-->
+    </namespace-type>
     
    
    <object-type name="RectI">
@@ -1509,7 +1509,7 @@
 
                     for (int j = 0; j &lt; subSize; ++j) {
                         PyObject* pyString = PyList_GET_ITEM(subList,j);
-                #if PY_VERSION_MAJOR &lt; 3
+                #if PY_MAJOR_VERSION &lt; 3
                         if ( PyString_Check(pyString) ) {
                             char* buf = PyString_AsString(pyString);
                             if (buf) {

--- a/Global/Enums.h
+++ b/Global/Enums.h
@@ -28,10 +28,10 @@ CLANG_DIAG_OFF(deprecated)
 CLANG_DIAG_ON(deprecated)
 
 NATRON_NAMESPACE_ENTER
-#if defined(SBK_RUN) && !defined(SBK2_GEN)
+#if defined(SBK_RUN)
 // shiboken doesn't generate SbkNatronEngine_StandardButtonEnum_as_number unless it is put in a class or namespace
 NATRON_NAMESPACE_EXIT
-namespace NATRON_NAMESPACE {
+namespace Natron {
 #endif
 
 enum ScaleTypeEnum
@@ -684,7 +684,7 @@ enum MergingFunctionEnum
 //typedef QFlags<StandardButtonEnum> StandardButtons;
 Q_DECLARE_FLAGS(StandardButtons, StandardButtonEnum)
 
-#if defined(SBK_RUN) && !defined(SBK2_GEN)
+#if defined(SBK_RUN)
 }
 NATRON_NAMESPACE_ENTER
 #endif
@@ -692,7 +692,7 @@ NATRON_NAMESPACE_ENTER
 
 NATRON_NAMESPACE_EXIT
 
-Q_DECLARE_METATYPE(NATRON_NAMESPACE::StandardButtons)
+Q_DECLARE_METATYPE(Natron::StandardButtons)
 
 
 #endif // NATRON_GLOBAL_ENUMS_H

--- a/Global/Macros.h
+++ b/Global/Macros.h
@@ -37,6 +37,14 @@
 #define __NATRON_LINUX__
 #endif
 
+#ifdef __cplusplus
+// Establish the name space.
+namespace Natron { }
+namespace Python { }
+#define NATRON_NAMESPACE_USING using namespace Natron;
+#define NATRON_PYTHON_NAMESPACE_USING using namespace Natron::Python;
+#endif
+
 #ifdef SBK_RUN
 
 // run shiboken without the Natron namespace, and add NATRON_NAMESPACE_USING to each cpp afterwards
@@ -53,18 +61,10 @@
 // Macros to use in each file to enter and exit the right name spaces.
 #define NATRON_NAMESPACE_ENTER namespace NATRON_NAMESPACE {
 #define NATRON_NAMESPACE_EXIT }
-#define NATRON_NAMESPACE_USING using namespace NATRON_NAMESPACE;
 
 #define NATRON_PYTHON_NAMESPACE Python
 #define NATRON_PYTHON_NAMESPACE_ENTER namespace NATRON_PYTHON_NAMESPACE {
 #define NATRON_PYTHON_NAMESPACE_EXIT }
-#define NATRON_PYTHON_NAMESPACE_USING using namespace NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE;
-
-#ifdef __cplusplus
-// Establish the name space.
-namespace NATRON_NAMESPACE { }
-namespace NATRON_PYTHON_NAMESPACE { }
-#endif
 
 #endif
 

--- a/tools/utils/runPostShiboken2.sh
+++ b/tools/utils/runPostShiboken2.sh
@@ -25,17 +25,17 @@ PYV="${1:-2}"
 
 # To be run after shiboken to fix errors
 
-sed -e '/<destroylistener.h>/d' -i'.bak' Engine/NatronEngine/*.cpp
-sed -e '/<destroylistener.h>/d' -i'.bak' Gui/NatronGui/*.cpp
-sed -e "/SbkPySide${PYV}_QtCoreTypes;/d" -i'.bak' Gui/NatronGui/natrongui_module_wrapper.cpp
-sed -e "/SbkPySide${PYV}_QtCoreTypeConverters;/d" -i'.bak' Gui/NatronGui/natrongui_module_wrapper.cpp
-sed -e '/SbkNatronEngineTypes;/d' -i'.bak' Gui/NatronGui/natrongui_module_wrapper.cpp
-sed -e '/SbkNatronEngineTypeConverters;/d' -i'.bak' Gui/NatronGui/natrongui_module_wrapper.cpp
-sed -e 's/cleanTypesAttributes/cleanGuiTypesAttributes/g' -i'.bak' Gui/NatronGui/natrongui_module_wrapper.cpp
-sed -e '/Py_BEGIN_ALLOW_THREADS/d' -i'.bak' Engine/NatronEngine/*.cpp
-sed -e '/Py_BEGIN_ALLOW_THREADS/d' -i'.bak' Gui/NatronGui/*.cpp
-sed -e '/Py_END_ALLOW_THREADS/d' -i'.bak' Engine/NatronEngine/*.cpp
-sed -e '/Py_END_ALLOW_THREADS/d' -i'.bak' Gui/NatronGui/*.cpp
+sed -e '/<destroylistener.h>/d' -i'.bak' Engine/NatronEngine5/*.cpp
+sed -e '/<destroylistener.h>/d' -i'.bak' Gui/NatronGui5/*.cpp
+sed -e "/SbkPySide${PYV}_QtCoreTypes;/d" -i'.bak' Gui/NatronGui5/natrongui_module_wrapper.cpp
+sed -e "/SbkPySide${PYV}_QtCoreTypeConverters;/d" -i'.bak' Gui/NatronGui5/natrongui_module_wrapper.cpp
+sed -e '/SbkNatronEngineTypes;/d' -i'.bak' Gui/NatronGui5/natrongui_module_wrapper.cpp
+sed -e '/SbkNatronEngineTypeConverters;/d' -i'.bak' Gui/NatronGui5/natrongui_module_wrapper.cpp
+sed -e 's/cleanTypesAttributes/cleanGuiTypesAttributes/g' -i'.bak' Gui/NatronGui5/natrongui_module_wrapper.cpp
+sed -e '/Py_BEGIN_ALLOW_THREADS/d' -i'.bak' Engine/NatronEngine5/*.cpp
+sed -e '/Py_BEGIN_ALLOW_THREADS/d' -i'.bak' Gui/NatronGui5/*.cpp
+sed -e '/Py_END_ALLOW_THREADS/d' -i'.bak' Engine/NatronEngine5/*.cpp
+sed -e '/Py_END_ALLOW_THREADS/d' -i'.bak' Gui/NatronGui5/*.cpp
 
 # fix warnings
 sed -e 's@^#include <shiboken.h>$@#include "Global/Macros.h"\
@@ -45,28 +45,28 @@ GCC_DIAG_OFF(missing-field-initializers)\
 GCC_DIAG_OFF(missing-declarations)\
 GCC_DIAG_OFF(uninitialized)\
 GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF\
-#include <shiboken.h> // produces many warnings@' -i'.bak' Engine/NatronEngine/*.cpp Gui/NatronGui/*.cpp
+#include <shiboken.h> // produces many warnings@' -i'.bak' Engine/NatronEngine5/*.cpp Gui/NatronGui5/*.cpp
 
 sed -e 's@// inner classes@// inner classes\
-NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING@' -i'.bak' Engine/NatronEngine/*.cpp Gui/NatronGui/*.cpp
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING@' -i'.bak' Engine/NatronEngine5/*.cpp Gui/NatronGui5/*.cpp
 
 # replace NATRON_NAMESPACE with Natron for enums with flags (e.g. StandardButtonEnum)
-sed -e 's@"NatronEngine\.NATRON_NAMESPACE@"NatronEngine.Natron@g' -e 's@, NatronEngine\.NATRON_NAMESPACE@, NatronEngine.Natron@g' -e 's@"NatronGui\.NATRON_NAMESPACE@"NatronGui.Natron@g' -e 's@"NATRON_NAMESPACE@"Natron@g' -i'.bak' Engine/NatronEngine/*_wrapper.cpp
+sed -e 's@"1:NatronEngine\.NATRON_NAMESPACE@"1:NatronEngine.Natron@g' -e 's@, NatronEngine\.NATRON_NAMESPACE@, NatronEngine.Natron@g' -e 's@"1:NatronGui\.NATRON_NAMESPACE@"NatronGui.Natron@g' -e 's@"NATRON_NAMESPACE@"Natron@g' -i'.bak' Engine/NatronEngine5/*_wrapper.cpp
 
 # re-add the Natron namespace
-#sed -e 's@" ::\([^s][^t][^d]\)@ NATRON_NAMESPACE::\1@g' -i'.bak' Engine/NatronEngine/*.cpp Engine/NatronEngine/*.h Gui/NatronGui/*.cpp Gui/NatronGui/*.h
+#sed -e 's@" ::\([^s][^t][^d]\)@ NATRON_NAMESPACE::\1@g' -i'.bak' Engine/NatronEngine5/*.cpp Engine/NatronEngine5/*.h Gui/NatronGui5/*.cpp Gui/NatronGui5/*.h
 
-sed -e '/AnimatedParam/ {:y;n;by};s@SbkType< ::\(.*\) >@SbkType<NATRON_NAMESPACE::\1 >@g' -i Engine/NatronEngine/natronengine_python.h
-sed -e 's@SbkType< ::@SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::@g' -e 's@SbkType<NATRON_NAMESPACE::QFlags<@SbkType< ::QFlags<NATRON_NAMESPACE::@g' -e's@NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Rect@NATRON_NAMESPACE::Rect@g' -i'.bak' Engine/NatronEngine/natronengine_python.h Gui/NatronGui/natrongui_python.h
+sed -e 's@SbkType< ::\(\(QFlags<\)\?Natron::.*\) >@SbkType< \1 >@g' -i Engine/NatronEngine5/natronengine_python.h
+sed -e 's@SbkType< ::@SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::@g' -e 's@SbkType<Natron::QFlags<@SbkType< ::QFlags<NATRON_NAMESPACE::@g' -e's@NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Rect@NATRON_NAMESPACE::Rect@g' -i'.bak' Engine/NatronEngine5/natronengine_python.h Gui/NatronGui5/natrongui_python.h
 sed -e 's@^class @NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER\
 class @g;T;{:y;/^};/! {n;by}};s@^};@};\
-NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT@g'  -i'.bak' Engine/NatronEngine/*.h Gui/NatronGui/*.h
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT@g' -i'.bak' Engine/NatronEngine5/*.h Gui/NatronGui5/*.h
 
 # replace NATRON_NAMESPACE::NATRON_NAMESPACE with NATRON_NAMESPACE in the enums wrappers
-sed -e 's@NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::NATRON_NAMESPACE@NATRON_NAMESPACE@g' -i'.bak' Engine/NatronEngine/natronengine_python.h Gui/NatronGui/natrongui_python.h
+sed -e 's@NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::NATRON_NAMESPACE@NATRON_NAMESPACE@g' -i'.bak' Engine/NatronEngine5/natronengine_python.h Gui/NatronGui5/natrongui_python.h
 
 sed -e 's@^#include <pysidemetafunction.h>$@CLANG_DIAG_OFF(header-guard)\
-#include <pysidemetafunction.h> // has wrong header guards in pyside 1.2.2@' -i'.bak' Engine/NatronEngine/*.cpp Gui/NatronGui/*.cpp
+#include <pysidemetafunction.h> // has wrong header guards in pyside 1.2.2@' -i'.bak' Engine/NatronEngine5/*.cpp Gui/NatronGui5/*.cpp
 
 sed -e 's@^#include <pyside'${PYV}'_qtcore_python.h>$@CLANG_DIAG_OFF(deprecated)\
 CLANG_DIAG_OFF(uninitialized)\
@@ -74,7 +74,7 @@ CLANG_DIAG_OFF(keyword-macro)\
 #include <pyside'${PYV}'_qtcore_python.h> // produces warnings\
 CLANG_DIAG_ON(deprecated)\
 CLANG_DIAG_ON(uninitialized)\
-CLANG_DIAG_ON(keyword-macro)@' -i'.bak' Engine/NatronEngine/*.cpp Gui/NatronGui/*.cpp Engine/NatronEngine/*.h Gui/NatronGui/*.h
+CLANG_DIAG_ON(keyword-macro)@' -i'.bak' Engine/NatronEngine5/*.cpp Gui/NatronGui5/*.cpp Engine/NatronEngine5/*.h Gui/NatronGui5/*.h
 
 sed -e 's@^#include <pyside'${PYV}'_qtgui_python.h>$@CLANG_DIAG_OFF(deprecated)\
 CLANG_DIAG_OFF(uninitialized)\
@@ -82,7 +82,7 @@ CLANG_DIAG_OFF(keyword-macro)\
 #include <pyside'${PYV}'_qtgui_python.h> // produces warnings\
 CLANG_DIAG_ON(deprecated)\
 CLANG_DIAG_ON(uninitialized)\
-CLANG_DIAG_ON(keyword-macro)@' -i'.bak' Engine/NatronEngine/*.cpp Gui/NatronGui/*.cpp Engine/NatronEngine/*.h Gui/NatronGui/*.h
+CLANG_DIAG_ON(keyword-macro)@' -i'.bak' Engine/NatronEngine5/*.cpp Gui/NatronGui5/*.cpp Engine/NatronEngine5/*.h Gui/NatronGui5/*.h
 
 # clean up
-rm Gui/NatronGui/*.bak Engine/NatronEngine/*.bak
+rm Gui/NatronGui5/*.bak Engine/NatronEngine5/*.bak


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

This is a series of fixes after #697 was committed.
After the merge the enums of the Engine typesystem were placed in `NatronEngine` instead of `NatronEngine.Natron`, change which breaks scripts that used said enums. This PR amends the regression.
This change also makes the hidden `set` methods in `Int2DParam` and `Int3DParam` private so they are not called where it's not supposed to be.
And lastly the `Engine.pro` was modified to build with the Shiboken2 binding, which they'll reside in `Engine/NatronEngine5`.

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

Started `Natron` with this `init.py` to assert that the enum was in the correct place.

```python
import NatronEngine

print(NatronEngine.Natron.DisplayChannelsEnum.eDisplayChannelsRGB)
print(NatronEngine.Natron.DisplayChannelsEnum.eDisplayChannelsR)
print(NatronEngine.Natron.DisplayChannelsEnum.eDisplayChannelsG)
print(NatronEngine.Natron.DisplayChannelsEnum.eDisplayChannelsB)
print(NatronEngine.Natron.DisplayChannelsEnum.eDisplayChannelsA)
print(NatronEngine.Natron.DisplayChannelsEnum.eDisplayChannelsY)
print(NatronEngine.Natron.DisplayChannelsEnum.eDisplayChannelsMatte)
```

```stdout
NatronEngine.Natron.DisplayChannelsEnum.eDisplayChannelsR
NatronEngine.Natron.DisplayChannelsEnum.eDisplayChannelsG
NatronEngine.Natron.DisplayChannelsEnum.eDisplayChannelsB
NatronEngine.Natron.DisplayChannelsEnum.eDisplayChannelsA
NatronEngine.Natron.DisplayChannelsEnum.eDisplayChannelsY
NatronEngine.Natron.DisplayChannelsEnum.eDisplayChannelsMatte
```

Tried with `natron-python` but the thing turned out to be disobedient.

**Futher details of this pull request**

N/A.
