### PR TITLE
use a different (fake) enum namespace for shiboken & shiboken2

### DIFF
--- a/App/.gitignore
+++ b/App/.gitignore
@@ -1,1 +1,2 @@
+.xcode/XCBuildData
 NatronInfo.plist

--- a/Engine/AppManager.h
+++ b/Engine/AppManager.h
@@ -44,7 +44,7 @@ CLANG_DIAG_ON(deprecated)
 #include <QtCore/QProcess>
 #include <QtCore/QMap>
 
-#if (!defined(Q_MOC_RUN) && !defined(SBK_RUN)) || defined(SBK2_GEN)
+#if (!defined(Q_MOC_RUN) && !defined(SBK_RUN)) || defined(SBK2_RUN)
 #include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/noncopyable.hpp>
@@ -496,7 +496,7 @@ public:
     void setOFXHostHandle(void* handle);
 
     OFX::Host::ImageEffect::Descriptor* getPluginContextAndDescribe(OFX::Host::ImageEffect::ImageEffectPlugin* plugin,
-                                                                    ContextEnum* ctx);
+                                                                    NATRON_ENUM::ContextEnum* ctx);
     AppTLS* getAppTLS() const;
     const OfxHost* getOFXHost() const;
     GPUContextPool* getGPUContextPool() const;
@@ -569,7 +569,7 @@ public:
 
     bool isTextureFloatSupported() const;
 
-    bool hasOpenGLForRequirements(OpenGLRequirementsTypeEnum type, QString* missingOpenGLError = 0) const;
+    bool hasOpenGLForRequirements(NATRON_ENUM::OpenGLRequirementsTypeEnum type, QString* missingOpenGLError = 0) const;
 
     virtual void updateAboutWindowLibrariesVersion() {}
 
@@ -734,14 +734,14 @@ void warningDialog(const std::string & title, const std::string & message, bool*
 void informationDialog(const std::string & title, const std::string & message, bool useHtml = false);
 void informationDialog(const std::string & title, const std::string & message, bool* stopAsking, bool useHtml = false);
 
-StandardButtonEnum questionDialog(const std::string & title, const std::string & message, bool useHtml,
-                                  StandardButtons buttons =
-                                      StandardButtons(eStandardButtonYes | eStandardButtonNo),
-                                  StandardButtonEnum defaultButton = eStandardButtonNoButton);
+NATRON_ENUM::StandardButtonEnum questionDialog(const std::string & title, const std::string & message, bool useHtml,
+                                  NATRON_ENUM::StandardButtons buttons =
+                                      NATRON_ENUM::StandardButtons(NATRON_ENUM::eStandardButtonYes | NATRON_ENUM::eStandardButtonNo),
+                                  NATRON_ENUM::StandardButtonEnum defaultButton = NATRON_ENUM::eStandardButtonNoButton);
 
-StandardButtonEnum questionDialog(const std::string & title, const std::string & message, bool useHtml,
-                                  StandardButtons buttons,
-                                  StandardButtonEnum defaultButton,
+NATRON_ENUM::StandardButtonEnum questionDialog(const std::string & title, const std::string & message, bool useHtml,
+                                  NATRON_ENUM::StandardButtons buttons,
+                                  NATRON_ENUM::StandardButtonEnum defaultButton,
                                   bool* stopAsking);
 } // namespace Dialogs
 

--- a/Engine/Engine.pro
+++ b/Engine/Engine.pro
@@ -26,7 +26,7 @@ QT += core network
 greaterThan(QT_MAJOR_VERSION, 4): QT += concurrent
 
 greaterThan(QT_MAJOR_VERSION, 4) {
-    ENGINE_WRAPPER_DIR = NatronEngine$${QT_MAJOR_VERSION}
+    ENGINE_WRAPPER_DIR = Qt$${QT_MAJOR_VERSION}/NatronEngine
 } else {
     ENGINE_WRAPPER_DIR = NatronEngine
 }
@@ -464,6 +464,7 @@ ENGINE_GENERATED_SOURCES = \
     intparam_wrapper \
     itembase_wrapper \
     layer_wrapper \
+    natron_enum_wrapper \
     nodecreationproperty_wrapper \
     outputfileparam_wrapper \
     pageparam_wrapper \
@@ -487,12 +488,6 @@ for(name, ENGINE_GENERATED_SOURCES) {
     HEADERS += $${ENGINE_WRAPPER_DIR}/$${name}.h
 }
 
-greaterThan(QT_MAJOR_VERSION, 4) {
-    SOURCES += $${ENGINE_WRAPPER_DIR}/natron_wrapper.cpp
-    HEADERS += $${ENGINE_WRAPPER_DIR}/natron_wrapper.h
-} else {
-    SOURCES += $${ENGINE_WRAPPER_DIR}/natron_namespace_wrapper.cpp
-}
 
 OTHER_FILES += \
     typesystem_engine.xml

--- a/Engine/ImagePlaneDesc.h
+++ b/Engine/ImagePlaneDesc.h
@@ -31,7 +31,7 @@
 #include <string>
 #include <vector>
 
-#if (!defined(Q_MOC_RUN) && !defined(SBK_RUN)) || defined(SBK2_GEN)
+#if (!defined(Q_MOC_RUN) && !defined(SBK_RUN)) || defined(SBK2_RUN)
 GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
 GCC_DIAG_OFF(unused-parameter)
 // /opt/local/include/boost/serialization/smart_cast.hpp:254:25: warning: unused parameter 'u' [-Wunused-parameter]

--- a/Engine/Knob.h
+++ b/Engine/Knob.h
@@ -33,7 +33,7 @@
 #include <set>
 #include <map>
 
-#if (!defined(Q_MOC_RUN) && !defined(SBK_RUN)) || defined(SBK2_GEN)
+#if (!defined(Q_MOC_RUN) && !defined(SBK_RUN)) || defined(SBK2_RUN)
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/scoped_ptr.hpp>
 #endif
@@ -157,7 +157,7 @@ public:
         Q_EMIT setValueWithUndoStack(v, view, dim);
     }
 
-    void s_appendParamEditChange(ValueChangedReasonEnum reason,
+    void s_appendParamEditChange(NATRON_ENUM::ValueChangedReasonEnum reason,
                                  Variant v,
                                  ViewSpec view,
                                  int dim,
@@ -186,7 +186,7 @@ public:
         Q_EMIT keyFrameMoved(view, dimension, oldTime, newTime);
     }
 
-    void s_redrawGuiCurve(CurveChangeReason reason,
+    void s_redrawGuiCurve(NATRON_ENUM::CurveChangeReason reason,
                           ViewSpec view,
                           int dimension)
     {
@@ -358,7 +358,7 @@ Q_SIGNALS:
 struct KnobChange
 {
     KnobIPtr knob;
-    ValueChangedReasonEnum reason, originalReason;
+    NATRON_ENUM::ValueChangedReasonEnum reason, originalReason;
     bool originatedFromMainThread;
     bool refreshGui;
     double time;
@@ -489,7 +489,7 @@ public:
      * evaluate the new value (cause a render).
      * @returns true if the knobChanged handler was called once for this knob
      **/
-    virtual bool evaluateValueChange(int dimension, double time, ViewSpec view, ValueChangedReasonEnum reason) = 0;
+    virtual bool evaluateValueChange(int dimension, double time, ViewSpec view, NATRON_ENUM::ValueChangedReasonEnum reason) = 0;
 
     /**
      * @brief Copies all the values, animations and extra data the other knob might have
@@ -565,28 +565,28 @@ protected:
     /**
      * @brief Removes all the keyframes in the given dimension.
      **/
-    virtual void removeAnimationWithReason(ViewSpec view, int dimension, ValueChangedReasonEnum reason) = 0;
+    virtual void removeAnimationWithReason(ViewSpec view, int dimension, NATRON_ENUM::ValueChangedReasonEnum reason) = 0;
 
 public:
 
     /**
      * @brief Removes the keyframe at the given time and dimension if it matches any.
      **/
-    virtual void deleteValueAtTime(CurveChangeReason curveChangeReason, double time, ViewSpec view, int dimension, bool copyCurveValueAtTimeToInternalValue) = 0;
-    virtual void deleteValuesAtTime(CurveChangeReason curveChangeReason, const std::list<double>& times, ViewSpec view, int dimension, bool copyCurveValueAtTimeToInternalValue) = 0;
+    virtual void deleteValueAtTime(NATRON_ENUM::CurveChangeReason curveChangeReason, double time, ViewSpec view, int dimension, bool copyCurveValueAtTimeToInternalValue) = 0;
+    virtual void deleteValuesAtTime(NATRON_ENUM::CurveChangeReason curveChangeReason, const std::list<double>& times, ViewSpec view, int dimension, bool copyCurveValueAtTimeToInternalValue) = 0;
 
 
     /**
      * @brief Moves a keyframe by a given delta and emits the signal keyframeMoved
      **/
-    virtual bool moveValueAtTime(CurveChangeReason reason, double time, ViewSpec view,  int dimension, double dt, double dv, KeyFrame* newKey) = 0;
-    virtual bool moveValuesAtTime(CurveChangeReason reason, ViewSpec view,  int dimension, double dt, double dv, std::vector<KeyFrame>* keyframes) = 0;
+    virtual bool moveValueAtTime(NATRON_ENUM::CurveChangeReason reason, double time, ViewSpec view,  int dimension, double dt, double dv, KeyFrame* newKey) = 0;
+    virtual bool moveValuesAtTime(NATRON_ENUM::CurveChangeReason reason, ViewSpec view,  int dimension, double dt, double dv, std::vector<KeyFrame>* keyframes) = 0;
 
     /**
      * @brief Transforms a keyframe by a given matrix. The matrix must not contain any skew or rotation.
      **/
-    virtual bool transformValueAtTime(CurveChangeReason curveChangeReason, double time, ViewSpec view,  int dimension, const Transform::Matrix3x3& matrix, KeyFrame* newKey) = 0;
-    virtual bool transformValuesAtTime(CurveChangeReason curveChangeReason, ViewSpec view,  int dimension, const Transform::Matrix3x3& matrix, std::vector<KeyFrame>* keyframes) = 0;
+    virtual bool transformValueAtTime(NATRON_ENUM::CurveChangeReason curveChangeReason, double time, ViewSpec view,  int dimension, const Transform::Matrix3x3& matrix, KeyFrame* newKey) = 0;
+    virtual bool transformValuesAtTime(NATRON_ENUM::CurveChangeReason curveChangeReason, ViewSpec view,  int dimension, const Transform::Matrix3x3& matrix, std::vector<KeyFrame>* keyframes) = 0;
 
     /**
      * @brief Copies all the animation of *curve* into the animation curve at the given dimension.
@@ -596,25 +596,25 @@ public:
     /**
      * @brief Changes the interpolation type for the given keyframe
      **/
-    virtual bool setInterpolationAtTime(CurveChangeReason reason, ViewSpec view, int dimension, double time, KeyframeTypeEnum interpolation, KeyFrame* newKey) = 0;
+    virtual bool setInterpolationAtTime(NATRON_ENUM::CurveChangeReason reason, ViewSpec view, int dimension, double time, NATRON_ENUM::KeyframeTypeEnum interpolation, KeyFrame* newKey) = 0;
 
     /**
      * @brief Set the left/right derivatives of the control point at the given time.
      **/
-    virtual bool moveDerivativesAtTime(CurveChangeReason reason, ViewSpec view, int dimension, double time, double left, double right) = 0;
-    virtual bool moveDerivativeAtTime(CurveChangeReason reason, ViewSpec view, int dimension, double time, double derivative, bool isLeft) = 0;
+    virtual bool moveDerivativesAtTime(NATRON_ENUM::CurveChangeReason reason, ViewSpec view, int dimension, double time, double left, double right) = 0;
+    virtual bool moveDerivativeAtTime(NATRON_ENUM::CurveChangeReason reason, ViewSpec view, int dimension, double time, double derivative, bool isLeft) = 0;
 
     /**
      * @brief Removes animation before the given time and dimension. If the reason is different than eValueChangedReasonUserEdited
      * a signal will be emitted
      **/
-    virtual void deleteAnimationBeforeTime(double time, ViewSpec view, int dimension, ValueChangedReasonEnum reason) = 0;
+    virtual void deleteAnimationBeforeTime(double time, ViewSpec view, int dimension, NATRON_ENUM::ValueChangedReasonEnum reason) = 0;
 
     /**
      * @brief Removes animation before the given time and dimension. If the reason is different than eValueChangedReasonUserEdited
      * a signal will be emitted
      **/
-    virtual void deleteAnimationAfterTime(double time, ViewSpec view, int dimension, ValueChangedReasonEnum reason) = 0;
+    virtual void deleteAnimationAfterTime(double time, ViewSpec view, int dimension, NATRON_ENUM::ValueChangedReasonEnum reason) = 0;
 
     /**
      * @brief Calls removeAnimation with a reason of eValueChangedReasonNatronInternalEdited.
@@ -693,7 +693,7 @@ public:
 
 protected:
 
-    virtual void refreshListenersAfterValueChange(ViewSpec view, ValueChangedReasonEnum reason, int dimension) = 0;
+    virtual void refreshListenersAfterValueChange(ViewSpec view, NATRON_ENUM::ValueChangedReasonEnum reason, int dimension) = 0;
 
 public:
 
@@ -714,7 +714,7 @@ public:
      **/
     virtual bool onKeyFrameSet(double time, ViewSpec view, int dimension) = 0;
     virtual bool onKeyFrameSet(double time, ViewSpec view, const KeyFrame& key, int dimension) = 0;
-    virtual bool setKeyFrame(const KeyFrame& key, ViewSpec view,  int dimension, ValueChangedReasonEnum reason) = 0;
+    virtual bool setKeyFrame(const KeyFrame& key, ViewSpec view,  int dimension, NATRON_ENUM::ValueChangedReasonEnum reason) = 0;
 
     /**
      * @brief Called when the current time of the timeline changes.
@@ -1168,14 +1168,14 @@ protected:
      * at the same dimension for the knob 'other'.
      * In case of success, this function returns true, otherwise false.
      **/
-    virtual bool slaveToInternal(int dimension, const KnobIPtr &  other, int otherDimension, ValueChangedReasonEnum reason,
+    virtual bool slaveToInternal(int dimension, const KnobIPtr &  other, int otherDimension, NATRON_ENUM::ValueChangedReasonEnum reason,
                                  bool ignoreMasterPersistence) = 0;
 
     /**
      * @brief Unslaves a previously slaved dimension. The implementation should assert that
      * the dimension was really slaved.
      **/
-    virtual void unSlaveInternal(int dimension, ValueChangedReasonEnum reason, bool copyState) = 0;
+    virtual void unSlaveInternal(int dimension, NATRON_ENUM::ValueChangedReasonEnum reason, bool copyState) = 0;
 
 public:
 
@@ -1284,7 +1284,7 @@ public:
     /**
      * @brief Get the current animation level.
      **/
-    virtual AnimationLevelEnum getAnimationLevel(int dimension) const = 0;
+    virtual NATRON_ENUM::AnimationLevelEnum getAnimationLevel(int dimension) const = 0;
 
     /**
      * @brief Restores the default value
@@ -1394,15 +1394,15 @@ public:
     virtual void blockListenersNotification() OVERRIDE FINAL;
     virtual void unblockListenersNotification() OVERRIDE FINAL;
     virtual bool isListenersNotificationBlocked() const OVERRIDE FINAL WARN_UNUSED_RETURN;
-    virtual bool evaluateValueChange(int dimension, double time, ViewSpec view,  ValueChangedReasonEnum reason) OVERRIDE FINAL;
+    virtual bool evaluateValueChange(int dimension, double time, ViewSpec view,  NATRON_ENUM::ValueChangedReasonEnum reason) OVERRIDE FINAL;
 
 protected:
     // Returns true if the knobChanged handler was called
     bool evaluateValueChangeInternal(int dimension,
                                      double time,
                                      ViewSpec view,
-                                     ValueChangedReasonEnum reason,
-                                     ValueChangedReasonEnum originalReason);
+                                     NATRON_ENUM::ValueChangedReasonEnum reason,
+                                     NATRON_ENUM::ValueChangedReasonEnum originalReason);
 
     virtual void onInternalValueChanged(int /*dimension*/,
                                         double /*time*/,
@@ -1431,15 +1431,15 @@ protected:
 private:
 
 
-    virtual void removeAnimationWithReason(ViewSpec view, int dimension, ValueChangedReasonEnum reason) OVERRIDE FINAL;
-    virtual void deleteValueAtTime(CurveChangeReason curveChangeReason, double time, ViewSpec view,  int dimension,bool copyCurveValueAtTimeToInternalValue) OVERRIDE FINAL;
-    virtual void deleteValuesAtTime(CurveChangeReason curveChangeReason, const std::list<double>& times, ViewSpec view, int dimension, bool copyCurveValueAtTimeToInternalValue) OVERRIDE FINAL;
+    virtual void removeAnimationWithReason(ViewSpec view, int dimension, NATRON_ENUM::ValueChangedReasonEnum reason) OVERRIDE FINAL;
+    virtual void deleteValueAtTime(NATRON_ENUM::CurveChangeReason curveChangeReason, double time, ViewSpec view,  int dimension,bool copyCurveValueAtTimeToInternalValue) OVERRIDE FINAL;
+    virtual void deleteValuesAtTime(NATRON_ENUM::CurveChangeReason curveChangeReason, const std::list<double>& times, ViewSpec view, int dimension, bool copyCurveValueAtTimeToInternalValue) OVERRIDE FINAL;
 
 public:
 
     virtual void onKeyFrameRemoved(double time, ViewSpec view, int dimension, bool copyCurveValueAtTimeToInternalValue) OVERRIDE FINAL;
-    virtual bool moveValueAtTime(CurveChangeReason reason, double time, ViewSpec view, int dimension, double dt, double dv, KeyFrame* newKey) OVERRIDE FINAL;
-    virtual bool moveValuesAtTime(CurveChangeReason reason, ViewSpec view,  int dimension, double dt, double dv, std::vector<KeyFrame>* keyframes) OVERRIDE FINAL;
+    virtual bool moveValueAtTime(NATRON_ENUM::CurveChangeReason reason, double time, ViewSpec view, int dimension, double dt, double dv, KeyFrame* newKey) OVERRIDE FINAL;
+    virtual bool moveValuesAtTime(NATRON_ENUM::CurveChangeReason reason, ViewSpec view,  int dimension, double dt, double dv, std::vector<KeyFrame>* keyframes) OVERRIDE FINAL;
 
 private:
     bool moveValueAtTimeInternal(bool useGuiCurve, double time, ViewSpec view, int dimension, double dt, double dv, KeyFrame* newKey);
@@ -1447,8 +1447,8 @@ private:
 public:
 
 
-    virtual bool transformValueAtTime(CurveChangeReason curveChangeReason, double time, ViewSpec view, int dimension, const Transform::Matrix3x3& matrix, KeyFrame* newKey) OVERRIDE FINAL;
-    virtual bool transformValuesAtTime(CurveChangeReason curveChangeReason, ViewSpec view,  int dimension, const Transform::Matrix3x3& matrix, std::vector<KeyFrame>* keyframes) OVERRIDE FINAL;
+    virtual bool transformValueAtTime(NATRON_ENUM::CurveChangeReason curveChangeReason, double time, ViewSpec view, int dimension, const Transform::Matrix3x3& matrix, KeyFrame* newKey) OVERRIDE FINAL;
+    virtual bool transformValuesAtTime(NATRON_ENUM::CurveChangeReason curveChangeReason, ViewSpec view,  int dimension, const Transform::Matrix3x3& matrix, std::vector<KeyFrame>* keyframes) OVERRIDE FINAL;
 
 private:
     bool transformValueAtTimeInternal(bool useGuiCurve, double time, ViewSpec view, int dimension, const Transform::Matrix3x3& matrix, KeyFrame* newKey);
@@ -1456,15 +1456,15 @@ private:
 public:
 
     virtual void cloneCurve(ViewSpec view, int dimension, const Curve& curve) OVERRIDE FINAL;
-    virtual bool setInterpolationAtTime(CurveChangeReason reason, ViewSpec view, int dimension, double time, KeyframeTypeEnum interpolation, KeyFrame* newKey) OVERRIDE FINAL;
-    virtual bool moveDerivativesAtTime(CurveChangeReason reason, ViewSpec view, int dimension, double time, double left, double right)  OVERRIDE FINAL WARN_UNUSED_RETURN;
-    virtual bool moveDerivativeAtTime(CurveChangeReason reason, ViewSpec view, int dimension, double time, double derivative, bool isLeft) OVERRIDE FINAL WARN_UNUSED_RETURN;
-    virtual void deleteAnimationBeforeTime(double time, ViewSpec view, int dimension, ValueChangedReasonEnum reason) OVERRIDE FINAL;
-    virtual void deleteAnimationAfterTime(double time, ViewSpec view, int dimension, ValueChangedReasonEnum reason) OVERRIDE FINAL;
+    virtual bool setInterpolationAtTime(NATRON_ENUM::CurveChangeReason reason, ViewSpec view, int dimension, double time, NATRON_ENUM::KeyframeTypeEnum interpolation, KeyFrame* newKey) OVERRIDE FINAL;
+    virtual bool moveDerivativesAtTime(NATRON_ENUM::CurveChangeReason reason, ViewSpec view, int dimension, double time, double left, double right)  OVERRIDE FINAL WARN_UNUSED_RETURN;
+    virtual bool moveDerivativeAtTime(NATRON_ENUM::CurveChangeReason reason, ViewSpec view, int dimension, double time, double derivative, bool isLeft) OVERRIDE FINAL WARN_UNUSED_RETURN;
+    virtual void deleteAnimationBeforeTime(double time, ViewSpec view, int dimension, NATRON_ENUM::ValueChangedReasonEnum reason) OVERRIDE FINAL;
+    virtual void deleteAnimationAfterTime(double time, ViewSpec view, int dimension, NATRON_ENUM::ValueChangedReasonEnum reason) OVERRIDE FINAL;
 
 private:
 
-    void deleteAnimationConditional(double time, ViewSpec view, int dimension, ValueChangedReasonEnum reason, bool before);
+    void deleteAnimationConditional(double time, ViewSpec view, int dimension, NATRON_ENUM::ValueChangedReasonEnum reason, bool before);
 
 public:
 
@@ -1499,7 +1499,7 @@ protected:
     template <typename T>
     static T pyObjectToType(PyObject* o);
 
-    virtual void refreshListenersAfterValueChange(ViewSpec view, ValueChangedReasonEnum reason, int dimension) OVERRIDE FINAL;
+    virtual void refreshListenersAfterValueChange(ViewSpec view, NATRON_ENUM::ValueChangedReasonEnum reason, int dimension) OVERRIDE FINAL;
 
 public:
 
@@ -1617,7 +1617,7 @@ public:
 private:
 
 
-    virtual bool slaveToInternal(int dimension, const KnobIPtr &  other, int otherDimension, ValueChangedReasonEnum reason
+    virtual bool slaveToInternal(int dimension, const KnobIPtr &  other, int otherDimension, NATRON_ENUM::ValueChangedReasonEnum reason
                                  , bool ignoreMasterPersistence) OVERRIDE FINAL WARN_UNUSED_RETURN;
 
 protected:
@@ -1641,7 +1641,7 @@ public:
 
     virtual std::pair<int, KnobIPtr> getMaster(int dimension) const OVERRIDE FINAL WARN_UNUSED_RETURN;
     virtual bool isSlave(int dimension) const OVERRIDE FINAL WARN_UNUSED_RETURN;
-    virtual AnimationLevelEnum getAnimationLevel(int dimension) const OVERRIDE FINAL WARN_UNUSED_RETURN;
+    virtual NATRON_ENUM::AnimationLevelEnum getAnimationLevel(int dimension) const OVERRIDE FINAL WARN_UNUSED_RETURN;
     virtual bool isTypeCompatible(const KnobIPtr & other) const OVERRIDE WARN_UNUSED_RETURN = 0;
 
     /**
@@ -1751,19 +1751,19 @@ protected:
     {
     }
 
-    void cloneGuiCurvesIfNeeded(std::map<int, ValueChangedReasonEnum>& modifiedDimensions);
+    void cloneGuiCurvesIfNeeded(std::map<int, NATRON_ENUM::ValueChangedReasonEnum>& modifiedDimensions);
 
-    void cloneInternalCurvesIfNeeded(std::map<int, ValueChangedReasonEnum>& modifiedDimensions);
+    void cloneInternalCurvesIfNeeded(std::map<int, NATRON_ENUM::ValueChangedReasonEnum>& modifiedDimensions);
 
     void setInternalCurveHasChanged(ViewSpec view, int dimension, bool changed);
 
-    void guiCurveCloneInternalCurve(CurveChangeReason curveChangeReason, ViewSpec view, int dimension, ValueChangedReasonEnum reason);
+    void guiCurveCloneInternalCurve(NATRON_ENUM::CurveChangeReason curveChangeReason, ViewSpec view, int dimension, NATRON_ENUM::ValueChangedReasonEnum reason);
 
     virtual boost::shared_ptr<Curve> getGuiCurve(ViewSpec view, int dimension, bool byPassMaster = false) const OVERRIDE FINAL;
 
     void setGuiCurveHasChanged(ViewSpec view, int dimension, bool changed);
     bool hasGuiCurveChanged(ViewSpec view, int dimension) const;
-    void clearExpressionsResultsIfNeeded(std::map<int, ValueChangedReasonEnum>& modifiedDimensions);
+    void clearExpressionsResultsIfNeeded(std::map<int, NATRON_ENUM::ValueChangedReasonEnum>& modifiedDimensions);
 
 
     boost::shared_ptr<KnobSignalSlotHandler> _signalSlotHandler;
@@ -1845,7 +1845,7 @@ private:
 
 
     virtual void unSlaveInternal(int dimension,
-                                 ValueChangedReasonEnum reason,
+                                 NATRON_ENUM::ValueChangedReasonEnum reason,
                                  bool copyState) OVERRIDE FINAL;
 
 public:
@@ -1860,11 +1860,11 @@ public:
                                               const T & v,
                                               ViewSpec view,
                                               int dimension,
-                                              ValueChangedReasonEnum reason,
+                                              NATRON_ENUM::ValueChangedReasonEnum reason,
                                               KeyFrame* newKey,
                                               bool hasChanged = false); //!< set to true if any previous dimension of the same knob have changed
 
-    virtual bool setKeyFrame(const KeyFrame& key, ViewSpec view, int dimension, ValueChangedReasonEnum reason) OVERRIDE FINAL;
+    virtual bool setKeyFrame(const KeyFrame& key, ViewSpec view, int dimension, NATRON_ENUM::ValueChangedReasonEnum reason) OVERRIDE FINAL;
 
     /**
      * @brief Set the value of the knob in the given dimension with the given reason.
@@ -1874,7 +1874,7 @@ public:
     ValueChangedReturnCodeEnum setValue(const T & v,
                                         ViewSpec view,
                                         int dimension,
-                                        ValueChangedReasonEnum reason,
+                                        NATRON_ENUM::ValueChangedReasonEnum reason,
                                         KeyFrame* newKey,
                                         bool hasChanged = false); //!< set to true if any previous dimension of the same knob have changed
 
@@ -1892,25 +1892,25 @@ public:
     void setValues(const T& value0,
                    const T& value1,
                    ViewSpec view,
-                   ValueChangedReasonEnum reason);
+                   NATRON_ENUM::ValueChangedReasonEnum reason);
 
     void setValues(const T& value0,
                    const T& value1,
                    ViewSpec view,
-                   ValueChangedReasonEnum reason,
+                   NATRON_ENUM::ValueChangedReasonEnum reason,
                    int dimensionOffset);
 
     void setValues(const T& value0,
                    const T& value1,
                    const T& value2,
                    ViewSpec view,
-                   ValueChangedReasonEnum reason);
+                   NATRON_ENUM::ValueChangedReasonEnum reason);
 
     void setValues(const T& value0,
                    const T& value1,
                    const T& value2,
                    ViewSpec view,
-                   ValueChangedReasonEnum reason,
+                   NATRON_ENUM::ValueChangedReasonEnum reason,
                    int dimensionOffset);
 
 
@@ -1919,7 +1919,7 @@ public:
                    const T& value2,
                    const T& value3,
                    ViewSpec view,
-                   ValueChangedReasonEnum reason);
+                   NATRON_ENUM::ValueChangedReasonEnum reason);
 
     /**
      * @brief Calls setValue
@@ -1931,7 +1931,7 @@ public:
     ValueChangedReturnCodeEnum onValueChanged(const T & v,
                                               ViewSpec view,
                                               int dimension,
-                                              ValueChangedReasonEnum reason,
+                                              NATRON_ENUM::ValueChangedReasonEnum reason,
                                               KeyFrame* newKey);
 
     /**
@@ -1968,13 +1968,13 @@ public:
                          const T& value0,
                          const T& value1,
                          ViewSpec view,
-                         ValueChangedReasonEnum reason);
+                         NATRON_ENUM::ValueChangedReasonEnum reason);
 
     void setValuesAtTime(double time,
                          const T& value0,
                          const T& value1,
                          ViewSpec view,
-                         ValueChangedReasonEnum reason,
+                         NATRON_ENUM::ValueChangedReasonEnum reason,
                          int dimensionOffset);
 
     void setValuesAtTime(double time,
@@ -1982,14 +1982,14 @@ public:
                          const T& value1,
                          const T& value2,
                          ViewSpec view,
-                         ValueChangedReasonEnum reason);
+                         NATRON_ENUM::ValueChangedReasonEnum reason);
 
     void setValuesAtTime(double time,
                          const T& value0,
                          const T& value1,
                          const T& value2,
                          ViewSpec view,
-                         ValueChangedReasonEnum reason,
+                         NATRON_ENUM::ValueChangedReasonEnum reason,
                          int dimensionOffset);
 
     void setValuesAtTime(double time,
@@ -1998,7 +1998,7 @@ public:
                          const T& value2,
                          const T& value3,
                          ViewSpec view,
-                         ValueChangedReasonEnum reason);
+                         NATRON_ENUM::ValueChangedReasonEnum reason);
 
     /**
      * @brief Unlike getValueAtTime this function doesn't interpolate the values.
@@ -2191,7 +2191,7 @@ public:
                        const T& value,
                        const KeyFrame& key,
                        bool useKey,
-                       ValueChangedReasonEnum reason,
+                       NATRON_ENUM::ValueChangedReasonEnum reason,
                        bool valueChangesBlocked);
 
         virtual bool isSetValueAtTime() const { return false; }
@@ -2207,7 +2207,7 @@ public:
 
         bool useKey() const;
 
-        ValueChangedReasonEnum reason() const;
+        NATRON_ENUM::ValueChangedReasonEnum reason() const;
 
         bool valueChangesBlocked() const;
 
@@ -2226,7 +2226,7 @@ public:
                              int dimension,
                              const T& value,
                              const KeyFrame& key,
-                             ValueChangedReasonEnum reason,
+                             NATRON_ENUM::ValueChangedReasonEnum reason,
                              bool valueChangesBlocked)
             : QueuedSetValue(view, dimension, value, key, true, reason, valueChangesBlocked)
             , _time(time)
@@ -2552,8 +2552,8 @@ public:
                            bool refreshGui,
                            double time,
                            ViewSpec view,
-                           ValueChangedReasonEnum originalReason,
-                           ValueChangedReasonEnum reason);
+                           NATRON_ENUM::ValueChangedReasonEnum originalReason,
+                           NATRON_ENUM::ValueChangedReasonEnum reason);
 
     bool isSetValueCurrentlyPossible() const;
 
@@ -2618,14 +2618,14 @@ public:
      * You should NEVER CALL THIS YOURSELF as it would break the bracketing system.
      * You can overload this to prepare yourself to a lot of value changes.
      **/
-    void beginKnobsValuesChanged_public(ValueChangedReasonEnum reason);
+    void beginKnobsValuesChanged_public(NATRON_ENUM::ValueChangedReasonEnum reason);
 
     /**
      * @brief The virtual portion of notifyProjectEndKnobsValuesChanged(). This is called by the project
      * You should NEVER CALL THIS YOURSELF as it would break the bracketing system.
      * You can overload this to finish a serie of value changes, thus limiting the amount of changes to do.
      **/
-    void endKnobsValuesChanged_public(ValueChangedReasonEnum reason);
+    void endKnobsValuesChanged_public(NATRON_ENUM::ValueChangedReasonEnum reason);
 
 
     /**
@@ -2634,7 +2634,7 @@ public:
      * You can overload this to do things when a value is changed. Bear in mind that you can compress
      * the change by using the begin/end[ValueChanges] to optimize the changes.
      **/
-    virtual bool onKnobValueChanged_public(KnobI* k, ValueChangedReasonEnum reason, double time, ViewSpec view,
+    virtual bool onKnobValueChanged_public(KnobI* k, NATRON_ENUM::ValueChangedReasonEnum reason, double time, ViewSpec view,
                                            bool originatedFromMainThread);
 
 
@@ -2716,7 +2716,7 @@ protected:
      * You should NEVER CALL THIS YOURSELF as it would break the bracketing system.
      * You can overload this to prepare yourself to a lot of value changes.
      **/
-    virtual void beginKnobsValuesChanged(ValueChangedReasonEnum reason)
+    virtual void beginKnobsValuesChanged(NATRON_ENUM::ValueChangedReasonEnum reason)
     {
         Q_UNUSED(reason);
     }
@@ -2726,7 +2726,7 @@ protected:
      * You should NEVER CALL THIS YOURSELF as it would break the bracketing system.
      * You can overload this to finish a serie of value changes, thus limiting the amount of changes to do.
      **/
-    virtual void endKnobsValuesChanged(ValueChangedReasonEnum reason)
+    virtual void endKnobsValuesChanged(NATRON_ENUM::ValueChangedReasonEnum reason)
     {
         Q_UNUSED(reason);
     }
@@ -2738,7 +2738,7 @@ protected:
      * the change by using the begin/end[ValueChanges] to optimize the changes.
      **/
     virtual bool onKnobValueChanged(KnobI* /*k*/,
-                                    ValueChangedReasonEnum /*reason*/,
+                                    NATRON_ENUM::ValueChangedReasonEnum /*reason*/,
                                     double /*time*/,
                                     ViewSpec /*view*/,
                                     bool /*originatedFromMainThread*/)

--- a/Engine/KnobTypes.h
+++ b/Engine/KnobTypes.h
@@ -248,13 +248,13 @@ public:
 
     static const std::string & typeNameStatic();
 
-    ValueIsNormalizedEnum getValueIsNormalized(int dimension) const
+    NATRON_ENUM::ValueIsNormalizedEnum getValueIsNormalized(int dimension) const
     {
         return _valueIsNormalized[dimension];
     }
 
     void setValueIsNormalized(int dimension,
-                              ValueIsNormalizedEnum state)
+                              NATRON_ENUM::ValueIsNormalizedEnum state)
     {
         _valueIsNormalized[dimension] = state;
     }
@@ -372,7 +372,7 @@ private:
     /// - kOfxParamDoubleTypeNormalisedYAbsolute - normalised absolute position on the Y axis (1D only)
     /// - kOfxParamDoubleTypeNormalisedXY - normalised to the project's X and Y size (2D only),
     /// - kOfxParamDoubleTypeNormalisedXYAbsolute - normalised to the projects X and Y size, and is an absolute position on the image plane,
-    std::vector<ValueIsNormalizedEnum> _valueIsNormalized;
+    std::vector<NATRON_ENUM::ValueIsNormalizedEnum> _valueIsNormalized;
 
     ///For double params respecting the kOfxParamCoordinatesNormalised
     ///This tells us that only the default value is stored normalized.
@@ -1009,33 +1009,33 @@ public:
     std::pair<double, double> getParametricRange() const WARN_UNUSED_RETURN;
     CurvePtr getParametricCurve(int dimension) const;
     CurvePtr getDefaultParametricCurve(int dimension) const;
-    StatusEnum addControlPoint(ValueChangedReasonEnum reason, int dimension, double key, double value, KeyframeTypeEnum interpolation = eKeyframeTypeSmooth) WARN_UNUSED_RETURN;
-    StatusEnum addControlPoint(ValueChangedReasonEnum reason, int dimension, double key, double value, double leftDerivative, double rightDerivative, KeyframeTypeEnum interpolation = eKeyframeTypeSmooth) WARN_UNUSED_RETURN;
-    StatusEnum getValue(int dimension, double parametricPosition, double *returnValue) const WARN_UNUSED_RETURN;
-    StatusEnum getNControlPoints(int dimension, int *returnValue) const WARN_UNUSED_RETURN;
-    StatusEnum getNthControlPoint(int dimension,
+    NATRON_ENUM::StatusEnum addControlPoint(NATRON_ENUM::ValueChangedReasonEnum reason, int dimension, double key, double value, NATRON_ENUM::KeyframeTypeEnum interpolation = NATRON_ENUM::eKeyframeTypeSmooth) WARN_UNUSED_RETURN;
+    NATRON_ENUM::StatusEnum addControlPoint(NATRON_ENUM::ValueChangedReasonEnum reason, int dimension, double key, double value, double leftDerivative, double rightDerivative, NATRON_ENUM::KeyframeTypeEnum interpolation = NATRON_ENUM::eKeyframeTypeSmooth) WARN_UNUSED_RETURN;
+    NATRON_ENUM::StatusEnum getValue(int dimension, double parametricPosition, double *returnValue) const WARN_UNUSED_RETURN;
+    NATRON_ENUM::StatusEnum getNControlPoints(int dimension, int *returnValue) const WARN_UNUSED_RETURN;
+    NATRON_ENUM::StatusEnum getNthControlPoint(int dimension,
                                   int nthCtl,
                                   double *key,
                                   double *value) const WARN_UNUSED_RETURN;
-    StatusEnum getNthControlPoint(int dimension,
+    NATRON_ENUM::StatusEnum getNthControlPoint(int dimension,
                                   int nthCtl,
                                   double *key,
                                   double *value,
                                   double *leftDerivative,
                                   double *rightDerivative) const WARN_UNUSED_RETURN;
 
-    StatusEnum setNthControlPointInterpolation(ValueChangedReasonEnum reason,
+    NATRON_ENUM::StatusEnum setNthControlPointInterpolation(NATRON_ENUM::ValueChangedReasonEnum reason,
                                                int dimension,
                                                int nThCtl,
-                                               KeyframeTypeEnum interpolation) WARN_UNUSED_RETURN;
+                                               NATRON_ENUM::KeyframeTypeEnum interpolation) WARN_UNUSED_RETURN;
 
-    StatusEnum setNthControlPoint(ValueChangedReasonEnum reason,
+    NATRON_ENUM::StatusEnum setNthControlPoint(NATRON_ENUM::ValueChangedReasonEnum reason,
                                   int dimension,
                                   int nthCtl,
                                   double key,
                                   double value) WARN_UNUSED_RETURN;
 
-    StatusEnum setNthControlPoint(ValueChangedReasonEnum reason,
+    NATRON_ENUM::StatusEnum setNthControlPoint(NATRON_ENUM::ValueChangedReasonEnum reason,
                                   int dimension,
                                   int nthCtl,
                                   double key,
@@ -1044,8 +1044,8 @@ public:
                                   double rightDerivative) WARN_UNUSED_RETURN;
 
 
-    StatusEnum deleteControlPoint(ValueChangedReasonEnum reason, int dimension, int nthCtl) WARN_UNUSED_RETURN;
-    StatusEnum deleteAllControlPoints(ValueChangedReasonEnum reason, int dimension) WARN_UNUSED_RETURN;
+    NATRON_ENUM::StatusEnum deleteControlPoint(NATRON_ENUM::ValueChangedReasonEnum reason, int dimension, int nthCtl) WARN_UNUSED_RETURN;
+    NATRON_ENUM::StatusEnum deleteAllControlPoints(NATRON_ENUM::ValueChangedReasonEnum reason, int dimension) WARN_UNUSED_RETURN;
     static const std::string & typeNameStatic() WARN_UNUSED_RETURN;
 
     void saveParametricCurves(std::list<Curve >* curves) const;

--- a/Engine/MergingEnum.h
+++ b/Engine/MergingEnum.h
@@ -43,7 +43,7 @@ namespace Merge {
  * Keep this in sync with the Merge node's operators otherwise everything will fall apart.
  **/
 inline std::string
-getOperatorString(MergingFunctionEnum operation)
+getOperatorString(NATRON_ENUM::MergingFunctionEnum operation)
 {
     switch (operation) {
     case eMergeATop:
@@ -169,7 +169,7 @@ getOperatorString(MergingFunctionEnum operation)
 } // getOperationString
 
 inline std::string
-getOperatorHelpString(MergingFunctionEnum operation)
+getOperatorHelpString(NATRON_ENUM::MergingFunctionEnum operation)
 {
     switch (operation) {
     case eMergeATop:
@@ -295,8 +295,8 @@ getOperatorHelpString(MergingFunctionEnum operation)
 } // getOperationHelpString
 
 inline
-PixmapEnum
-getOperatorPixmap(MergingFunctionEnum operation)
+NATRON_ENUM::PixmapEnum
+getOperatorPixmap(NATRON_ENUM::MergingFunctionEnum operation)
 {
     switch (operation) {
     case eMergeATop:

--- a/Engine/Plugin.h
+++ b/Engine/Plugin.h
@@ -176,7 +176,7 @@ class Plugin
     QMutex* _lock;
     int _majorVersion;
     int _minorVersion;
-    ContextEnum _ofxContext;
+    NATRON_ENUM::ContextEnum _ofxContext;
     mutable bool _hasShortcutSet; //< to speed up the keypress event of Nodegraph, this is used to find out quickly whether it has a shortcut or not.
     bool _isReader, _isWriter;
 
@@ -198,7 +198,7 @@ class Plugin
     bool _multiThreadingEnabled;
     bool _openglActivated;
 
-    PluginOpenGLRenderSupport _openglRenderSupport;
+    NATRON_ENUM::PluginOpenGLRenderSupport _openglRenderSupport;
 
 public:
 
@@ -358,9 +358,9 @@ public:
     void setOfxPlugin(OFX::Host::ImageEffect::ImageEffectPlugin* p);
 
     OFX::Host::ImageEffect::ImageEffectPlugin* getOfxPlugin() const;
-    OFX::Host::ImageEffect::Descriptor* getOfxDesc(ContextEnum* ctx) const;
+    OFX::Host::ImageEffect::Descriptor* getOfxDesc(NATRON_ENUM::ContextEnum* ctx) const;
 
-    void setOfxDesc(OFX::Host::ImageEffect::Descriptor* desc, ContextEnum ctx);
+    void setOfxDesc(OFX::Host::ImageEffect::Descriptor* desc, NATRON_ENUM::ContextEnum ctx);
 
     bool isRenderScaleEnabled() const;
     void setRenderScaleEnabled(bool b);
@@ -374,8 +374,8 @@ public:
     bool isOpenGLEnabled() const;
     void setOpenGLEnabled(bool b);
 
-    void setOpenGLRenderSupport(PluginOpenGLRenderSupport support);
-    PluginOpenGLRenderSupport getPluginOpenGLRenderSupport() const;
+    void setOpenGLRenderSupport(NATRON_ENUM::PluginOpenGLRenderSupport support);
+    NATRON_ENUM::PluginOpenGLRenderSupport getPluginOpenGLRenderSupport() const;
 };
 
 struct Plugin_compare_version

--- a/Engine/PyNode.h
+++ b/Engine/PyNode.h
@@ -203,7 +203,7 @@ public:
     void refreshUserParamsGUI();
 
     virtual bool onKnobValueChanged(KnobI* k,
-                                    NATRON_NAMESPACE::ValueChangedReasonEnum reason,
+                                    NATRON_ENUM::ValueChangedReasonEnum reason,
                                     double time,
                                     ViewSpec view,
                                     bool originatedFromMainThread)
@@ -386,8 +386,8 @@ public:
 
     double getPixelAspectRatio() const;
 
-    NATRON_NAMESPACE::ImageBitDepthEnum getBitDepth() const;
-    NATRON_NAMESPACE::ImagePremultiplicationEnum getPremult() const;
+    NATRON_ENUM::ImageBitDepthEnum getBitDepth() const;
+    NATRON_ENUM::ImagePremultiplicationEnum getPremult() const;
 
     void setPagesOrder(const QStringList& pages);
 };

--- a/Engine/PyParameter.h
+++ b/Engine/PyParameter.h
@@ -269,7 +269,7 @@ public:
     bool setExpression(const QString& expr, bool hasRetVariable, int dimension = 0);
     QString getExpression(int dimension, bool* hasRetVariable) const;
 
-    bool setInterpolationAtTime(double time, NATRON_NAMESPACE::KeyframeTypeEnum interpolation, int dimension = 0);
+    bool setInterpolationAtTime(double time, NATRON_ENUM::KeyframeTypeEnum interpolation, int dimension = 0);
 };
 
 /**
@@ -1174,31 +1174,31 @@ public:
 
     void getCurveColor(int dimension, ColorTuple& ret) const;
 
-    NATRON_NAMESPACE::StatusEnum addControlPoint(int dimension, double key, double value, NATRON_NAMESPACE::KeyframeTypeEnum interpolation = eKeyframeTypeSmooth);
-    NATRON_NAMESPACE::StatusEnum addControlPoint(int dimension, double key, double value, double leftDerivative, double rightDerivative, NATRON_NAMESPACE::KeyframeTypeEnum interpolation = eKeyframeTypeSmooth);
+    NATRON_ENUM::StatusEnum addControlPoint(int dimension, double key, double value, NATRON_ENUM::KeyframeTypeEnum interpolation = NATRON_ENUM::eKeyframeTypeSmooth);
+    NATRON_ENUM::StatusEnum addControlPoint(int dimension, double key, double value, double leftDerivative, double rightDerivative, NATRON_ENUM::KeyframeTypeEnum interpolation = NATRON_ENUM::eKeyframeTypeSmooth);
 
     double getValue(int dimension, double parametricPosition) const;
 
     int getNControlPoints(int dimension) const;
 
-    // NATRON_NAMESPACE is necessary for shiboken
-    NATRON_NAMESPACE::StatusEnum getNthControlPoint(int dimension,
+    // NATRON_ENUM:: is necessary for shiboken
+    NATRON_ENUM::StatusEnum getNthControlPoint(int dimension,
                                                     int nthCtl,
                                                     double *key,
                                                     double *value,
                                                     double *leftDerivative,
                                                     double *rightDerivative) const;
-    NATRON_NAMESPACE::StatusEnum setNthControlPoint(int dimension,
+    NATRON_ENUM::StatusEnum setNthControlPoint(int dimension,
                                                     int nthCtl,
                                                     double key,
                                                     double value,
                                                     double leftDerivative,
                                                     double rightDerivative);
-    NATRON_NAMESPACE::StatusEnum setNthControlPointInterpolation(int dimension,
+    NATRON_ENUM::StatusEnum setNthControlPointInterpolation(int dimension,
                                                                  int nThCtl,
-                                                                 NATRON_NAMESPACE::KeyframeTypeEnum interpolation);
-    NATRON_NAMESPACE::StatusEnum deleteControlPoint(int dimension, int nthCtl);
-    NATRON_NAMESPACE::StatusEnum deleteAllControlPoints(int dimension);
+                                                                 NATRON_ENUM::KeyframeTypeEnum interpolation);
+    NATRON_ENUM::StatusEnum deleteControlPoint(int dimension, int nthCtl);
+    NATRON_ENUM::StatusEnum deleteAllControlPoints(int dimension);
 
     void setDefaultCurvesFromCurrentCurves();
 };

--- a/Engine/PyRoto.h
+++ b/Engine/PyRoto.h
@@ -158,8 +158,8 @@ public:
     ColorTuple getColor(double time);
     void setColor(double time, double r, double g, double b);
 
-    void setCompositingOperator(NATRON_NAMESPACE::MergingFunctionEnum op);
-    NATRON_NAMESPACE::MergingFunctionEnum getCompositingOperator() const;
+    void setCompositingOperator(NATRON_ENUM::MergingFunctionEnum op);
+    NATRON_ENUM::MergingFunctionEnum getCompositingOperator() const;
     BooleanParam* getActivatedParam() const;
     DoubleParam* getOpacityParam() const;
     DoubleParam* getFeatherDistanceParam() const;

--- a/Engine/PySide2_Engine_Python.h
+++ b/Engine/PySide2_Engine_Python.h
@@ -1,0 +1,29 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * This file is part of Natron <https://natrongithub.github.io/>,
+ * (C) 2018-2021 The Natron developers
+ * (C) 2013-2018 INRIA and Alexandre Gauthier-Foichat
+ *
+ * Natron is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Natron is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Natron.  If not, see <http://www.gnu.org/licenses/gpl-2.0.html>
+ * ***** END LICENSE BLOCK ***** */
+
+
+#ifndef PYSIDE2_ENGINE_PYTHON_H
+#define PYSIDE2_ENGINE_PYTHON_H
+
+// Defined for shiboken2-specific tweaks
+#define SBK2_RUN
+
+#include "Pyside_Engine_Python.h"
+
+#endif // PYSIDE2_ENGINE_PYTHON_H

--- a/Engine/PySideCompat.cpp
+++ b/Engine/PySideCompat.cpp
@@ -38,7 +38,7 @@
 CLANG_DIAG_OFF(mismatched-tags)
 GCC_DIAG_OFF(unused-parameter)
 GCC_DIAG_OFF(missing-field-initializers)
-#ifdef SBK2_GEN
+#ifdef SBK2_RUN
 #include <basewrapper.h>
 #include <sbkconverter.h>
 #include <gilstate.h>

--- a/Engine/Pyside_Engine_Python.h
+++ b/Engine/Pyside_Engine_Python.h
@@ -36,7 +36,7 @@
  * Do not include it when compiling Natron.
  **/
 
-#ifdef SBK2_GEN
+#ifdef SBK2_RUN
 #include <pyside2_global.h>
 #else
 #include <pyside_global.h>

--- a/Engine/typesystem_engine.xml
+++ b/Engine/typesystem_engine.xml
@@ -210,7 +210,7 @@
     </container-type>
 
      <!--Natron global enums-->
-    <namespace-type name="NATRON_NAMESPACE">
+    <namespace-type name="NATRON_ENUM">
     <enum-type name="StatusEnum"/>
     <enum-type name="MergingFunctionEnum"/>
     <enum-type name="StandardButtonEnum" flags="StandardButtons"/>
@@ -1558,7 +1558,7 @@
                 double key,value,left,right;
                 %RETURN_TYPE %0 = %CPPSELF.%FUNCTION_NAME(%1, %2,&amp;key,&amp;value, &amp;left, &amp;right);
                 %PYARG_0 = PyTuple_New(5);
-                PyTuple_SET_ITEM(%PYARG_0, 0, %CONVERTTOPYTHON[NATRON_NAMESPACE::StatusEnum](%0));
+                PyTuple_SET_ITEM(%PYARG_0, 0, %CONVERTTOPYTHON[NATRON_ENUM::StatusEnum](%0));
                 PyTuple_SET_ITEM(%PYARG_0, 1, %CONVERTTOPYTHON[double](key));
                 PyTuple_SET_ITEM(%PYARG_0, 2, %CONVERTTOPYTHON[double](value));
                 PyTuple_SET_ITEM(%PYARG_0, 3, %CONVERTTOPYTHON[double](left));

--- a/Global/Enums.h
+++ b/Global/Enums.h
@@ -31,7 +31,7 @@ NATRON_NAMESPACE_ENTER
 #ifdef SBK_RUN
 // shiboken doesn't generate SbkNatronEngine_StandardButtonEnum_as_number unless it is put in a class or namespace
 NATRON_NAMESPACE_EXIT
-namespace NATRON_NAMESPACE {
+namespace NATRON_ENUM {
 #endif
 
 enum ScaleTypeEnum
@@ -692,7 +692,7 @@ NATRON_NAMESPACE_ENTER
 
 NATRON_NAMESPACE_EXIT
 
-Q_DECLARE_METATYPE(NATRON_NAMESPACE::StandardButtons)
+Q_DECLARE_METATYPE(NATRON_ENUM::StandardButtons)
 
 
 #endif // NATRON_GLOBAL_ENUMS_H

--- a/Global/Macros.h
+++ b/Global/Macros.h
@@ -45,10 +45,11 @@ namespace Python { }
 #define NATRON_PYTHON_NAMESPACE_USING using namespace Natron::Python;
 #endif
 
-#ifdef SBK_RUN
+#if defined(SBK_RUN)
 
 // run shiboken without the Natron namespace, and add NATRON_NAMESPACE_USING to each cpp afterwards
 #define NATRON_NAMESPACE
+#undef NATRON_ENUM
 #define NATRON_NAMESPACE_ENTER
 #define NATRON_NAMESPACE_EXIT
 #define NATRON_PYTHON_NAMESPACE
@@ -58,6 +59,7 @@ namespace Python { }
 #else // !SBK_RUN
 
 #define NATRON_NAMESPACE Natron
+#define NATRON_ENUM NATRON_NAMESPACE
 // Macros to use in each file to enter and exit the right name spaces.
 #define NATRON_NAMESPACE_ENTER namespace NATRON_NAMESPACE {
 #define NATRON_NAMESPACE_EXIT }

--- a/Global/Pyside_Shiboken2_Macros.h
+++ b/Global/Pyside_Shiboken2_Macros.h
@@ -1,1 +1,0 @@
-#define SBK2_GEN

--- a/Gui/PyGlobalGui.h
+++ b/Gui/PyGlobalGui.h
@@ -59,7 +59,7 @@ public:
     {
     }
 
-    QPixmap getIcon(NATRON_NAMESPACE::PixmapEnum val) const
+    QPixmap getIcon(NATRON_ENUM::PixmapEnum val) const
     {
         QPixmap ret;
 
@@ -101,7 +101,7 @@ public:
         Dialogs::errorDialog( title.toStdString(), message.toStdString() );
     }
 
-    NATRON_NAMESPACE::StandardButtonEnum questionDialog(const QString& title,
+    NATRON_ENUM::StandardButtonEnum questionDialog(const QString& title,
                                                         const QString& message)
     {
         return Dialogs::questionDialog(title.toStdString(), message.toStdString(), false);

--- a/Gui/PyGuiApp.h
+++ b/Gui/PyGuiApp.h
@@ -74,13 +74,13 @@ public:
 
     void getFrameRange(int* firstFrame, int* lastFrame) const;
 
-    void setPlaybackMode(NATRON_NAMESPACE::PlaybackModeEnum mode);
+    void setPlaybackMode(NATRON_ENUM::PlaybackModeEnum mode);
 
-    NATRON_NAMESPACE::PlaybackModeEnum getPlaybackMode() const;
+    NATRON_ENUM::PlaybackModeEnum getPlaybackMode() const;
 
-    NATRON_NAMESPACE::ViewerCompositingOperatorEnum getCompositingOperator() const;
+    NATRON_ENUM::ViewerCompositingOperatorEnum getCompositingOperator() const;
 
-    void setCompositingOperator(NATRON_NAMESPACE::ViewerCompositingOperatorEnum op);
+    void setCompositingOperator(NATRON_ENUM::ViewerCompositingOperatorEnum op);
 
     int getAInput() const;
 
@@ -90,9 +90,9 @@ public:
 
     void setBInput(int index);
 
-    void setChannels(NATRON_NAMESPACE::DisplayChannelsEnum channels);
+    void setChannels(NATRON_ENUM::DisplayChannelsEnum channels);
 
-    NATRON_NAMESPACE::DisplayChannelsEnum getChannels() const;
+    NATRON_ENUM::DisplayChannelsEnum getChannels() const;
 
     void setProxyModeEnabled(bool enabled);
 

--- a/INSTALL_LINUX.md
+++ b/INSTALL_LINUX.md
@@ -444,11 +444,13 @@ If using PySide2 for Qt5, the command-line would be:
 ```Shell
 SDK_PREFIX=/opt/Natron-sdk
 PYSIDE_PREFIX=/opt/Natron-sdk
+PYV=3.9
+QT=5
 rm Engine/NatronEngine/* Gui/NatronGui/*
 
-shiboken2 --avoid-protected-hack --enable-pyside-extensions --include-paths=../Engine:../Global:$SDK_PREFIX/include:$PYSIDE_PREFIX/include/PySide2 --typesystem-paths=$PYSIDE_PREFIX/lib/python2.7/site-packages/PySide2/typesystems --output-directory=Engine Engine/Pyside_Engine_Python.h  Engine/typesystem_engine.xml
+shiboken2 --avoid-protected-hack --enable-pyside-extensions --include-paths=.:Engine:Global:$SDK_PREFIX/include:$PYSIDE_PREFIX/include/PySide2 --typesystem-paths=$PYSIDE_PREFIX/lib/python${PYV}/site-packages/PySide2/typesystems --output-directory=Engine/Qt5 Engine/Pyside_Engine_Python.h  Engine/typesystem_engine.xml
 
-shiboken2 --avoid-protected-hack --enable-pyside-extensions --include-paths=../Engine:../Gui:../Global:$SDK_PREFIX/include:$PYSIDE_PREFIX/include/PySide2 --typesystem-paths=$PYSIDE_PREFIX/lib/python2.7/site-packages/PySide2/typesystems:Engine --output-directory=Gui Gui/Pyside_Gui_Python.h  Gui/typesystem_natronGui.xml
+shiboken2 --avoid-protected-hack --enable-pyside-extensions --include-paths=.:Engine:Gui:Global:$SDK_PREFIX/include:$PYSIDE_PREFIX/include/PySide2 --typesystem-paths=$PYSIDE_PREFIX/lib/python${PYV}/site-packages/PySide2/typesystems:Engine --output-directory=Gui/Qt5 Gui/Pyside_Gui_Python.h  Gui/typesystem_natronGui.xml
 
 tools/utils/runPostShiboken.sh
 ```

--- a/INSTALL_MACOS.md
+++ b/INSTALL_MACOS.md
@@ -615,13 +615,16 @@ shiboken-${PYV} --avoid-protected-hack --enable-pyside-extensions --include-path
 tools/utils/runPostShiboken.sh
 ```
 
-on HomeBrew:
+on HomeBrew with Qt5/PySide2/Shiboken2:
 ```Shell
-rm Engine/NatronEngine/* Gui/NatronGui/*
+PYV=3.9 # Set to the python version
+export PATH="/usr/local/opt/pyside@2/bin:$PATH"
 
-shiboken --avoid-protected-hack --enable-pyside-extensions --include-paths=../Engine:../Global:/usr/local/include:/usr/local/include/PySide  --typesystem-paths=/usr/local/share/PySide/typesystems --output-directory=Engine Engine/Pyside_Engine_Python.h  Engine/typesystem_engine.xml
+rm Engine/NatronEngine/Qt5/* Gui/NatronGui/Qt5/*
 
-shiboken --avoid-protected-hack --enable-pyside-extensions --include-paths=../Engine:../Gui:../Global:/usr/local/include:/usr/local/include/PySide  --typesystem-paths=/usr/local/share/PySide/typesystems:Engine --output-directory=Gui Gui/Pyside_Gui_Python.h  Gui/typesystem_natronGui.xml
+shiboken2 --avoid-protected-hack --enable-pyside-extensions --include-paths=.:Engine:Global:libs/OpenFX/include:/usr/local/Frameworks/Python.framework/Versions/${PYV}/include/python${PYV}:/usr/local/include:/usr/local/opt/pyside@2/include/PySide2  --typesystem-paths=/usr/local/opt/pyside@2/share/PySide2/typesystems --output-directory=Engine/Qt5 Engine/PySide2_Engine_Python.h  Engine/typesystem_engine.xml
+
+shiboken2 --avoid-protected-hack --enable-pyside-extensions --include-paths=.:Engine:Gui:Global:libs/OpenFX/include:/usr/local/Frameworks/Python.framework/Versions/${PYV}/include/python${PYV}:/usr/local/include:/usr/local/opt/pyside@2/include/PySide2  --typesystem-paths=/usr/local/opt/pyside@2/share/PySide2/typesystems:Engine --output-directory=Gui/Qt5 Gui/Pyside_Gui_Python.h  Gui/typesystem_natronGui.xml
 
 tools/utils/runPostShiboken.sh
 ```

--- a/tools/utils/runPostShiboken.sh
+++ b/tools/utils/runPostShiboken.sh
@@ -63,6 +63,7 @@ NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT@g'  -i'.bak' Engine/NatronEng
 
 # replace NATRON_NAMESPACE::NATRON_NAMESPACE with NATRON_NAMESPACE in the enums wrappers
 sed -e 's@NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::NATRON_NAMESPACE@NATRON_NAMESPACE@g' -i'.bak' Engine/NatronEngine/natronengine_python.h Gui/NatronGui/natrongui_python.h
+sed -e 's@NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::NATRON_ENUM@NATRON_ENUM@g' -i'.bak' Engine/NatronEngine/natronengine_python.h Gui/NatronGui/natrongui_python.h
 
 sed -e 's@^#include <pysidemetafunction.h>$@CLANG_DIAG_OFF(header-guard)\
 #include <pysidemetafunction.h> // has wrong header guards in pyside 1.2.2@' -i'.bak' Engine/NatronEngine/*.cpp Gui/NatronGui/*.cpp


### PR DESCRIPTION
See discussion in #698:
- #697 and #704 introduced changes that broke shiboken1.
- we want to keep sbk1 compatibility as long as possible, because sbk2 means switching to Qt5, and this won't happen before 2.6 or 3.0
- this PR fixes that, so that both shiboken1 and shiboken2 can be used.
- it puts all enums in the fake NATRON_ENUM namespace, so that the shiboken/shiboken2-generated code is OK, and when compiling Natron this is defined to NATRON_NAMESPACE (see Global/Macros.h)

Things to watch for:
- a lot of the pypanel_wrapper code is not generated anymore, why? same for a few other Gui classes

If this is merged, next operations are:
- rework #698 the same way
- move all shiboken-generated source files to Engine/Qt4/NatronEngine end Gui/Qt4/NatronGui
- update instructions in INSTALL_LINUX and INSTALL_MACOS to regenerate these
- generate shiboken1 and shiboken2 files, and check in the generated sources
