### PR TITLE
Initial Qt5 sources for Engine

### DIFF
--- a/Engine/Qt5/NatronEngine/animatedparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/animatedparam_wrapper.cpp
@@ -1,0 +1,1140 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "animatedparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void AnimatedParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void AnimatedParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+AnimatedParamWrapper::~AnimatedParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_AnimatedParamFunc_deleteValueAtTime(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AnimatedParamWrapper *>(reinterpret_cast< ::AnimatedParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.deleteValueAtTime(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.deleteValueAtTime(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:deleteValueAtTime", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: AnimatedParam::deleteValueAtTime(double,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // deleteValueAtTime(double,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // deleteValueAtTime(double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AnimatedParamFunc_deleteValueAtTime_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.deleteValueAtTime(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_AnimatedParamFunc_deleteValueAtTime_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // deleteValueAtTime(double,int)
+            cppSelf->deleteValueAtTime(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_AnimatedParamFunc_deleteValueAtTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.AnimatedParam.deleteValueAtTime");
+        return {};
+}
+
+static PyObject *Sbk_AnimatedParamFunc_getCurrentTime(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AnimatedParamWrapper *>(reinterpret_cast< ::AnimatedParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getCurrentTime()const
+            int cppResult = const_cast<const ::AnimatedParamWrapper *>(cppSelf)->getCurrentTime();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_AnimatedParamFunc_getDerivativeAtTime(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AnimatedParamWrapper *>(reinterpret_cast< ::AnimatedParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.getDerivativeAtTime(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.getDerivativeAtTime(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:getDerivativeAtTime", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: AnimatedParam::getDerivativeAtTime(double,int)const
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // getDerivativeAtTime(double,int)const
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // getDerivativeAtTime(double,int)const
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AnimatedParamFunc_getDerivativeAtTime_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.getDerivativeAtTime(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_AnimatedParamFunc_getDerivativeAtTime_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // getDerivativeAtTime(double,int)const
+            double cppResult = const_cast<const ::AnimatedParamWrapper *>(cppSelf)->getDerivativeAtTime(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AnimatedParamFunc_getDerivativeAtTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.AnimatedParam.getDerivativeAtTime");
+        return {};
+}
+
+static PyObject *Sbk_AnimatedParamFunc_getExpression(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AnimatedParamWrapper *>(reinterpret_cast< ::AnimatedParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: AnimatedParam::getExpression(int,bool*)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // getExpression(int,bool*)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AnimatedParamFunc_getExpression_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getExpression(int,bool*)const
+            // Begin code injection
+            bool hasRetVar;
+            QString cppResult = cppSelf->getExpression(cppArg0,&hasRetVar);
+            pyResult = PyTuple_New(2);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &hasRetVar));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AnimatedParamFunc_getExpression_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.AnimatedParam.getExpression");
+        return {};
+}
+
+static PyObject *Sbk_AnimatedParamFunc_getIntegrateFromTimeToTime(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AnimatedParamWrapper *>(reinterpret_cast< ::AnimatedParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 3) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.getIntegrateFromTimeToTime(): too many arguments");
+        return {};
+    } else if (numArgs < 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.getIntegrateFromTimeToTime(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOO:getIntegrateFromTimeToTime", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: AnimatedParam::getIntegrateFromTimeToTime(double,double,int)const
+    if (numArgs >= 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        if (numArgs == 2) {
+            overloadId = 0; // getIntegrateFromTimeToTime(double,double,int)const
+        } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+            overloadId = 0; // getIntegrateFromTimeToTime(double,double,int)const
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AnimatedParamFunc_getIntegrateFromTimeToTime_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.getIntegrateFromTimeToTime(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2]))))
+                        goto Sbk_AnimatedParamFunc_getIntegrateFromTimeToTime_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        int cppArg2 = 0;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // getIntegrateFromTimeToTime(double,double,int)const
+            double cppResult = const_cast<const ::AnimatedParamWrapper *>(cppSelf)->getIntegrateFromTimeToTime(cppArg0, cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AnimatedParamFunc_getIntegrateFromTimeToTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.AnimatedParam.getIntegrateFromTimeToTime");
+        return {};
+}
+
+static PyObject *Sbk_AnimatedParamFunc_getIsAnimated(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AnimatedParamWrapper *>(reinterpret_cast< ::AnimatedParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.getIsAnimated(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getIsAnimated", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: AnimatedParam::getIsAnimated(int)const
+    if (numArgs == 0) {
+        overloadId = 0; // getIsAnimated(int)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // getIsAnimated(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AnimatedParamFunc_getIsAnimated_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.getIsAnimated(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_AnimatedParamFunc_getIsAnimated_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getIsAnimated(int)const
+            bool cppResult = const_cast<const ::AnimatedParamWrapper *>(cppSelf)->getIsAnimated(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AnimatedParamFunc_getIsAnimated_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.AnimatedParam.getIsAnimated");
+        return {};
+}
+
+static PyObject *Sbk_AnimatedParamFunc_getKeyIndex(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AnimatedParamWrapper *>(reinterpret_cast< ::AnimatedParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.getKeyIndex(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.getKeyIndex(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:getKeyIndex", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: AnimatedParam::getKeyIndex(double,int)const
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // getKeyIndex(double,int)const
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // getKeyIndex(double,int)const
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AnimatedParamFunc_getKeyIndex_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.getKeyIndex(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_AnimatedParamFunc_getKeyIndex_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // getKeyIndex(double,int)const
+            int cppResult = const_cast<const ::AnimatedParamWrapper *>(cppSelf)->getKeyIndex(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AnimatedParamFunc_getKeyIndex_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.AnimatedParam.getKeyIndex");
+        return {};
+}
+
+static PyObject *Sbk_AnimatedParamFunc_getKeyTime(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AnimatedParamWrapper *>(reinterpret_cast< ::AnimatedParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "getKeyTime", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: AnimatedParam::getKeyTime(int,int,double*)const
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+        overloadId = 0; // getKeyTime(int,int,double*)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AnimatedParamFunc_getKeyTime_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // getKeyTime(int,int,double*)const
+            // Begin code injection
+            double time;
+            bool cppResult = cppSelf->getKeyTime(cppArg0, cppArg1,&time);
+            pyResult = PyTuple_New(2);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &time));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AnimatedParamFunc_getKeyTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.AnimatedParam.getKeyTime");
+        return {};
+}
+
+static PyObject *Sbk_AnimatedParamFunc_getNumKeys(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AnimatedParamWrapper *>(reinterpret_cast< ::AnimatedParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.getNumKeys(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getNumKeys", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: AnimatedParam::getNumKeys(int)const
+    if (numArgs == 0) {
+        overloadId = 0; // getNumKeys(int)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // getNumKeys(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AnimatedParamFunc_getNumKeys_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.getNumKeys(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_AnimatedParamFunc_getNumKeys_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getNumKeys(int)const
+            int cppResult = const_cast<const ::AnimatedParamWrapper *>(cppSelf)->getNumKeys(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AnimatedParamFunc_getNumKeys_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.AnimatedParam.getNumKeys");
+        return {};
+}
+
+static PyObject *Sbk_AnimatedParamFunc_removeAnimation(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AnimatedParamWrapper *>(reinterpret_cast< ::AnimatedParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.removeAnimation(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:removeAnimation", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: AnimatedParam::removeAnimation(int)
+    if (numArgs == 0) {
+        overloadId = 0; // removeAnimation(int)
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // removeAnimation(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AnimatedParamFunc_removeAnimation_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.removeAnimation(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_AnimatedParamFunc_removeAnimation_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // removeAnimation(int)
+            cppSelf->removeAnimation(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_AnimatedParamFunc_removeAnimation_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.AnimatedParam.removeAnimation");
+        return {};
+}
+
+static PyObject *Sbk_AnimatedParamFunc_setExpression(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AnimatedParamWrapper *>(reinterpret_cast< ::AnimatedParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 3) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.setExpression(): too many arguments");
+        return {};
+    } else if (numArgs < 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.setExpression(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOO:setExpression", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: AnimatedParam::setExpression(QString,bool,int)
+    if (numArgs >= 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[1])))) {
+        if (numArgs == 2) {
+            overloadId = 0; // setExpression(QString,bool,int)
+        } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+            overloadId = 0; // setExpression(QString,bool,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AnimatedParamFunc_setExpression_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.setExpression(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2]))))
+                        goto Sbk_AnimatedParamFunc_setExpression_TypeError;
+                }
+            }
+        }
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        bool cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        int cppArg2 = 0;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // setExpression(QString,bool,int)
+            // Begin code injection
+            bool cppResult = cppSelf->setExpression(cppArg0,cppArg1,cppArg2);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AnimatedParamFunc_setExpression_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.AnimatedParam.setExpression");
+        return {};
+}
+
+static PyObject *Sbk_AnimatedParamFunc_setInterpolationAtTime(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AnimatedParamWrapper *>(reinterpret_cast< ::AnimatedParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 3) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.setInterpolationAtTime(): too many arguments");
+        return {};
+    } else if (numArgs < 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.setInterpolationAtTime(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOO:setInterpolationAtTime", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: AnimatedParam::setInterpolationAtTime(double,NATRON_ENUM::KeyframeTypeEnum,int)
+    if (numArgs >= 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX])->converter, (pyArgs[1])))) {
+        if (numArgs == 2) {
+            overloadId = 0; // setInterpolationAtTime(double,NATRON_ENUM::KeyframeTypeEnum,int)
+        } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+            overloadId = 0; // setInterpolationAtTime(double,NATRON_ENUM::KeyframeTypeEnum,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AnimatedParamFunc_setInterpolationAtTime_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.AnimatedParam.setInterpolationAtTime(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2]))))
+                        goto Sbk_AnimatedParamFunc_setInterpolationAtTime_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::NATRON_ENUM::KeyframeTypeEnum cppArg1{NATRON_ENUM::eKeyframeTypeConstant};
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        int cppArg2 = 0;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // setInterpolationAtTime(double,NATRON_ENUM::KeyframeTypeEnum,int)
+            bool cppResult = cppSelf->setInterpolationAtTime(cppArg0, cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AnimatedParamFunc_setInterpolationAtTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.AnimatedParam.setInterpolationAtTime");
+        return {};
+}
+
+
+static const char *Sbk_AnimatedParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_AnimatedParam_methods[] = {
+    {"deleteValueAtTime", reinterpret_cast<PyCFunction>(Sbk_AnimatedParamFunc_deleteValueAtTime), METH_VARARGS|METH_KEYWORDS},
+    {"getCurrentTime", reinterpret_cast<PyCFunction>(Sbk_AnimatedParamFunc_getCurrentTime), METH_NOARGS},
+    {"getDerivativeAtTime", reinterpret_cast<PyCFunction>(Sbk_AnimatedParamFunc_getDerivativeAtTime), METH_VARARGS|METH_KEYWORDS},
+    {"getExpression", reinterpret_cast<PyCFunction>(Sbk_AnimatedParamFunc_getExpression), METH_O},
+    {"getIntegrateFromTimeToTime", reinterpret_cast<PyCFunction>(Sbk_AnimatedParamFunc_getIntegrateFromTimeToTime), METH_VARARGS|METH_KEYWORDS},
+    {"getIsAnimated", reinterpret_cast<PyCFunction>(Sbk_AnimatedParamFunc_getIsAnimated), METH_VARARGS|METH_KEYWORDS},
+    {"getKeyIndex", reinterpret_cast<PyCFunction>(Sbk_AnimatedParamFunc_getKeyIndex), METH_VARARGS|METH_KEYWORDS},
+    {"getKeyTime", reinterpret_cast<PyCFunction>(Sbk_AnimatedParamFunc_getKeyTime), METH_VARARGS},
+    {"getNumKeys", reinterpret_cast<PyCFunction>(Sbk_AnimatedParamFunc_getNumKeys), METH_VARARGS|METH_KEYWORDS},
+    {"removeAnimation", reinterpret_cast<PyCFunction>(Sbk_AnimatedParamFunc_removeAnimation), METH_VARARGS|METH_KEYWORDS},
+    {"setExpression", reinterpret_cast<PyCFunction>(Sbk_AnimatedParamFunc_setExpression), METH_VARARGS|METH_KEYWORDS},
+    {"setInterpolationAtTime", reinterpret_cast<PyCFunction>(Sbk_AnimatedParamFunc_setInterpolationAtTime), METH_VARARGS|METH_KEYWORDS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_AnimatedParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::AnimatedParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<AnimatedParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_AnimatedParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_AnimatedParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_AnimatedParam_Type = nullptr;
+static SbkObjectType *Sbk_AnimatedParam_TypeF(void)
+{
+    return _Sbk_AnimatedParam_Type;
+}
+
+static PyType_Slot Sbk_AnimatedParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_AnimatedParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_AnimatedParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_AnimatedParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_AnimatedParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_AnimatedParam_spec = {
+    "1:NatronEngine.AnimatedParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_AnimatedParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_AnimatedParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::AnimatedParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void AnimatedParam_PythonToCpp_AnimatedParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_AnimatedParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_AnimatedParam_PythonToCpp_AnimatedParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_AnimatedParam_TypeF())))
+        return AnimatedParam_PythonToCpp_AnimatedParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *AnimatedParam_PTR_CppToPython_AnimatedParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::AnimatedParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_AnimatedParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *AnimatedParam_SignatureStrings[] = {
+    "NatronEngine.AnimatedParam.deleteValueAtTime(self,time:double,dimension:int=0)",
+    "NatronEngine.AnimatedParam.getCurrentTime(self)->int",
+    "NatronEngine.AnimatedParam.getDerivativeAtTime(self,time:double,dimension:int=0)->double",
+    "NatronEngine.AnimatedParam.getExpression(self,dimension:int,hasRetVariable:bool*)->QString",
+    "NatronEngine.AnimatedParam.getIntegrateFromTimeToTime(self,time1:double,time2:double,dimension:int=0)->double",
+    "NatronEngine.AnimatedParam.getIsAnimated(self,dimension:int=0)->bool",
+    "NatronEngine.AnimatedParam.getKeyIndex(self,time:double,dimension:int=0)->int",
+    "NatronEngine.AnimatedParam.getKeyTime(self,index:int,dimension:int,time:double*)->bool",
+    "NatronEngine.AnimatedParam.getNumKeys(self,dimension:int=0)->int",
+    "NatronEngine.AnimatedParam.removeAnimation(self,dimension:int=0)",
+    "NatronEngine.AnimatedParam.setExpression(self,expr:QString,hasRetVariable:bool,dimension:int=0)->bool",
+    "NatronEngine.AnimatedParam.setInterpolationAtTime(self,time:double,interpolation:NatronEngine.NATRON_ENUM.KeyframeTypeEnum,dimension:int=0)->bool",
+    nullptr}; // Sentinel
+
+void init_AnimatedParam(PyObject *module)
+{
+    _Sbk_AnimatedParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "AnimatedParam",
+        "AnimatedParam*",
+        &Sbk_AnimatedParam_spec,
+        &Shiboken::callCppDestructor< ::AnimatedParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_AnimatedParam_Type);
+    InitSignatureStrings(pyType, AnimatedParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_AnimatedParam_Type), Sbk_AnimatedParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_AnimatedParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_AnimatedParam_TypeF(),
+        AnimatedParam_PythonToCpp_AnimatedParam_PTR,
+        is_AnimatedParam_PythonToCpp_AnimatedParam_PTR_Convertible,
+        AnimatedParam_PTR_CppToPython_AnimatedParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "AnimatedParam");
+    Shiboken::Conversions::registerConverterName(converter, "AnimatedParam*");
+    Shiboken::Conversions::registerConverterName(converter, "AnimatedParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::AnimatedParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::AnimatedParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_AnimatedParam_TypeF(), &Sbk_AnimatedParam_typeDiscovery);
+
+
+    AnimatedParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/animatedparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/animatedparam_wrapper.h
@@ -1,0 +1,42 @@
+#ifndef SBK_ANIMATEDPARAMWRAPPER_H
+#define SBK_ANIMATEDPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AnimatedParamWrapper : public AnimatedParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { AnimatedParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~AnimatedParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_ANIMATEDPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/app_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/app_wrapper.cpp
@@ -1,0 +1,1345 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "app_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void AppWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void AppWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+AppWrapper::~AppWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_AppFunc_addFormat(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: App::addFormat(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // addFormat(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AppFunc_addFormat_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // addFormat(QString)
+            cppSelf->addFormat(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_AppFunc_addFormat_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.App.addFormat");
+        return {};
+}
+
+static PyObject *Sbk_AppFunc_addProjectLayer(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: App::addProjectLayer(ImageLayer)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), (pyArg)))) {
+        overloadId = 0; // addProjectLayer(ImageLayer)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AppFunc_addProjectLayer_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::ImageLayer cppArg0_local = ::ImageLayer(::QString(), ::QString(), ::QStringList());
+        ::ImageLayer *cppArg0 = &cppArg0_local;
+        if (Shiboken::Conversions::isImplicitConversion(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), pythonToCpp))
+            pythonToCpp(pyArg, &cppArg0_local);
+        else
+            pythonToCpp(pyArg, &cppArg0);
+
+
+        if (!PyErr_Occurred()) {
+            // addProjectLayer(ImageLayer)
+            cppSelf->addProjectLayer(*cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_AppFunc_addProjectLayer_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.App.addProjectLayer");
+        return {};
+}
+
+static PyObject *Sbk_AppFunc_closeProject(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // closeProject()
+            bool cppResult = cppSelf->closeProject();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_AppFunc_createNode(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 4) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.App.createNode(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.App.createNode(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOOO:createNode", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: App::createNode(QString,int,Group*,std::map<QString,NodeCreationProperty*>)const
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // createNode(QString,int,Group*,std::map<QString,NodeCreationProperty*>)const
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 0; // createNode(QString,int,Group*,std::map<QString,NodeCreationProperty*>)const
+            } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]), (pyArgs[2])))) {
+                if (numArgs == 3) {
+                    overloadId = 0; // createNode(QString,int,Group*,std::map<QString,NodeCreationProperty*>)const
+                } else if ((pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_MAP_QSTRING_NODECREATIONPROPERTYPTR_IDX], (pyArgs[3])))) {
+                    overloadId = 0; // createNode(QString,int,Group*,std::map<QString,NodeCreationProperty*>)const
+                }
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AppFunc_createNode_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","majorVersion");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.App.createNode(): got multiple values for keyword argument 'majorVersion'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_AppFunc_createNode_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","group");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.App.createNode(): got multiple values for keyword argument 'group'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]), (pyArgs[2]))))
+                        goto Sbk_AppFunc_createNode_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","props");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[3]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.App.createNode(): got multiple values for keyword argument 'props'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[3] = value;
+                    if (!(pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_MAP_QSTRING_NODECREATIONPROPERTYPTR_IDX], (pyArgs[3]))))
+                        goto Sbk_AppFunc_createNode_TypeError;
+                }
+            }
+        }
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = -1;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+        if (!Shiboken::Object::isValid(pyArgs[2]))
+            return {};
+        ::Group *cppArg2 = 0;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+        ::std::map<QString,NodeCreationProperty* > cppArg3;
+        if (pythonToCpp[3]) pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // createNode(QString,int,Group*,std::map<QString,NodeCreationProperty*>)const
+            // Begin code injection
+            Effect * cppResult = cppSelf->createNode(cppArg0,cppArg1,cppArg2, cppArg3);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), cppResult);
+
+            // End of code injection
+
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AppFunc_createNode_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.App.createNode");
+        return {};
+}
+
+static PyObject *Sbk_AppFunc_createReader(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 3) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.App.createReader(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.App.createReader(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOO:createReader", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: App::createReader(QString,Group*,std::map<QString,NodeCreationProperty*>)const
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // createReader(QString,Group*,std::map<QString,NodeCreationProperty*>)const
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 0; // createReader(QString,Group*,std::map<QString,NodeCreationProperty*>)const
+            } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_MAP_QSTRING_NODECREATIONPROPERTYPTR_IDX], (pyArgs[2])))) {
+                overloadId = 0; // createReader(QString,Group*,std::map<QString,NodeCreationProperty*>)const
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AppFunc_createReader_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","group");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.App.createReader(): got multiple values for keyword argument 'group'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]), (pyArgs[1]))))
+                        goto Sbk_AppFunc_createReader_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","props");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.App.createReader(): got multiple values for keyword argument 'props'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_MAP_QSTRING_NODECREATIONPROPERTYPTR_IDX], (pyArgs[2]))))
+                        goto Sbk_AppFunc_createReader_TypeError;
+                }
+            }
+        }
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        if (!Shiboken::Object::isValid(pyArgs[1]))
+            return {};
+        ::Group *cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+        ::std::map<QString,NodeCreationProperty* > cppArg2;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // createReader(QString,Group*,std::map<QString,NodeCreationProperty*>)const
+            // Begin code injection
+            Effect * cppResult = cppSelf->createReader(cppArg0,cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), cppResult);
+
+            // End of code injection
+
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AppFunc_createReader_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.App.createReader");
+        return {};
+}
+
+static PyObject *Sbk_AppFunc_createWriter(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 3) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.App.createWriter(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.App.createWriter(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOO:createWriter", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: App::createWriter(QString,Group*,std::map<QString,NodeCreationProperty*>)const
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // createWriter(QString,Group*,std::map<QString,NodeCreationProperty*>)const
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 0; // createWriter(QString,Group*,std::map<QString,NodeCreationProperty*>)const
+            } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_MAP_QSTRING_NODECREATIONPROPERTYPTR_IDX], (pyArgs[2])))) {
+                overloadId = 0; // createWriter(QString,Group*,std::map<QString,NodeCreationProperty*>)const
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AppFunc_createWriter_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","group");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.App.createWriter(): got multiple values for keyword argument 'group'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]), (pyArgs[1]))))
+                        goto Sbk_AppFunc_createWriter_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","props");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.App.createWriter(): got multiple values for keyword argument 'props'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_MAP_QSTRING_NODECREATIONPROPERTYPTR_IDX], (pyArgs[2]))))
+                        goto Sbk_AppFunc_createWriter_TypeError;
+                }
+            }
+        }
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        if (!Shiboken::Object::isValid(pyArgs[1]))
+            return {};
+        ::Group *cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+        ::std::map<QString,NodeCreationProperty* > cppArg2;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // createWriter(QString,Group*,std::map<QString,NodeCreationProperty*>)const
+            // Begin code injection
+            Effect * cppResult = cppSelf->createWriter(cppArg0,cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), cppResult);
+
+            // End of code injection
+
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AppFunc_createWriter_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.App.createWriter");
+        return {};
+}
+
+static PyObject *Sbk_AppFunc_getAppID(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getAppID()const
+            int cppResult = const_cast<const ::AppWrapper *>(cppSelf)->getAppID();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_AppFunc_getProjectParam(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: App::getProjectParam(QString)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // getProjectParam(QString)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AppFunc_getProjectParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getProjectParam(QString)const
+            Param * cppResult = const_cast<const ::AppWrapper *>(cppSelf)->getProjectParam(cppArg0);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AppFunc_getProjectParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.App.getProjectParam");
+        return {};
+}
+
+static PyObject *Sbk_AppFunc_getViewNames(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getViewNames()const
+            std::list<QString > cppResult = const_cast<const ::AppWrapper *>(cppSelf)->getViewNames();
+            pyResult = Shiboken::Conversions::copyToPython(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_AppFunc_loadProject(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: App::loadProject(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // loadProject(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AppFunc_loadProject_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // loadProject(QString)
+            // Begin code injection
+            App * cppResult = cppSelf->loadProject(cppArg0);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_APP_IDX]), cppResult);
+
+            // End of code injection
+
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AppFunc_loadProject_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.App.loadProject");
+        return {};
+}
+
+static PyObject *Sbk_AppFunc_newProject(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // newProject()
+            // Begin code injection
+            App * cppResult = cppSelf->newProject();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_APP_IDX]), cppResult);
+
+            // End of code injection
+
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_AppFunc_render(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 4) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.App.render(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.App.render(): not enough arguments");
+        return {};
+    } else if (numArgs == 2)
+        goto Sbk_AppFunc_render_TypeError;
+
+    if (!PyArg_ParseTuple(args, "|OOOO:render", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: App::render(Effect*,int,int,int)
+    // 1: App::render(std::list<Effect*>,std::list<int>,std::list<int>,std::list<int>)
+    if (numArgs >= 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+        if (numArgs == 3) {
+            overloadId = 0; // render(Effect*,int,int,int)
+        } else if ((pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[3])))) {
+            overloadId = 0; // render(Effect*,int,int,int)
+        }
+    } else if (numArgs == 1
+        && PyList_Check(pyArgs[0])) {
+        overloadId = 1; // render(std::list<Effect*>,std::list<int>,std::list<int>,std::list<int>)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AppFunc_render_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // render(Effect * writeNode, int firstFrame, int lastFrame, int frameStep)
+        {
+            if (kwds) {
+                PyObject *keyName = nullptr;
+                PyObject *value = nullptr;
+                keyName = Py_BuildValue("s","frameStep");
+                if (PyDict_Contains(kwds, keyName)) {
+                    value = PyDict_GetItem(kwds, keyName);
+                    if (value && pyArgs[3]) {
+                        PyErr_SetString(PyExc_TypeError, "NatronEngine.App.render(): got multiple values for keyword argument 'frameStep'.");
+                        return {};
+                    }
+                    if (value) {
+                        pyArgs[3] = value;
+                        if (!(pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[3]))))
+                            goto Sbk_AppFunc_render_TypeError;
+                    }
+                }
+            }
+            if (!Shiboken::Object::isValid(pyArgs[0]))
+                return {};
+            ::Effect *cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            int cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            int cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            int cppArg3 = 1;
+            if (pythonToCpp[3]) pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // render(Effect*,int,int,int)
+                cppSelf->render(cppArg0, cppArg1, cppArg2, cppArg3);
+            }
+            break;
+        }
+        case 1: // render(const std::list<Effect* > & effects, const std::list<int > & firstFrames, const std::list<int > & lastFrames, const std::list<int > & frameSteps)
+        {
+
+            if (!PyErr_Occurred()) {
+                // render(std::list<Effect*>,std::list<int>,std::list<int>,std::list<int>)
+                // Begin code injection
+                if (!PyList_Check(pyArgs[1-1])) {
+                    PyErr_SetString(PyExc_TypeError, "tasks must be a list of tuple objects.");
+                    return 0;
+                }
+                std::list<Effect*> effects;
+
+                std::list<int> firstFrames;
+
+                std::list<int> lastFrames;
+
+                std::list<int> frameSteps;
+
+                int size = (int)PyList_GET_SIZE(pyArgs[1-1]);
+                for (int i = 0; i < size; ++i) {
+                    PyObject* tuple = PyList_GET_ITEM(pyArgs[1-1],i);
+                    if (!tuple) {
+                        PyErr_SetString(PyExc_TypeError, "tasks must be a list of tuple objects.");
+                        return 0;
+                    }
+
+                    int tupleSize = PyTuple_GET_SIZE(tuple);
+                    if (tupleSize != 4 && tupleSize != 3) {
+                        PyErr_SetString(PyExc_TypeError, "the tuple must have 3 or 4 items.");
+                        return 0;
+                    }
+                    ::Effect* writeNode{nullptr};
+                    Shiboken::Conversions::pythonToCppPointer(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), PyTuple_GET_ITEM(tuple, 0), &(writeNode));
+                    int firstFrame;
+                    Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<int>(), PyTuple_GET_ITEM(tuple, 1), &(firstFrame));
+                    int lastFrame;
+                    Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<int>(), PyTuple_GET_ITEM(tuple, 2), &(lastFrame));
+                    int frameStep;
+                    if (tupleSize == 4) {
+                        Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<int>(), PyTuple_GET_ITEM(tuple, 3), &(frameStep));
+                    } else {
+                        frameStep = INT_MIN;
+                    }
+                    effects.push_back(writeNode);
+                    firstFrames.push_back(firstFrame);
+                    lastFrames.push_back(lastFrame);
+                    frameSteps.push_back(frameStep);
+                }
+
+                cppSelf->render(effects,firstFrames,lastFrames, frameSteps);
+
+                // End of code injection
+
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_AppFunc_render_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.App.render");
+        return {};
+}
+
+static PyObject *Sbk_AppFunc_resetProject(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // resetProject()
+            bool cppResult = cppSelf->resetProject();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_AppFunc_saveProject(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: App::saveProject(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // saveProject(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AppFunc_saveProject_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // saveProject(QString)
+            bool cppResult = cppSelf->saveProject(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AppFunc_saveProject_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.App.saveProject");
+        return {};
+}
+
+static PyObject *Sbk_AppFunc_saveProjectAs(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: App::saveProjectAs(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // saveProjectAs(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AppFunc_saveProjectAs_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // saveProjectAs(QString)
+            bool cppResult = cppSelf->saveProjectAs(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AppFunc_saveProjectAs_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.App.saveProjectAs");
+        return {};
+}
+
+static PyObject *Sbk_AppFunc_saveTempProject(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: App::saveTempProject(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // saveTempProject(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AppFunc_saveTempProject_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // saveTempProject(QString)
+            bool cppResult = cppSelf->saveTempProject(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AppFunc_saveTempProject_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.App.saveTempProject");
+        return {};
+}
+
+static PyObject *Sbk_AppFunc_timelineGetLeftBound(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // timelineGetLeftBound()const
+            int cppResult = const_cast<const ::AppWrapper *>(cppSelf)->timelineGetLeftBound();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_AppFunc_timelineGetRightBound(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // timelineGetRightBound()const
+            int cppResult = const_cast<const ::AppWrapper *>(cppSelf)->timelineGetRightBound();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_AppFunc_timelineGetTime(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // timelineGetTime()const
+            int cppResult = const_cast<const ::AppWrapper *>(cppSelf)->timelineGetTime();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_AppFunc_writeToScriptEditor(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<AppWrapper *>(reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: App::writeToScriptEditor(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // writeToScriptEditor(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AppFunc_writeToScriptEditor_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // writeToScriptEditor(QString)
+            cppSelf->writeToScriptEditor(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_AppFunc_writeToScriptEditor_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.App.writeToScriptEditor");
+        return {};
+}
+
+
+static const char *Sbk_App_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_App_methods[] = {
+    {"addFormat", reinterpret_cast<PyCFunction>(Sbk_AppFunc_addFormat), METH_O},
+    {"addProjectLayer", reinterpret_cast<PyCFunction>(Sbk_AppFunc_addProjectLayer), METH_O},
+    {"closeProject", reinterpret_cast<PyCFunction>(Sbk_AppFunc_closeProject), METH_NOARGS},
+    {"createNode", reinterpret_cast<PyCFunction>(Sbk_AppFunc_createNode), METH_VARARGS|METH_KEYWORDS},
+    {"createReader", reinterpret_cast<PyCFunction>(Sbk_AppFunc_createReader), METH_VARARGS|METH_KEYWORDS},
+    {"createWriter", reinterpret_cast<PyCFunction>(Sbk_AppFunc_createWriter), METH_VARARGS|METH_KEYWORDS},
+    {"getAppID", reinterpret_cast<PyCFunction>(Sbk_AppFunc_getAppID), METH_NOARGS},
+    {"getProjectParam", reinterpret_cast<PyCFunction>(Sbk_AppFunc_getProjectParam), METH_O},
+    {"getViewNames", reinterpret_cast<PyCFunction>(Sbk_AppFunc_getViewNames), METH_NOARGS},
+    {"loadProject", reinterpret_cast<PyCFunction>(Sbk_AppFunc_loadProject), METH_O},
+    {"newProject", reinterpret_cast<PyCFunction>(Sbk_AppFunc_newProject), METH_NOARGS},
+    {"render", reinterpret_cast<PyCFunction>(Sbk_AppFunc_render), METH_VARARGS|METH_KEYWORDS},
+    {"resetProject", reinterpret_cast<PyCFunction>(Sbk_AppFunc_resetProject), METH_NOARGS},
+    {"saveProject", reinterpret_cast<PyCFunction>(Sbk_AppFunc_saveProject), METH_O},
+    {"saveProjectAs", reinterpret_cast<PyCFunction>(Sbk_AppFunc_saveProjectAs), METH_O},
+    {"saveTempProject", reinterpret_cast<PyCFunction>(Sbk_AppFunc_saveTempProject), METH_O},
+    {"timelineGetLeftBound", reinterpret_cast<PyCFunction>(Sbk_AppFunc_timelineGetLeftBound), METH_NOARGS},
+    {"timelineGetRightBound", reinterpret_cast<PyCFunction>(Sbk_AppFunc_timelineGetRightBound), METH_NOARGS},
+    {"timelineGetTime", reinterpret_cast<PyCFunction>(Sbk_AppFunc_timelineGetTime), METH_NOARGS},
+    {"writeToScriptEditor", reinterpret_cast<PyCFunction>(Sbk_AppFunc_writeToScriptEditor), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_App_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::App *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APP_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<AppWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_App_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_App_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_App_Type = nullptr;
+static SbkObjectType *Sbk_App_TypeF(void)
+{
+    return _Sbk_App_Type;
+}
+
+static PyType_Slot Sbk_App_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_App_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_App_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_App_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_App_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_App_spec = {
+    "1:NatronEngine.App",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_App_slots
+};
+
+} //extern "C"
+
+static void *Sbk_App_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Group >()))
+        return dynamic_cast< ::App *>(reinterpret_cast< ::Group *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void App_PythonToCpp_App_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_App_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_App_PythonToCpp_App_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_App_TypeF())))
+        return App_PythonToCpp_App_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *App_PTR_CppToPython_App(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::App *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_App_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *App_SignatureStrings[] = {
+    "NatronEngine.App.addFormat(self,formatSpec:QString)",
+    "NatronEngine.App.addProjectLayer(self,layer:NatronEngine.ImageLayer)",
+    "NatronEngine.App.closeProject(self)->bool",
+    "NatronEngine.App.createNode(self,pluginID:QString,majorVersion:int=-1,group:NatronEngine.Group=0,props:std.map[QString, NatronEngine.NodeCreationProperty]=NodeCreationPropertyMap())->NatronEngine.Effect",
+    "NatronEngine.App.createReader(self,filename:QString,group:NatronEngine.Group=0,props:std.map[QString, NatronEngine.NodeCreationProperty]=NodeCreationPropertyMap())->NatronEngine.Effect",
+    "NatronEngine.App.createWriter(self,filename:QString,group:NatronEngine.Group=0,props:std.map[QString, NatronEngine.NodeCreationProperty]=NodeCreationPropertyMap())->NatronEngine.Effect",
+    "NatronEngine.App.getAppID(self)->int",
+    "NatronEngine.App.getProjectParam(self,name:QString)->NatronEngine.Param",
+    "NatronEngine.App.getViewNames(self)->std.list[QString]",
+    "NatronEngine.App.loadProject(self,filename:QString)->NatronEngine.App",
+    "NatronEngine.App.newProject(self)->NatronEngine.App",
+    "1:NatronEngine.App.render(self,writeNode:NatronEngine.Effect,firstFrame:int,lastFrame:int,frameStep:int=1)",
+    "0:NatronEngine.App.render(self,effects:std.list[NatronEngine.Effect],firstFrames:std.list[int],lastFrames:std.list[int],frameSteps:std.list[int])",
+    "NatronEngine.App.resetProject(self)->bool",
+    "NatronEngine.App.saveProject(self,filename:QString)->bool",
+    "NatronEngine.App.saveProjectAs(self,filename:QString)->bool",
+    "NatronEngine.App.saveTempProject(self,filename:QString)->bool",
+    "NatronEngine.App.timelineGetLeftBound(self)->int",
+    "NatronEngine.App.timelineGetRightBound(self)->int",
+    "NatronEngine.App.timelineGetTime(self)->int",
+    "NatronEngine.App.writeToScriptEditor(self,message:QString)",
+    nullptr}; // Sentinel
+
+void init_App(PyObject *module)
+{
+    _Sbk_App_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "App",
+        "App*",
+        &Sbk_App_spec,
+        &Shiboken::callCppDestructor< ::App >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_App_Type);
+    InitSignatureStrings(pyType, App_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_App_Type), Sbk_App_PropertyStrings);
+    SbkNatronEngineTypes[SBK_APP_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_App_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_App_TypeF(),
+        App_PythonToCpp_App_PTR,
+        is_App_PythonToCpp_App_PTR_Convertible,
+        App_PTR_CppToPython_App);
+
+    Shiboken::Conversions::registerConverterName(converter, "App");
+    Shiboken::Conversions::registerConverterName(converter, "App*");
+    Shiboken::Conversions::registerConverterName(converter, "App&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::App).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::AppWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_App_TypeF(), &Sbk_App_typeDiscovery);
+
+
+    AppWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/app_wrapper.h
+++ b/Engine/Qt5/NatronEngine/app_wrapper.h
@@ -1,0 +1,48 @@
+#ifndef SBK_APPWRAPPER_H
+#define SBK_APPWRAPPER_H
+
+#include <PyAppInstance.h>
+
+
+// Extra includes
+#include <PyNode.h>
+#include <PyNodeGroup.h>
+#include <map>
+#include <PyAppInstance.h>
+#include <list>
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AppWrapper : public App
+{
+public:
+    inline void renderInternal_protected(bool forceBlocking, Effect * writeNode, int firstFrame, int lastFrame, int frameStep) { App::renderInternal(forceBlocking, writeNode, firstFrame, lastFrame, frameStep); }
+    inline void renderInternal_protected(bool forceBlocking, const std::list<Effect* > & effects, const std::list<int > & firstFrames, const std::list<int > & lastFrames, const std::list<int > & frameSteps) { App::renderInternal(forceBlocking, effects, firstFrames, lastFrames, frameSteps); }
+    ~AppWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_GROUPWRAPPER_H
+#  define SBK_GROUPWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class GroupWrapper : public Group
+{
+public:
+    GroupWrapper();
+    ~GroupWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_GROUPWRAPPER_H
+
+#endif // SBK_APPWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/appsettings_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/appsettings_wrapper.cpp
@@ -1,0 +1,340 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "appsettings_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+// Extra includes
+#include <PyParameter.h>
+#include <list>
+
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_AppSettingsFunc_getParam(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::AppSettings *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APPSETTINGS_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: AppSettings::getParam(QString)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // getParam(QString)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_AppSettingsFunc_getParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getParam(QString)const
+            Param * cppResult = const_cast<const ::AppSettings *>(cppSelf)->getParam(cppArg0);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_AppSettingsFunc_getParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.AppSettings.getParam");
+        return {};
+}
+
+static PyObject *Sbk_AppSettingsFunc_getParams(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::AppSettings *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APPSETTINGS_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getParams()const
+            // Begin code injection
+            std::list<Param*> params = cppSelf->getParams();
+            PyObject* ret = PyList_New((int) params.size());
+            int idx = 0;
+            for (std::list<Param*>::iterator it = params.begin(); it!=params.end(); ++it,++idx) {
+            PyObject* item = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), *it);
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(item);
+            PyList_SET_ITEM(ret, idx, item);
+            }
+            return ret;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_AppSettingsFunc_restoreDefaultSettings(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::AppSettings *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APPSETTINGS_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // restoreDefaultSettings()
+            cppSelf->restoreDefaultSettings();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_AppSettingsFunc_saveSettings(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::AppSettings *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_APPSETTINGS_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // saveSettings()
+            cppSelf->saveSettings();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+
+static const char *Sbk_AppSettings_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_AppSettings_methods[] = {
+    {"getParam", reinterpret_cast<PyCFunction>(Sbk_AppSettingsFunc_getParam), METH_O},
+    {"getParams", reinterpret_cast<PyCFunction>(Sbk_AppSettingsFunc_getParams), METH_NOARGS},
+    {"restoreDefaultSettings", reinterpret_cast<PyCFunction>(Sbk_AppSettingsFunc_restoreDefaultSettings), METH_NOARGS},
+    {"saveSettings", reinterpret_cast<PyCFunction>(Sbk_AppSettingsFunc_saveSettings), METH_NOARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+} // extern "C"
+
+static int Sbk_AppSettings_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_AppSettings_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_AppSettings_Type = nullptr;
+static SbkObjectType *Sbk_AppSettings_TypeF(void)
+{
+    return _Sbk_AppSettings_Type;
+}
+
+static PyType_Slot Sbk_AppSettings_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    nullptr},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_AppSettings_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_AppSettings_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_AppSettings_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_AppSettings_spec = {
+    "1:NatronEngine.AppSettings",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_AppSettings_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void AppSettings_PythonToCpp_AppSettings_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_AppSettings_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_AppSettings_PythonToCpp_AppSettings_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_AppSettings_TypeF())))
+        return AppSettings_PythonToCpp_AppSettings_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *AppSettings_PTR_CppToPython_AppSettings(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::AppSettings *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_AppSettings_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *AppSettings_SignatureStrings[] = {
+    "NatronEngine.AppSettings.getParam(self,scriptName:QString)->NatronEngine.Param",
+    "NatronEngine.AppSettings.getParams(self)->std.list[NatronEngine.Param]",
+    "NatronEngine.AppSettings.restoreDefaultSettings(self)",
+    "NatronEngine.AppSettings.saveSettings(self)",
+    nullptr}; // Sentinel
+
+void init_AppSettings(PyObject *module)
+{
+    _Sbk_AppSettings_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "AppSettings",
+        "AppSettings*",
+        &Sbk_AppSettings_spec,
+        &Shiboken::callCppDestructor< ::AppSettings >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_AppSettings_Type);
+    InitSignatureStrings(pyType, AppSettings_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_AppSettings_Type), Sbk_AppSettings_PropertyStrings);
+    SbkNatronEngineTypes[SBK_APPSETTINGS_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_AppSettings_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_AppSettings_TypeF(),
+        AppSettings_PythonToCpp_AppSettings_PTR,
+        is_AppSettings_PythonToCpp_AppSettings_PTR_Convertible,
+        AppSettings_PTR_CppToPython_AppSettings);
+
+    Shiboken::Conversions::registerConverterName(converter, "AppSettings");
+    Shiboken::Conversions::registerConverterName(converter, "AppSettings*");
+    Shiboken::Conversions::registerConverterName(converter, "AppSettings&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::AppSettings).name());
+
+
+
+}

--- a/Engine/Qt5/NatronEngine/appsettings_wrapper.h
+++ b/Engine/Qt5/NatronEngine/appsettings_wrapper.h
@@ -1,0 +1,7 @@
+#ifndef SBK_APPSETTINGS_H
+#define SBK_APPSETTINGS_H
+
+#include <PyAppInstance.h>
+
+#endif // SBK_APPSETTINGS_H
+

--- a/Engine/Qt5/NatronEngine/beziercurve_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/beziercurve_wrapper.cpp
@@ -1,0 +1,1918 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "beziercurve_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void BezierCurveWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void BezierCurveWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+BezierCurveWrapper::~BezierCurveWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_BezierCurveFunc_addControlPoint(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "addControlPoint", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BezierCurve::addControlPoint(double,double)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        overloadId = 0; // addControlPoint(double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_addControlPoint_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // addControlPoint(double,double)
+            cppSelf->addControlPoint(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_addControlPoint_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BezierCurve.addControlPoint");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_addControlPointOnSegment(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "addControlPointOnSegment", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BezierCurve::addControlPointOnSegment(int,double)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        overloadId = 0; // addControlPointOnSegment(int,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_addControlPointOnSegment_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // addControlPointOnSegment(int,double)
+            cppSelf->addControlPointOnSegment(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_addControlPointOnSegment_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BezierCurve.addControlPointOnSegment");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_getActivatedParam(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getActivatedParam()const
+            BooleanParam * cppResult = const_cast<const ::BezierCurve *>(cppSelf)->getActivatedParam();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_BOOLEANPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_BezierCurveFunc_getColor(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: BezierCurve::getColor(double)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArg)))) {
+        overloadId = 0; // getColor(double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_getColor_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getColor(double)
+            ColorTuple* cppResult = new ColorTuple(cppSelf->getColor(cppArg0));
+            pyResult = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_COLORTUPLE_IDX]), cppResult, true, true);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_BezierCurveFunc_getColor_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.BezierCurve.getColor");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_getColorParam(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getColorParam()const
+            ColorParam * cppResult = const_cast<const ::BezierCurve *>(cppSelf)->getColorParam();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_COLORPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_BezierCurveFunc_getCompositingOperator(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getCompositingOperator()const
+            NATRON_ENUM::MergingFunctionEnum cppResult = NATRON_ENUM::MergingFunctionEnum(const_cast<const ::BezierCurve *>(cppSelf)->getCompositingOperator());
+            pyResult = Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX])->converter, &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_BezierCurveFunc_getCompositingOperatorParam(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getCompositingOperatorParam()const
+            ChoiceParam * cppResult = const_cast<const ::BezierCurve *>(cppSelf)->getCompositingOperatorParam();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_BezierCurveFunc_getControlPointPosition(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "getControlPointPosition", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BezierCurve::getControlPointPosition(int,double,double*,double*,double*,double*,double*,double*)const
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        overloadId = 0; // getControlPointPosition(int,double,double*,double*,double*,double*,double*,double*)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_getControlPointPosition_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // getControlPointPosition(int,double,double*,double*,double*,double*,double*,double*)const
+            // Begin code injection
+            double x,y,rx,ry,lx,ly;
+            cppSelf->getControlPointPosition(cppArg0, cppArg1, &x,&y, &lx,&ly,&rx,&ry);
+
+            PyObject* ret = PyTuple_New(6);
+            PyTuple_SET_ITEM(ret, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &x));
+            PyTuple_SET_ITEM(ret, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &y));
+            PyTuple_SET_ITEM(ret, 2, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &lx));
+            PyTuple_SET_ITEM(ret, 3, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ly));
+            PyTuple_SET_ITEM(ret, 4, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &rx));
+            PyTuple_SET_ITEM(ret, 5, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ry));
+            return ret;
+
+            // End of code injection
+
+            pyResult = Py_None;
+            Py_INCREF(Py_None);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_BezierCurveFunc_getControlPointPosition_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BezierCurve.getControlPointPosition");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_getFeatherDistance(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: BezierCurve::getFeatherDistance(double)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArg)))) {
+        overloadId = 0; // getFeatherDistance(double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_getFeatherDistance_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getFeatherDistance(double)const
+            double cppResult = const_cast<const ::BezierCurve *>(cppSelf)->getFeatherDistance(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_BezierCurveFunc_getFeatherDistance_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.BezierCurve.getFeatherDistance");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_getFeatherDistanceParam(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getFeatherDistanceParam()const
+            DoubleParam * cppResult = const_cast<const ::BezierCurve *>(cppSelf)->getFeatherDistanceParam();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_BezierCurveFunc_getFeatherFallOff(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: BezierCurve::getFeatherFallOff(double)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArg)))) {
+        overloadId = 0; // getFeatherFallOff(double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_getFeatherFallOff_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getFeatherFallOff(double)const
+            double cppResult = const_cast<const ::BezierCurve *>(cppSelf)->getFeatherFallOff(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_BezierCurveFunc_getFeatherFallOff_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.BezierCurve.getFeatherFallOff");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_getFeatherFallOffParam(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getFeatherFallOffParam()const
+            DoubleParam * cppResult = const_cast<const ::BezierCurve *>(cppSelf)->getFeatherFallOffParam();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_BezierCurveFunc_getFeatherPointPosition(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "getFeatherPointPosition", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BezierCurve::getFeatherPointPosition(int,double,double*,double*,double*,double*,double*,double*)const
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        overloadId = 0; // getFeatherPointPosition(int,double,double*,double*,double*,double*,double*,double*)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_getFeatherPointPosition_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // getFeatherPointPosition(int,double,double*,double*,double*,double*,double*,double*)const
+            // Begin code injection
+            double x,y,rx,ry,lx,ly;
+            cppSelf->getFeatherPointPosition(cppArg0, cppArg1, &x,&y, &lx,&ly,&rx,&ry);
+
+            PyObject* ret = PyTuple_New(6);
+            PyTuple_SET_ITEM(ret, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &x));
+            PyTuple_SET_ITEM(ret, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &y));
+            PyTuple_SET_ITEM(ret, 2, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &lx));
+            PyTuple_SET_ITEM(ret, 3, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ly));
+            PyTuple_SET_ITEM(ret, 4, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &rx));
+            PyTuple_SET_ITEM(ret, 5, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ry));
+            return ret;
+
+            // End of code injection
+
+            pyResult = Py_None;
+            Py_INCREF(Py_None);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_BezierCurveFunc_getFeatherPointPosition_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BezierCurve.getFeatherPointPosition");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_getIsActivated(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: BezierCurve::getIsActivated(double)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArg)))) {
+        overloadId = 0; // getIsActivated(double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_getIsActivated_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getIsActivated(double)
+            bool cppResult = cppSelf->getIsActivated(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_BezierCurveFunc_getIsActivated_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.BezierCurve.getIsActivated");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_getKeyframes(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getKeyframes(std::list<double>*)const
+            // Begin code injection
+            std::list<double> keys;
+            cppSelf->getKeyframes(&keys);
+            PyObject* ret = PyList_New((int) keys.size());
+            int idx = 0;
+            for (std::list<double>::iterator it = keys.begin(); it!=keys.end(); ++it,++idx) {
+            PyList_SET_ITEM(ret, idx, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &*it));
+            }
+            return ret;
+
+            // End of code injection
+
+            pyResult = Py_None;
+            Py_INCREF(Py_None);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_BezierCurveFunc_getNumControlPoints(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getNumControlPoints()const
+            int cppResult = const_cast<const ::BezierCurve *>(cppSelf)->getNumControlPoints();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_BezierCurveFunc_getOpacity(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: BezierCurve::getOpacity(double)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArg)))) {
+        overloadId = 0; // getOpacity(double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_getOpacity_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getOpacity(double)const
+            double cppResult = const_cast<const ::BezierCurve *>(cppSelf)->getOpacity(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_BezierCurveFunc_getOpacity_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.BezierCurve.getOpacity");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_getOpacityParam(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getOpacityParam()const
+            DoubleParam * cppResult = const_cast<const ::BezierCurve *>(cppSelf)->getOpacityParam();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_BezierCurveFunc_getOverlayColor(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getOverlayColor()const
+            ColorTuple* cppResult = new ColorTuple(const_cast<const ::BezierCurve *>(cppSelf)->getOverlayColor());
+            pyResult = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_COLORTUPLE_IDX]), cppResult, true, true);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_BezierCurveFunc_isCurveFinished(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // isCurveFinished()const
+            bool cppResult = const_cast<const ::BezierCurve *>(cppSelf)->isCurveFinished();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_BezierCurveFunc_moveFeatherByIndex(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "moveFeatherByIndex", 4, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BezierCurve::moveFeatherByIndex(int,double,double,double)
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+        overloadId = 0; // moveFeatherByIndex(int,double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_moveFeatherByIndex_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3;
+        pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // moveFeatherByIndex(int,double,double,double)
+            cppSelf->moveFeatherByIndex(cppArg0, cppArg1, cppArg2, cppArg3);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_moveFeatherByIndex_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BezierCurve.moveFeatherByIndex");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_moveLeftBezierPoint(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "moveLeftBezierPoint", 4, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BezierCurve::moveLeftBezierPoint(int,double,double,double)
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+        overloadId = 0; // moveLeftBezierPoint(int,double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_moveLeftBezierPoint_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3;
+        pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // moveLeftBezierPoint(int,double,double,double)
+            cppSelf->moveLeftBezierPoint(cppArg0, cppArg1, cppArg2, cppArg3);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_moveLeftBezierPoint_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BezierCurve.moveLeftBezierPoint");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_movePointByIndex(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "movePointByIndex", 4, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BezierCurve::movePointByIndex(int,double,double,double)
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+        overloadId = 0; // movePointByIndex(int,double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_movePointByIndex_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3;
+        pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // movePointByIndex(int,double,double,double)
+            cppSelf->movePointByIndex(cppArg0, cppArg1, cppArg2, cppArg3);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_movePointByIndex_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BezierCurve.movePointByIndex");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_moveRightBezierPoint(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "moveRightBezierPoint", 4, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BezierCurve::moveRightBezierPoint(int,double,double,double)
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+        overloadId = 0; // moveRightBezierPoint(int,double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_moveRightBezierPoint_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3;
+        pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // moveRightBezierPoint(int,double,double,double)
+            cppSelf->moveRightBezierPoint(cppArg0, cppArg1, cppArg2, cppArg3);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_moveRightBezierPoint_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BezierCurve.moveRightBezierPoint");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_removeControlPointByIndex(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: BezierCurve::removeControlPointByIndex(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // removeControlPointByIndex(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_removeControlPointByIndex_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // removeControlPointByIndex(int)
+            cppSelf->removeControlPointByIndex(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_removeControlPointByIndex_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.BezierCurve.removeControlPointByIndex");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_setActivated(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setActivated", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BezierCurve::setActivated(double,bool)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[1])))) {
+        overloadId = 0; // setActivated(double,bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_setActivated_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        bool cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setActivated(double,bool)
+            cppSelf->setActivated(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_setActivated_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BezierCurve.setActivated");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_setColor(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setColor", 4, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BezierCurve::setColor(double,double,double,double)
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+        overloadId = 0; // setColor(double,double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_setColor_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3;
+        pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // setColor(double,double,double,double)
+            cppSelf->setColor(cppArg0, cppArg1, cppArg2, cppArg3);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_setColor_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BezierCurve.setColor");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_setCompositingOperator(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: BezierCurve::setCompositingOperator(NATRON_ENUM::MergingFunctionEnum)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX])->converter, (pyArg)))) {
+        overloadId = 0; // setCompositingOperator(NATRON_ENUM::MergingFunctionEnum)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_setCompositingOperator_TypeError;
+
+    // Call function/method
+    {
+        ::NATRON_ENUM::MergingFunctionEnum cppArg0{NATRON_ENUM::eMergeATop};
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setCompositingOperator(NATRON_ENUM::MergingFunctionEnum)
+            cppSelf->setCompositingOperator(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_setCompositingOperator_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.BezierCurve.setCompositingOperator");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_setCurveFinished(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: BezierCurve::setCurveFinished(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setCurveFinished(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_setCurveFinished_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setCurveFinished(bool)
+            cppSelf->setCurveFinished(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_setCurveFinished_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.BezierCurve.setCurveFinished");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_setFeatherDistance(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setFeatherDistance", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BezierCurve::setFeatherDistance(double,double)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        overloadId = 0; // setFeatherDistance(double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_setFeatherDistance_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setFeatherDistance(double,double)
+            cppSelf->setFeatherDistance(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_setFeatherDistance_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BezierCurve.setFeatherDistance");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_setFeatherFallOff(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setFeatherFallOff", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BezierCurve::setFeatherFallOff(double,double)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        overloadId = 0; // setFeatherFallOff(double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_setFeatherFallOff_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setFeatherFallOff(double,double)
+            cppSelf->setFeatherFallOff(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_setFeatherFallOff_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BezierCurve.setFeatherFallOff");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_setFeatherPointAtIndex(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setFeatherPointAtIndex", 8, 8, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3]), &(pyArgs[4]), &(pyArgs[5]), &(pyArgs[6]), &(pyArgs[7])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BezierCurve::setFeatherPointAtIndex(int,double,double,double,double,double,double,double)
+    if (numArgs == 8
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))
+        && (pythonToCpp[4] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[4])))
+        && (pythonToCpp[5] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[5])))
+        && (pythonToCpp[6] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[6])))
+        && (pythonToCpp[7] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[7])))) {
+        overloadId = 0; // setFeatherPointAtIndex(int,double,double,double,double,double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_setFeatherPointAtIndex_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3;
+        pythonToCpp[3](pyArgs[3], &cppArg3);
+        double cppArg4;
+        pythonToCpp[4](pyArgs[4], &cppArg4);
+        double cppArg5;
+        pythonToCpp[5](pyArgs[5], &cppArg5);
+        double cppArg6;
+        pythonToCpp[6](pyArgs[6], &cppArg6);
+        double cppArg7;
+        pythonToCpp[7](pyArgs[7], &cppArg7);
+
+        if (!PyErr_Occurred()) {
+            // setFeatherPointAtIndex(int,double,double,double,double,double,double,double)
+            cppSelf->setFeatherPointAtIndex(cppArg0, cppArg1, cppArg2, cppArg3, cppArg4, cppArg5, cppArg6, cppArg7);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_setFeatherPointAtIndex_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BezierCurve.setFeatherPointAtIndex");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_setOpacity(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setOpacity", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BezierCurve::setOpacity(double,double)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        overloadId = 0; // setOpacity(double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_setOpacity_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setOpacity(double,double)
+            cppSelf->setOpacity(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_setOpacity_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BezierCurve.setOpacity");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_setOverlayColor(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setOverlayColor", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BezierCurve::setOverlayColor(double,double,double)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+        overloadId = 0; // setOverlayColor(double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_setOverlayColor_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // setOverlayColor(double,double,double)
+            cppSelf->setOverlayColor(cppArg0, cppArg1, cppArg2);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_setOverlayColor_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BezierCurve.setOverlayColor");
+        return {};
+}
+
+static PyObject *Sbk_BezierCurveFunc_setPointAtIndex(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setPointAtIndex", 8, 8, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3]), &(pyArgs[4]), &(pyArgs[5]), &(pyArgs[6]), &(pyArgs[7])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BezierCurve::setPointAtIndex(int,double,double,double,double,double,double,double)
+    if (numArgs == 8
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))
+        && (pythonToCpp[4] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[4])))
+        && (pythonToCpp[5] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[5])))
+        && (pythonToCpp[6] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[6])))
+        && (pythonToCpp[7] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[7])))) {
+        overloadId = 0; // setPointAtIndex(int,double,double,double,double,double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BezierCurveFunc_setPointAtIndex_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3;
+        pythonToCpp[3](pyArgs[3], &cppArg3);
+        double cppArg4;
+        pythonToCpp[4](pyArgs[4], &cppArg4);
+        double cppArg5;
+        pythonToCpp[5](pyArgs[5], &cppArg5);
+        double cppArg6;
+        pythonToCpp[6](pyArgs[6], &cppArg6);
+        double cppArg7;
+        pythonToCpp[7](pyArgs[7], &cppArg7);
+
+        if (!PyErr_Occurred()) {
+            // setPointAtIndex(int,double,double,double,double,double,double,double)
+            cppSelf->setPointAtIndex(cppArg0, cppArg1, cppArg2, cppArg3, cppArg4, cppArg5, cppArg6, cppArg7);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BezierCurveFunc_setPointAtIndex_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BezierCurve.setPointAtIndex");
+        return {};
+}
+
+
+static const char *Sbk_BezierCurve_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_BezierCurve_methods[] = {
+    {"addControlPoint", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_addControlPoint), METH_VARARGS},
+    {"addControlPointOnSegment", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_addControlPointOnSegment), METH_VARARGS},
+    {"getActivatedParam", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getActivatedParam), METH_NOARGS},
+    {"getColor", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getColor), METH_O},
+    {"getColorParam", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getColorParam), METH_NOARGS},
+    {"getCompositingOperator", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getCompositingOperator), METH_NOARGS},
+    {"getCompositingOperatorParam", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getCompositingOperatorParam), METH_NOARGS},
+    {"getControlPointPosition", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getControlPointPosition), METH_VARARGS},
+    {"getFeatherDistance", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getFeatherDistance), METH_O},
+    {"getFeatherDistanceParam", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getFeatherDistanceParam), METH_NOARGS},
+    {"getFeatherFallOff", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getFeatherFallOff), METH_O},
+    {"getFeatherFallOffParam", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getFeatherFallOffParam), METH_NOARGS},
+    {"getFeatherPointPosition", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getFeatherPointPosition), METH_VARARGS},
+    {"getIsActivated", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getIsActivated), METH_O},
+    {"getKeyframes", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getKeyframes), METH_NOARGS},
+    {"getNumControlPoints", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getNumControlPoints), METH_NOARGS},
+    {"getOpacity", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getOpacity), METH_O},
+    {"getOpacityParam", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getOpacityParam), METH_NOARGS},
+    {"getOverlayColor", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_getOverlayColor), METH_NOARGS},
+    {"isCurveFinished", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_isCurveFinished), METH_NOARGS},
+    {"moveFeatherByIndex", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_moveFeatherByIndex), METH_VARARGS},
+    {"moveLeftBezierPoint", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_moveLeftBezierPoint), METH_VARARGS},
+    {"movePointByIndex", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_movePointByIndex), METH_VARARGS},
+    {"moveRightBezierPoint", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_moveRightBezierPoint), METH_VARARGS},
+    {"removeControlPointByIndex", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_removeControlPointByIndex), METH_O},
+    {"setActivated", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_setActivated), METH_VARARGS},
+    {"setColor", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_setColor), METH_VARARGS},
+    {"setCompositingOperator", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_setCompositingOperator), METH_O},
+    {"setCurveFinished", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_setCurveFinished), METH_O},
+    {"setFeatherDistance", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_setFeatherDistance), METH_VARARGS},
+    {"setFeatherFallOff", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_setFeatherFallOff), METH_VARARGS},
+    {"setFeatherPointAtIndex", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_setFeatherPointAtIndex), METH_VARARGS},
+    {"setOpacity", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_setOpacity), METH_VARARGS},
+    {"setOverlayColor", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_setOverlayColor), METH_VARARGS},
+    {"setPointAtIndex", reinterpret_cast<PyCFunction>(Sbk_BezierCurveFunc_setPointAtIndex), METH_VARARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_BezierCurve_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::BezierCurve *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<BezierCurveWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_BezierCurve_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_BezierCurve_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_BezierCurve_Type = nullptr;
+static SbkObjectType *Sbk_BezierCurve_TypeF(void)
+{
+    return _Sbk_BezierCurve_Type;
+}
+
+static PyType_Slot Sbk_BezierCurve_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_BezierCurve_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_BezierCurve_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_BezierCurve_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_BezierCurve_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_BezierCurve_spec = {
+    "1:NatronEngine.BezierCurve",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_BezierCurve_slots
+};
+
+} //extern "C"
+
+static void *Sbk_BezierCurve_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::ItemBase >()))
+        return dynamic_cast< ::BezierCurve *>(reinterpret_cast< ::ItemBase *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void BezierCurve_PythonToCpp_BezierCurve_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_BezierCurve_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_BezierCurve_PythonToCpp_BezierCurve_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_BezierCurve_TypeF())))
+        return BezierCurve_PythonToCpp_BezierCurve_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *BezierCurve_PTR_CppToPython_BezierCurve(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::BezierCurve *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_BezierCurve_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *BezierCurve_SignatureStrings[] = {
+    "NatronEngine.BezierCurve.addControlPoint(self,x:double,y:double)",
+    "NatronEngine.BezierCurve.addControlPointOnSegment(self,index:int,t:double)",
+    "NatronEngine.BezierCurve.getActivatedParam(self)->NatronEngine.BooleanParam",
+    "NatronEngine.BezierCurve.getColor(self,time:double)->NatronEngine.ColorTuple",
+    "NatronEngine.BezierCurve.getColorParam(self)->NatronEngine.ColorParam",
+    "NatronEngine.BezierCurve.getCompositingOperator(self)->NatronEngine.NATRON_ENUM.MergingFunctionEnum",
+    "NatronEngine.BezierCurve.getCompositingOperatorParam(self)->NatronEngine.ChoiceParam",
+    "NatronEngine.BezierCurve.getControlPointPosition(self,index:int,time:double,x:double*,y:double*,lx:double*,ly:double*,rx:double*,ry:double*)",
+    "NatronEngine.BezierCurve.getFeatherDistance(self,time:double)->double",
+    "NatronEngine.BezierCurve.getFeatherDistanceParam(self)->NatronEngine.DoubleParam",
+    "NatronEngine.BezierCurve.getFeatherFallOff(self,time:double)->double",
+    "NatronEngine.BezierCurve.getFeatherFallOffParam(self)->NatronEngine.DoubleParam",
+    "NatronEngine.BezierCurve.getFeatherPointPosition(self,index:int,time:double,x:double*,y:double*,lx:double*,ly:double*,rx:double*,ry:double*)",
+    "NatronEngine.BezierCurve.getIsActivated(self,time:double)->bool",
+    "NatronEngine.BezierCurve.getKeyframes(self,keys:std.list[double])",
+    "NatronEngine.BezierCurve.getNumControlPoints(self)->int",
+    "NatronEngine.BezierCurve.getOpacity(self,time:double)->double",
+    "NatronEngine.BezierCurve.getOpacityParam(self)->NatronEngine.DoubleParam",
+    "NatronEngine.BezierCurve.getOverlayColor(self)->NatronEngine.ColorTuple",
+    "NatronEngine.BezierCurve.isCurveFinished(self)->bool",
+    "NatronEngine.BezierCurve.moveFeatherByIndex(self,index:int,time:double,dx:double,dy:double)",
+    "NatronEngine.BezierCurve.moveLeftBezierPoint(self,index:int,time:double,dx:double,dy:double)",
+    "NatronEngine.BezierCurve.movePointByIndex(self,index:int,time:double,dx:double,dy:double)",
+    "NatronEngine.BezierCurve.moveRightBezierPoint(self,index:int,time:double,dx:double,dy:double)",
+    "NatronEngine.BezierCurve.removeControlPointByIndex(self,index:int)",
+    "NatronEngine.BezierCurve.setActivated(self,time:double,activated:bool)",
+    "NatronEngine.BezierCurve.setColor(self,time:double,r:double,g:double,b:double)",
+    "NatronEngine.BezierCurve.setCompositingOperator(self,op:NatronEngine.NATRON_ENUM.MergingFunctionEnum)",
+    "NatronEngine.BezierCurve.setCurveFinished(self,finished:bool)",
+    "NatronEngine.BezierCurve.setFeatherDistance(self,dist:double,time:double)",
+    "NatronEngine.BezierCurve.setFeatherFallOff(self,falloff:double,time:double)",
+    "NatronEngine.BezierCurve.setFeatherPointAtIndex(self,index:int,time:double,x:double,y:double,lx:double,ly:double,rx:double,ry:double)",
+    "NatronEngine.BezierCurve.setOpacity(self,opacity:double,time:double)",
+    "NatronEngine.BezierCurve.setOverlayColor(self,r:double,g:double,b:double)",
+    "NatronEngine.BezierCurve.setPointAtIndex(self,index:int,time:double,x:double,y:double,lx:double,ly:double,rx:double,ry:double)",
+    nullptr}; // Sentinel
+
+void init_BezierCurve(PyObject *module)
+{
+    _Sbk_BezierCurve_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "BezierCurve",
+        "BezierCurve*",
+        &Sbk_BezierCurve_spec,
+        &Shiboken::callCppDestructor< ::BezierCurve >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_ITEMBASE_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_BezierCurve_Type);
+    InitSignatureStrings(pyType, BezierCurve_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_BezierCurve_Type), Sbk_BezierCurve_PropertyStrings);
+    SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_BezierCurve_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_BezierCurve_TypeF(),
+        BezierCurve_PythonToCpp_BezierCurve_PTR,
+        is_BezierCurve_PythonToCpp_BezierCurve_PTR_Convertible,
+        BezierCurve_PTR_CppToPython_BezierCurve);
+
+    Shiboken::Conversions::registerConverterName(converter, "BezierCurve");
+    Shiboken::Conversions::registerConverterName(converter, "BezierCurve*");
+    Shiboken::Conversions::registerConverterName(converter, "BezierCurve&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::BezierCurve).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::BezierCurveWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_BezierCurve_TypeF(), &Sbk_BezierCurve_typeDiscovery);
+
+
+    BezierCurveWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/beziercurve_wrapper.h
+++ b/Engine/Qt5/NatronEngine/beziercurve_wrapper.h
@@ -1,0 +1,42 @@
+#ifndef SBK_BEZIERCURVEWRAPPER_H
+#define SBK_BEZIERCURVEWRAPPER_H
+
+#include <PyRoto.h>
+
+
+// Extra includes
+#include <list>
+#include <PyParameter.h>
+#include <PyRoto.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class BezierCurveWrapper : public BezierCurve
+{
+public:
+    ~BezierCurveWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_ITEMBASEWRAPPER_H
+#  define SBK_ITEMBASEWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ItemBaseWrapper : public ItemBase
+{
+public:
+    ~ItemBaseWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_ITEMBASEWRAPPER_H
+
+#endif // SBK_BEZIERCURVEWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/booleanparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/booleanparam_wrapper.cpp
@@ -1,0 +1,716 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "booleanparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void BooleanParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void BooleanParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+BooleanParamWrapper::~BooleanParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_BooleanParamFunc_addAsDependencyOf(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BooleanParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BOOLEANPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "addAsDependencyOf", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BooleanParam::addAsDependencyOf(int,Param*,int)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+        overloadId = 0; // addAsDependencyOf(int,Param*,int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BooleanParamFunc_addAsDependencyOf_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        if (!Shiboken::Object::isValid(pyArgs[1]))
+            return {};
+        ::Param *cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        int cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // addAsDependencyOf(int,Param*,int)
+            bool cppResult = cppSelf->addAsDependencyOf(cppArg0, cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_BooleanParamFunc_addAsDependencyOf_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BooleanParam.addAsDependencyOf");
+        return {};
+}
+
+static PyObject *Sbk_BooleanParamFunc_get(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BooleanParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BOOLEANPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "get", 0, 1, &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BooleanParam::get()const
+    // 1: BooleanParam::get(double)const
+    if (numArgs == 0) {
+        overloadId = 0; // get()const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        overloadId = 1; // get(double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BooleanParamFunc_get_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // get() const
+        {
+
+            if (!PyErr_Occurred()) {
+                // get()const
+                bool cppResult = const_cast<const ::BooleanParam *>(cppSelf)->get();
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            }
+            break;
+        }
+        case 1: // get(double frame) const
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // get(double)const
+                bool cppResult = const_cast<const ::BooleanParam *>(cppSelf)->get(cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_BooleanParamFunc_get_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BooleanParam.get");
+        return {};
+}
+
+static PyObject *Sbk_BooleanParamFunc_getDefaultValue(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BooleanParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BOOLEANPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getDefaultValue()const
+            bool cppResult = const_cast<const ::BooleanParam *>(cppSelf)->getDefaultValue();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_BooleanParamFunc_getValue(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BooleanParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BOOLEANPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getValue()const
+            bool cppResult = const_cast<const ::BooleanParam *>(cppSelf)->getValue();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_BooleanParamFunc_getValueAtTime(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BooleanParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BOOLEANPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: BooleanParam::getValueAtTime(double)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArg)))) {
+        overloadId = 0; // getValueAtTime(double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BooleanParamFunc_getValueAtTime_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getValueAtTime(double)const
+            bool cppResult = const_cast<const ::BooleanParam *>(cppSelf)->getValueAtTime(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_BooleanParamFunc_getValueAtTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.BooleanParam.getValueAtTime");
+        return {};
+}
+
+static PyObject *Sbk_BooleanParamFunc_restoreDefaultValue(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BooleanParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BOOLEANPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // restoreDefaultValue()
+            cppSelf->restoreDefaultValue();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_BooleanParamFunc_set(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BooleanParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BOOLEANPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "set", 1, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BooleanParam::set(bool)
+    // 1: BooleanParam::set(bool,double)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // set(bool)
+        } else if (numArgs == 2
+            && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+            overloadId = 1; // set(bool,double)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BooleanParamFunc_set_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // set(bool x)
+        {
+            bool cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // set(bool)
+                cppSelf->set(cppArg0);
+            }
+            break;
+        }
+        case 1: // set(bool x, double frame)
+        {
+            bool cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+
+            if (!PyErr_Occurred()) {
+                // set(bool,double)
+                cppSelf->set(cppArg0, cppArg1);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BooleanParamFunc_set_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BooleanParam.set");
+        return {};
+}
+
+static PyObject *Sbk_BooleanParamFunc_setDefaultValue(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BooleanParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BOOLEANPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: BooleanParam::setDefaultValue(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setDefaultValue(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BooleanParamFunc_setDefaultValue_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setDefaultValue(bool)
+            cppSelf->setDefaultValue(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BooleanParamFunc_setDefaultValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.BooleanParam.setDefaultValue");
+        return {};
+}
+
+static PyObject *Sbk_BooleanParamFunc_setValue(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BooleanParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BOOLEANPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: BooleanParam::setValue(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setValue(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BooleanParamFunc_setValue_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setValue(bool)
+            cppSelf->setValue(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BooleanParamFunc_setValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.BooleanParam.setValue");
+        return {};
+}
+
+static PyObject *Sbk_BooleanParamFunc_setValueAtTime(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BooleanParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BOOLEANPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setValueAtTime", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BooleanParam::setValueAtTime(bool,double)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        overloadId = 0; // setValueAtTime(bool,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BooleanParamFunc_setValueAtTime_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setValueAtTime(bool,double)
+            cppSelf->setValueAtTime(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BooleanParamFunc_setValueAtTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BooleanParam.setValueAtTime");
+        return {};
+}
+
+
+static const char *Sbk_BooleanParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_BooleanParam_methods[] = {
+    {"addAsDependencyOf", reinterpret_cast<PyCFunction>(Sbk_BooleanParamFunc_addAsDependencyOf), METH_VARARGS},
+    {"get", reinterpret_cast<PyCFunction>(Sbk_BooleanParamFunc_get), METH_VARARGS},
+    {"getDefaultValue", reinterpret_cast<PyCFunction>(Sbk_BooleanParamFunc_getDefaultValue), METH_NOARGS},
+    {"getValue", reinterpret_cast<PyCFunction>(Sbk_BooleanParamFunc_getValue), METH_NOARGS},
+    {"getValueAtTime", reinterpret_cast<PyCFunction>(Sbk_BooleanParamFunc_getValueAtTime), METH_O},
+    {"restoreDefaultValue", reinterpret_cast<PyCFunction>(Sbk_BooleanParamFunc_restoreDefaultValue), METH_NOARGS},
+    {"set", reinterpret_cast<PyCFunction>(Sbk_BooleanParamFunc_set), METH_VARARGS},
+    {"setDefaultValue", reinterpret_cast<PyCFunction>(Sbk_BooleanParamFunc_setDefaultValue), METH_O},
+    {"setValue", reinterpret_cast<PyCFunction>(Sbk_BooleanParamFunc_setValue), METH_O},
+    {"setValueAtTime", reinterpret_cast<PyCFunction>(Sbk_BooleanParamFunc_setValueAtTime), METH_VARARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_BooleanParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::BooleanParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BOOLEANPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<BooleanParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_BooleanParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_BooleanParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_BooleanParam_Type = nullptr;
+static SbkObjectType *Sbk_BooleanParam_TypeF(void)
+{
+    return _Sbk_BooleanParam_Type;
+}
+
+static PyType_Slot Sbk_BooleanParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_BooleanParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_BooleanParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_BooleanParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_BooleanParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_BooleanParam_spec = {
+    "1:NatronEngine.BooleanParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_BooleanParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_BooleanParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::BooleanParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void BooleanParam_PythonToCpp_BooleanParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_BooleanParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_BooleanParam_PythonToCpp_BooleanParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_BooleanParam_TypeF())))
+        return BooleanParam_PythonToCpp_BooleanParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *BooleanParam_PTR_CppToPython_BooleanParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::BooleanParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_BooleanParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *BooleanParam_SignatureStrings[] = {
+    "NatronEngine.BooleanParam.addAsDependencyOf(self,fromExprDimension:int,param:NatronEngine.Param,thisDimension:int)->bool",
+    "1:NatronEngine.BooleanParam.get(self)->bool",
+    "0:NatronEngine.BooleanParam.get(self,frame:double)->bool",
+    "NatronEngine.BooleanParam.getDefaultValue(self)->bool",
+    "NatronEngine.BooleanParam.getValue(self)->bool",
+    "NatronEngine.BooleanParam.getValueAtTime(self,time:double)->bool",
+    "NatronEngine.BooleanParam.restoreDefaultValue(self)",
+    "1:NatronEngine.BooleanParam.set(self,x:bool)",
+    "0:NatronEngine.BooleanParam.set(self,x:bool,frame:double)",
+    "NatronEngine.BooleanParam.setDefaultValue(self,value:bool)",
+    "NatronEngine.BooleanParam.setValue(self,value:bool)",
+    "NatronEngine.BooleanParam.setValueAtTime(self,value:bool,time:double)",
+    nullptr}; // Sentinel
+
+void init_BooleanParam(PyObject *module)
+{
+    _Sbk_BooleanParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "BooleanParam",
+        "BooleanParam*",
+        &Sbk_BooleanParam_spec,
+        &Shiboken::callCppDestructor< ::BooleanParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_BooleanParam_Type);
+    InitSignatureStrings(pyType, BooleanParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_BooleanParam_Type), Sbk_BooleanParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_BOOLEANPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_BooleanParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_BooleanParam_TypeF(),
+        BooleanParam_PythonToCpp_BooleanParam_PTR,
+        is_BooleanParam_PythonToCpp_BooleanParam_PTR_Convertible,
+        BooleanParam_PTR_CppToPython_BooleanParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "BooleanParam");
+    Shiboken::Conversions::registerConverterName(converter, "BooleanParam*");
+    Shiboken::Conversions::registerConverterName(converter, "BooleanParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::BooleanParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::BooleanParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_BooleanParam_TypeF(), &Sbk_BooleanParam_typeDiscovery);
+
+
+    BooleanParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/booleanparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/booleanparam_wrapper.h
@@ -1,0 +1,60 @@
+#ifndef SBK_BOOLEANPARAMWRAPPER_H
+#define SBK_BOOLEANPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class BooleanParamWrapper : public BooleanParam
+{
+public:
+    ~BooleanParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_ANIMATEDPARAMWRAPPER_H
+#  define SBK_ANIMATEDPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AnimatedParamWrapper : public AnimatedParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { AnimatedParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~AnimatedParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_ANIMATEDPARAMWRAPPER_H
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_BOOLEANPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/boolnodecreationproperty_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/boolnodecreationproperty_wrapper.cpp
@@ -1,0 +1,467 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "boolnodecreationproperty_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void BoolNodeCreationPropertyWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void BoolNodeCreationPropertyWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+BoolNodeCreationPropertyWrapper::BoolNodeCreationPropertyWrapper(bool value) : BoolNodeCreationProperty(value)
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+BoolNodeCreationPropertyWrapper::BoolNodeCreationPropertyWrapper(const std::vector<bool > & values) : BoolNodeCreationProperty(values)
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+BoolNodeCreationPropertyWrapper::~BoolNodeCreationPropertyWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_BoolNodeCreationProperty_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::BoolNodeCreationProperty >()))
+        return -1;
+
+    ::BoolNodeCreationPropertyWrapper *cptr{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.BoolNodeCreationProperty(): too many arguments");
+        return -1;
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:BoolNodeCreationProperty", &(pyArgs[0])))
+        return -1;
+
+
+    // Overloaded function decisor
+    // 0: BoolNodeCreationProperty::BoolNodeCreationProperty(bool)
+    // 1: BoolNodeCreationProperty::BoolNodeCreationProperty(std::vector<bool>)
+    if (numArgs == 0) {
+        overloadId = 1; // BoolNodeCreationProperty(std::vector<bool>)
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[0])))) {
+        overloadId = 0; // BoolNodeCreationProperty(bool)
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_BOOL_IDX], (pyArgs[0])))) {
+        overloadId = 1; // BoolNodeCreationProperty(std::vector<bool>)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BoolNodeCreationProperty_Init_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // BoolNodeCreationProperty(bool value)
+        {
+            bool cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // BoolNodeCreationProperty(bool)
+                cptr = new ::BoolNodeCreationPropertyWrapper(cppArg0);
+            }
+            break;
+        }
+        case 1: // BoolNodeCreationProperty(const std::vector<bool > & values)
+        {
+            if (kwds) {
+                PyObject *keyName = nullptr;
+                PyObject *value = nullptr;
+                keyName = Py_BuildValue("s","values");
+                if (PyDict_Contains(kwds, keyName)) {
+                    value = PyDict_GetItem(kwds, keyName);
+                    if (value && pyArgs[0]) {
+                        PyErr_SetString(PyExc_TypeError, "NatronEngine.BoolNodeCreationProperty(): got multiple values for keyword argument 'values'.");
+                        return -1;
+                    }
+                    if (value) {
+                        pyArgs[0] = value;
+                        if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_BOOL_IDX], (pyArgs[0]))))
+                            goto Sbk_BoolNodeCreationProperty_Init_TypeError;
+                    }
+                }
+            }
+            ::std::vector<bool > cppArg0;
+            if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // BoolNodeCreationProperty(std::vector<bool>)
+                cptr = new ::BoolNodeCreationPropertyWrapper(cppArg0);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::BoolNodeCreationProperty >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    if (!cptr) goto Sbk_BoolNodeCreationProperty_Init_TypeError;
+
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    Shiboken::Object::setHasCppWrapper(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+
+    Sbk_BoolNodeCreationProperty_Init_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BoolNodeCreationProperty");
+        return -1;
+}
+
+static PyObject *Sbk_BoolNodeCreationPropertyFunc_getValues(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BoolNodeCreationProperty *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BOOLNODECREATIONPROPERTY_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getValues()const
+            const std::vector<bool > & cppResult = const_cast<const ::BoolNodeCreationProperty *>(cppSelf)->getValues();
+            pyResult = Shiboken::Conversions::copyToPython(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_BOOL_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_BoolNodeCreationPropertyFunc_setValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::BoolNodeCreationProperty *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BOOLNODECREATIONPROPERTY_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.BoolNodeCreationProperty.setValue(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.BoolNodeCreationProperty.setValue(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setValue", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: BoolNodeCreationProperty::setValue(bool,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setValue(bool,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setValue(bool,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_BoolNodeCreationPropertyFunc_setValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","index");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.BoolNodeCreationProperty.setValue(): got multiple values for keyword argument 'index'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_BoolNodeCreationPropertyFunc_setValue_TypeError;
+                }
+            }
+        }
+        bool cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setValue(bool,int)
+            cppSelf->setValue(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_BoolNodeCreationPropertyFunc_setValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.BoolNodeCreationProperty.setValue");
+        return {};
+}
+
+
+static const char *Sbk_BoolNodeCreationProperty_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_BoolNodeCreationProperty_methods[] = {
+    {"getValues", reinterpret_cast<PyCFunction>(Sbk_BoolNodeCreationPropertyFunc_getValues), METH_NOARGS},
+    {"setValue", reinterpret_cast<PyCFunction>(Sbk_BoolNodeCreationPropertyFunc_setValue), METH_VARARGS|METH_KEYWORDS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_BoolNodeCreationProperty_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::BoolNodeCreationProperty *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BOOLNODECREATIONPROPERTY_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<BoolNodeCreationPropertyWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_BoolNodeCreationProperty_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_BoolNodeCreationProperty_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_BoolNodeCreationProperty_Type = nullptr;
+static SbkObjectType *Sbk_BoolNodeCreationProperty_TypeF(void)
+{
+    return _Sbk_BoolNodeCreationProperty_Type;
+}
+
+static PyType_Slot Sbk_BoolNodeCreationProperty_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_BoolNodeCreationProperty_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_BoolNodeCreationProperty_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_BoolNodeCreationProperty_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_BoolNodeCreationProperty_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_BoolNodeCreationProperty_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_BoolNodeCreationProperty_spec = {
+    "1:NatronEngine.BoolNodeCreationProperty",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_BoolNodeCreationProperty_slots
+};
+
+} //extern "C"
+
+static void *Sbk_BoolNodeCreationProperty_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::NodeCreationProperty >()))
+        return dynamic_cast< ::BoolNodeCreationProperty *>(reinterpret_cast< ::NodeCreationProperty *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void BoolNodeCreationProperty_PythonToCpp_BoolNodeCreationProperty_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_BoolNodeCreationProperty_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_BoolNodeCreationProperty_PythonToCpp_BoolNodeCreationProperty_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_BoolNodeCreationProperty_TypeF())))
+        return BoolNodeCreationProperty_PythonToCpp_BoolNodeCreationProperty_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *BoolNodeCreationProperty_PTR_CppToPython_BoolNodeCreationProperty(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::BoolNodeCreationProperty *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_BoolNodeCreationProperty_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *BoolNodeCreationProperty_SignatureStrings[] = {
+    "1:NatronEngine.BoolNodeCreationProperty(self,value:bool)",
+    "0:NatronEngine.BoolNodeCreationProperty(self,values:std.vector[bool]=std.vector< bool >())",
+    "NatronEngine.BoolNodeCreationProperty.getValues(self)->std.vector[bool]",
+    "NatronEngine.BoolNodeCreationProperty.setValue(self,value:bool,index:int=0)",
+    nullptr}; // Sentinel
+
+void init_BoolNodeCreationProperty(PyObject *module)
+{
+    _Sbk_BoolNodeCreationProperty_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "BoolNodeCreationProperty",
+        "BoolNodeCreationProperty*",
+        &Sbk_BoolNodeCreationProperty_spec,
+        &Shiboken::callCppDestructor< ::BoolNodeCreationProperty >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_NODECREATIONPROPERTY_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_BoolNodeCreationProperty_Type);
+    InitSignatureStrings(pyType, BoolNodeCreationProperty_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_BoolNodeCreationProperty_Type), Sbk_BoolNodeCreationProperty_PropertyStrings);
+    SbkNatronEngineTypes[SBK_BOOLNODECREATIONPROPERTY_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_BoolNodeCreationProperty_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_BoolNodeCreationProperty_TypeF(),
+        BoolNodeCreationProperty_PythonToCpp_BoolNodeCreationProperty_PTR,
+        is_BoolNodeCreationProperty_PythonToCpp_BoolNodeCreationProperty_PTR_Convertible,
+        BoolNodeCreationProperty_PTR_CppToPython_BoolNodeCreationProperty);
+
+    Shiboken::Conversions::registerConverterName(converter, "BoolNodeCreationProperty");
+    Shiboken::Conversions::registerConverterName(converter, "BoolNodeCreationProperty*");
+    Shiboken::Conversions::registerConverterName(converter, "BoolNodeCreationProperty&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::BoolNodeCreationProperty).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::BoolNodeCreationPropertyWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_BoolNodeCreationProperty_TypeF(), &Sbk_BoolNodeCreationProperty_typeDiscovery);
+
+
+    BoolNodeCreationPropertyWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/boolnodecreationproperty_wrapper.h
+++ b/Engine/Qt5/NatronEngine/boolnodecreationproperty_wrapper.h
@@ -1,0 +1,43 @@
+#ifndef SBK_BOOLNODECREATIONPROPERTYWRAPPER_H
+#define SBK_BOOLNODECREATIONPROPERTYWRAPPER_H
+
+#include <PyAppInstance.h>
+
+
+// Extra includes
+#include <vector>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class BoolNodeCreationPropertyWrapper : public BoolNodeCreationProperty
+{
+public:
+    BoolNodeCreationPropertyWrapper(bool value);
+    BoolNodeCreationPropertyWrapper(const std::vector<bool > & values = std::vector< bool >());
+    ~BoolNodeCreationPropertyWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_NODECREATIONPROPERTYWRAPPER_H
+#  define SBK_NODECREATIONPROPERTYWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class NodeCreationPropertyWrapper : public NodeCreationProperty
+{
+public:
+    NodeCreationPropertyWrapper();
+    ~NodeCreationPropertyWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_NODECREATIONPROPERTYWRAPPER_H
+
+#endif // SBK_BOOLNODECREATIONPROPERTYWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/buttonparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/buttonparam_wrapper.cpp
@@ -1,0 +1,263 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "buttonparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void ButtonParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void ButtonParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+ButtonParamWrapper::~ButtonParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_ButtonParamFunc_trigger(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ButtonParamWrapper *>(reinterpret_cast< ::ButtonParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BUTTONPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // trigger()
+            cppSelf->trigger();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+
+static const char *Sbk_ButtonParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_ButtonParam_methods[] = {
+    {"trigger", reinterpret_cast<PyCFunction>(Sbk_ButtonParamFunc_trigger), METH_NOARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_ButtonParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::ButtonParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_BUTTONPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<ButtonParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_ButtonParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_ButtonParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_ButtonParam_Type = nullptr;
+static SbkObjectType *Sbk_ButtonParam_TypeF(void)
+{
+    return _Sbk_ButtonParam_Type;
+}
+
+static PyType_Slot Sbk_ButtonParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_ButtonParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_ButtonParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_ButtonParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_ButtonParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_ButtonParam_spec = {
+    "1:NatronEngine.ButtonParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_ButtonParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_ButtonParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::ButtonParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void ButtonParam_PythonToCpp_ButtonParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_ButtonParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_ButtonParam_PythonToCpp_ButtonParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_ButtonParam_TypeF())))
+        return ButtonParam_PythonToCpp_ButtonParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *ButtonParam_PTR_CppToPython_ButtonParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::ButtonParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_ButtonParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *ButtonParam_SignatureStrings[] = {
+    "NatronEngine.ButtonParam.trigger(self)",
+    nullptr}; // Sentinel
+
+void init_ButtonParam(PyObject *module)
+{
+    _Sbk_ButtonParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "ButtonParam",
+        "ButtonParam*",
+        &Sbk_ButtonParam_spec,
+        &Shiboken::callCppDestructor< ::ButtonParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_ButtonParam_Type);
+    InitSignatureStrings(pyType, ButtonParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_ButtonParam_Type), Sbk_ButtonParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_BUTTONPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_ButtonParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_ButtonParam_TypeF(),
+        ButtonParam_PythonToCpp_ButtonParam_PTR,
+        is_ButtonParam_PythonToCpp_ButtonParam_PTR_Convertible,
+        ButtonParam_PTR_CppToPython_ButtonParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "ButtonParam");
+    Shiboken::Conversions::registerConverterName(converter, "ButtonParam*");
+    Shiboken::Conversions::registerConverterName(converter, "ButtonParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::ButtonParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::ButtonParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_ButtonParam_TypeF(), &Sbk_ButtonParam_typeDiscovery);
+
+
+    ButtonParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/buttonparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/buttonparam_wrapper.h
@@ -1,0 +1,42 @@
+#ifndef SBK_BUTTONPARAMWRAPPER_H
+#define SBK_BUTTONPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ButtonParamWrapper : public ButtonParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { ButtonParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ButtonParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_BUTTONPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/choiceparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/choiceparam_wrapper.cpp
@@ -1,0 +1,967 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "choiceparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void ChoiceParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void ChoiceParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+ChoiceParamWrapper::~ChoiceParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_ChoiceParamFunc_addAsDependencyOf(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ChoiceParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "addAsDependencyOf", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ChoiceParam::addAsDependencyOf(int,Param*,int)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+        overloadId = 0; // addAsDependencyOf(int,Param*,int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ChoiceParamFunc_addAsDependencyOf_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        if (!Shiboken::Object::isValid(pyArgs[1]))
+            return {};
+        ::Param *cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        int cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // addAsDependencyOf(int,Param*,int)
+            int cppResult = cppSelf->addAsDependencyOf(cppArg0, cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ChoiceParamFunc_addAsDependencyOf_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ChoiceParam.addAsDependencyOf");
+        return {};
+}
+
+static PyObject *Sbk_ChoiceParamFunc_addOption(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ChoiceParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "addOption", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ChoiceParam::addOption(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // addOption(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ChoiceParamFunc_addOption_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // addOption(QString,QString)
+            cppSelf->addOption(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ChoiceParamFunc_addOption_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ChoiceParam.addOption");
+        return {};
+}
+
+static PyObject *Sbk_ChoiceParamFunc_get(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ChoiceParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "get", 0, 1, &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ChoiceParam::get()const
+    // 1: ChoiceParam::get(double)const
+    if (numArgs == 0) {
+        overloadId = 0; // get()const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        overloadId = 1; // get(double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ChoiceParamFunc_get_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // get() const
+        {
+
+            if (!PyErr_Occurred()) {
+                // get()const
+                int cppResult = const_cast<const ::ChoiceParam *>(cppSelf)->get();
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+            }
+            break;
+        }
+        case 1: // get(double frame) const
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // get(double)const
+                int cppResult = const_cast<const ::ChoiceParam *>(cppSelf)->get(cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ChoiceParamFunc_get_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ChoiceParam.get");
+        return {};
+}
+
+static PyObject *Sbk_ChoiceParamFunc_getDefaultValue(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ChoiceParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getDefaultValue()const
+            int cppResult = const_cast<const ::ChoiceParam *>(cppSelf)->getDefaultValue();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ChoiceParamFunc_getNumOptions(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ChoiceParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getNumOptions()const
+            int cppResult = const_cast<const ::ChoiceParam *>(cppSelf)->getNumOptions();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ChoiceParamFunc_getOption(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ChoiceParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: ChoiceParam::getOption(int)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // getOption(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ChoiceParamFunc_getOption_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getOption(int)const
+            QString cppResult = const_cast<const ::ChoiceParam *>(cppSelf)->getOption(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ChoiceParamFunc_getOption_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ChoiceParam.getOption");
+        return {};
+}
+
+static PyObject *Sbk_ChoiceParamFunc_getOptions(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ChoiceParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getOptions()const
+            QStringList cppResult = const_cast<const ::ChoiceParam *>(cppSelf)->getOptions();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRINGLIST_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ChoiceParamFunc_getValue(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ChoiceParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getValue()const
+            int cppResult = const_cast<const ::ChoiceParam *>(cppSelf)->getValue();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ChoiceParamFunc_getValueAtTime(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ChoiceParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: ChoiceParam::getValueAtTime(double)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArg)))) {
+        overloadId = 0; // getValueAtTime(double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ChoiceParamFunc_getValueAtTime_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getValueAtTime(double)const
+            int cppResult = const_cast<const ::ChoiceParam *>(cppSelf)->getValueAtTime(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ChoiceParamFunc_getValueAtTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ChoiceParam.getValueAtTime");
+        return {};
+}
+
+static PyObject *Sbk_ChoiceParamFunc_restoreDefaultValue(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ChoiceParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // restoreDefaultValue()
+            cppSelf->restoreDefaultValue();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_ChoiceParamFunc_set(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ChoiceParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "set", 1, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ChoiceParam::set(QString)
+    // 1: ChoiceParam::set(int)
+    // 2: ChoiceParam::set(int,double)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 1; // set(int)
+        } else if (numArgs == 2
+            && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+            overloadId = 2; // set(int,double)
+        }
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))) {
+        overloadId = 0; // set(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ChoiceParamFunc_set_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // set(const QString & label)
+        {
+            ::QString cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // set(QString)
+                cppSelf->set(cppArg0);
+            }
+            break;
+        }
+        case 1: // set(int x)
+        {
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // set(int)
+                cppSelf->set(cppArg0);
+            }
+            break;
+        }
+        case 2: // set(int x, double frame)
+        {
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+
+            if (!PyErr_Occurred()) {
+                // set(int,double)
+                cppSelf->set(cppArg0, cppArg1);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ChoiceParamFunc_set_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ChoiceParam.set");
+        return {};
+}
+
+static PyObject *Sbk_ChoiceParamFunc_setDefaultValue(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ChoiceParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: ChoiceParam::setDefaultValue(QString)
+    // 1: ChoiceParam::setDefaultValue(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 1; // setDefaultValue(int)
+    } else if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setDefaultValue(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ChoiceParamFunc_setDefaultValue_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // setDefaultValue(const QString & value)
+        {
+            ::QString cppArg0;
+            pythonToCpp(pyArg, &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // setDefaultValue(QString)
+                cppSelf->setDefaultValue(cppArg0);
+            }
+            break;
+        }
+        case 1: // setDefaultValue(int value)
+        {
+            int cppArg0;
+            pythonToCpp(pyArg, &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // setDefaultValue(int)
+                cppSelf->setDefaultValue(cppArg0);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ChoiceParamFunc_setDefaultValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ChoiceParam.setDefaultValue");
+        return {};
+}
+
+static PyObject *Sbk_ChoiceParamFunc_setOptions(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ChoiceParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: ChoiceParam::setOptions(std::list<std::pair<QString,QString> >)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_STD_PAIR_QSTRING_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setOptions(std::list<std::pair<QString,QString> >)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ChoiceParamFunc_setOptions_TypeError;
+
+    // Call function/method
+    {
+        ::std::list<std::pair< QString,QString > > cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setOptions(std::list<std::pair<QString,QString> >)
+            cppSelf->setOptions(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ChoiceParamFunc_setOptions_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ChoiceParam.setOptions");
+        return {};
+}
+
+static PyObject *Sbk_ChoiceParamFunc_setValue(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ChoiceParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: ChoiceParam::setValue(QString)
+    // 1: ChoiceParam::setValue(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 1; // setValue(int)
+    } else if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setValue(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ChoiceParamFunc_setValue_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // setValue(const QString & label)
+        {
+            ::QString cppArg0;
+            pythonToCpp(pyArg, &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // setValue(QString)
+                cppSelf->setValue(cppArg0);
+            }
+            break;
+        }
+        case 1: // setValue(int value)
+        {
+            int cppArg0;
+            pythonToCpp(pyArg, &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // setValue(int)
+                cppSelf->setValue(cppArg0);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ChoiceParamFunc_setValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ChoiceParam.setValue");
+        return {};
+}
+
+static PyObject *Sbk_ChoiceParamFunc_setValueAtTime(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ChoiceParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setValueAtTime", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ChoiceParam::setValueAtTime(int,double)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        overloadId = 0; // setValueAtTime(int,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ChoiceParamFunc_setValueAtTime_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setValueAtTime(int,double)
+            cppSelf->setValueAtTime(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ChoiceParamFunc_setValueAtTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ChoiceParam.setValueAtTime");
+        return {};
+}
+
+
+static const char *Sbk_ChoiceParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_ChoiceParam_methods[] = {
+    {"addAsDependencyOf", reinterpret_cast<PyCFunction>(Sbk_ChoiceParamFunc_addAsDependencyOf), METH_VARARGS},
+    {"addOption", reinterpret_cast<PyCFunction>(Sbk_ChoiceParamFunc_addOption), METH_VARARGS},
+    {"get", reinterpret_cast<PyCFunction>(Sbk_ChoiceParamFunc_get), METH_VARARGS},
+    {"getDefaultValue", reinterpret_cast<PyCFunction>(Sbk_ChoiceParamFunc_getDefaultValue), METH_NOARGS},
+    {"getNumOptions", reinterpret_cast<PyCFunction>(Sbk_ChoiceParamFunc_getNumOptions), METH_NOARGS},
+    {"getOption", reinterpret_cast<PyCFunction>(Sbk_ChoiceParamFunc_getOption), METH_O},
+    {"getOptions", reinterpret_cast<PyCFunction>(Sbk_ChoiceParamFunc_getOptions), METH_NOARGS},
+    {"getValue", reinterpret_cast<PyCFunction>(Sbk_ChoiceParamFunc_getValue), METH_NOARGS},
+    {"getValueAtTime", reinterpret_cast<PyCFunction>(Sbk_ChoiceParamFunc_getValueAtTime), METH_O},
+    {"restoreDefaultValue", reinterpret_cast<PyCFunction>(Sbk_ChoiceParamFunc_restoreDefaultValue), METH_NOARGS},
+    {"set", reinterpret_cast<PyCFunction>(Sbk_ChoiceParamFunc_set), METH_VARARGS},
+    {"setDefaultValue", reinterpret_cast<PyCFunction>(Sbk_ChoiceParamFunc_setDefaultValue), METH_O},
+    {"setOptions", reinterpret_cast<PyCFunction>(Sbk_ChoiceParamFunc_setOptions), METH_O},
+    {"setValue", reinterpret_cast<PyCFunction>(Sbk_ChoiceParamFunc_setValue), METH_O},
+    {"setValueAtTime", reinterpret_cast<PyCFunction>(Sbk_ChoiceParamFunc_setValueAtTime), METH_VARARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_ChoiceParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::ChoiceParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<ChoiceParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_ChoiceParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_ChoiceParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_ChoiceParam_Type = nullptr;
+static SbkObjectType *Sbk_ChoiceParam_TypeF(void)
+{
+    return _Sbk_ChoiceParam_Type;
+}
+
+static PyType_Slot Sbk_ChoiceParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_ChoiceParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_ChoiceParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_ChoiceParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_ChoiceParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_ChoiceParam_spec = {
+    "1:NatronEngine.ChoiceParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_ChoiceParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_ChoiceParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::ChoiceParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void ChoiceParam_PythonToCpp_ChoiceParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_ChoiceParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_ChoiceParam_PythonToCpp_ChoiceParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_ChoiceParam_TypeF())))
+        return ChoiceParam_PythonToCpp_ChoiceParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *ChoiceParam_PTR_CppToPython_ChoiceParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::ChoiceParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_ChoiceParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *ChoiceParam_SignatureStrings[] = {
+    "NatronEngine.ChoiceParam.addAsDependencyOf(self,fromExprDimension:int,param:NatronEngine.Param,thisDimension:int)->int",
+    "NatronEngine.ChoiceParam.addOption(self,option:QString,help:QString)",
+    "1:NatronEngine.ChoiceParam.get(self)->int",
+    "0:NatronEngine.ChoiceParam.get(self,frame:double)->int",
+    "NatronEngine.ChoiceParam.getDefaultValue(self)->int",
+    "NatronEngine.ChoiceParam.getNumOptions(self)->int",
+    "NatronEngine.ChoiceParam.getOption(self,index:int)->QString",
+    "NatronEngine.ChoiceParam.getOptions(self)->QStringList",
+    "NatronEngine.ChoiceParam.getValue(self)->int",
+    "NatronEngine.ChoiceParam.getValueAtTime(self,time:double)->int",
+    "NatronEngine.ChoiceParam.restoreDefaultValue(self)",
+    "2:NatronEngine.ChoiceParam.set(self,label:QString)",
+    "1:NatronEngine.ChoiceParam.set(self,x:int)",
+    "0:NatronEngine.ChoiceParam.set(self,x:int,frame:double)",
+    "1:NatronEngine.ChoiceParam.setDefaultValue(self,value:QString)",
+    "0:NatronEngine.ChoiceParam.setDefaultValue(self,value:int)",
+    "NatronEngine.ChoiceParam.setOptions(self,options:std.list[std.pair[QString, QString]])",
+    "1:NatronEngine.ChoiceParam.setValue(self,label:QString)",
+    "0:NatronEngine.ChoiceParam.setValue(self,value:int)",
+    "NatronEngine.ChoiceParam.setValueAtTime(self,value:int,time:double)",
+    nullptr}; // Sentinel
+
+void init_ChoiceParam(PyObject *module)
+{
+    _Sbk_ChoiceParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "ChoiceParam",
+        "ChoiceParam*",
+        &Sbk_ChoiceParam_spec,
+        &Shiboken::callCppDestructor< ::ChoiceParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_ChoiceParam_Type);
+    InitSignatureStrings(pyType, ChoiceParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_ChoiceParam_Type), Sbk_ChoiceParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_ChoiceParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_ChoiceParam_TypeF(),
+        ChoiceParam_PythonToCpp_ChoiceParam_PTR,
+        is_ChoiceParam_PythonToCpp_ChoiceParam_PTR_Convertible,
+        ChoiceParam_PTR_CppToPython_ChoiceParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "ChoiceParam");
+    Shiboken::Conversions::registerConverterName(converter, "ChoiceParam*");
+    Shiboken::Conversions::registerConverterName(converter, "ChoiceParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::ChoiceParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::ChoiceParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_ChoiceParam_TypeF(), &Sbk_ChoiceParam_typeDiscovery);
+
+
+    ChoiceParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/choiceparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/choiceparam_wrapper.h
@@ -1,0 +1,62 @@
+#ifndef SBK_CHOICEPARAMWRAPPER_H
+#define SBK_CHOICEPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <list>
+#include <utility>
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ChoiceParamWrapper : public ChoiceParam
+{
+public:
+    ~ChoiceParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_ANIMATEDPARAMWRAPPER_H
+#  define SBK_ANIMATEDPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AnimatedParamWrapper : public AnimatedParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { AnimatedParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~AnimatedParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_ANIMATEDPARAMWRAPPER_H
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_CHOICEPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/colorparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/colorparam_wrapper.cpp
@@ -1,0 +1,1609 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "colorparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void ColorParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void ColorParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+ColorParamWrapper::~ColorParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_ColorParamFunc_addAsDependencyOf(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "addAsDependencyOf", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ColorParam::addAsDependencyOf(int,Param*,int)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+        overloadId = 0; // addAsDependencyOf(int,Param*,int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_addAsDependencyOf_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        if (!Shiboken::Object::isValid(pyArgs[1]))
+            return {};
+        ::Param *cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        int cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // addAsDependencyOf(int,Param*,int)
+            double cppResult = cppSelf->addAsDependencyOf(cppArg0, cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ColorParamFunc_addAsDependencyOf_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ColorParam.addAsDependencyOf");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_get(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "get", 0, 1, &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ColorParam::get()const
+    // 1: ColorParam::get(double)const
+    if (numArgs == 0) {
+        overloadId = 0; // get()const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        overloadId = 1; // get(double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_get_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // get() const
+        {
+
+            if (!PyErr_Occurred()) {
+                // get()const
+                ColorTuple* cppResult = new ColorTuple(const_cast<const ::ColorParam *>(cppSelf)->get());
+                pyResult = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_COLORTUPLE_IDX]), cppResult, true, true);
+            }
+            break;
+        }
+        case 1: // get(double frame) const
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // get(double)const
+                ColorTuple* cppResult = new ColorTuple(const_cast<const ::ColorParam *>(cppSelf)->get(cppArg0));
+                pyResult = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_COLORTUPLE_IDX]), cppResult, true, true);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ColorParamFunc_get_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ColorParam.get");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_getDefaultValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.getDefaultValue(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getDefaultValue", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ColorParam::getDefaultValue(int)const
+    if (numArgs == 0) {
+        overloadId = 0; // getDefaultValue(int)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // getDefaultValue(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_getDefaultValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.getDefaultValue(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_ColorParamFunc_getDefaultValue_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getDefaultValue(int)const
+            double cppResult = const_cast<const ::ColorParam *>(cppSelf)->getDefaultValue(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ColorParamFunc_getDefaultValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ColorParam.getDefaultValue");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_getDisplayMaximum(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: ColorParam::getDisplayMaximum(int)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // getDisplayMaximum(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_getDisplayMaximum_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getDisplayMaximum(int)const
+            double cppResult = const_cast<const ::ColorParam *>(cppSelf)->getDisplayMaximum(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ColorParamFunc_getDisplayMaximum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ColorParam.getDisplayMaximum");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_getDisplayMinimum(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: ColorParam::getDisplayMinimum(int)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // getDisplayMinimum(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_getDisplayMinimum_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getDisplayMinimum(int)const
+            double cppResult = const_cast<const ::ColorParam *>(cppSelf)->getDisplayMinimum(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ColorParamFunc_getDisplayMinimum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ColorParam.getDisplayMinimum");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_getMaximum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.getMaximum(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getMaximum", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ColorParam::getMaximum(int)const
+    if (numArgs == 0) {
+        overloadId = 0; // getMaximum(int)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // getMaximum(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_getMaximum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.getMaximum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_ColorParamFunc_getMaximum_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getMaximum(int)const
+            double cppResult = const_cast<const ::ColorParam *>(cppSelf)->getMaximum(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ColorParamFunc_getMaximum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ColorParam.getMaximum");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_getMinimum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.getMinimum(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getMinimum", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ColorParam::getMinimum(int)const
+    if (numArgs == 0) {
+        overloadId = 0; // getMinimum(int)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // getMinimum(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_getMinimum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.getMinimum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_ColorParamFunc_getMinimum_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getMinimum(int)const
+            double cppResult = const_cast<const ::ColorParam *>(cppSelf)->getMinimum(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ColorParamFunc_getMinimum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ColorParam.getMinimum");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_getValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.getValue(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getValue", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ColorParam::getValue(int)const
+    if (numArgs == 0) {
+        overloadId = 0; // getValue(int)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // getValue(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_getValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.getValue(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_ColorParamFunc_getValue_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getValue(int)const
+            double cppResult = const_cast<const ::ColorParam *>(cppSelf)->getValue(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ColorParamFunc_getValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ColorParam.getValue");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_getValueAtTime(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.getValueAtTime(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.getValueAtTime(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:getValueAtTime", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ColorParam::getValueAtTime(double,int)const
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // getValueAtTime(double,int)const
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // getValueAtTime(double,int)const
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_getValueAtTime_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.getValueAtTime(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ColorParamFunc_getValueAtTime_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // getValueAtTime(double,int)const
+            double cppResult = const_cast<const ::ColorParam *>(cppSelf)->getValueAtTime(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ColorParamFunc_getValueAtTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ColorParam.getValueAtTime");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_restoreDefaultValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.restoreDefaultValue(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:restoreDefaultValue", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ColorParam::restoreDefaultValue(int)
+    if (numArgs == 0) {
+        overloadId = 0; // restoreDefaultValue(int)
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // restoreDefaultValue(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_restoreDefaultValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.restoreDefaultValue(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_ColorParamFunc_restoreDefaultValue_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // restoreDefaultValue(int)
+            cppSelf->restoreDefaultValue(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ColorParamFunc_restoreDefaultValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ColorParam.restoreDefaultValue");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_set(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "set", 4, 5, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3]), &(pyArgs[4])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ColorParam::set(double,double,double,double)
+    // 1: ColorParam::set(double,double,double,double,double)
+    if (numArgs >= 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+        if (numArgs == 4) {
+            overloadId = 0; // set(double,double,double,double)
+        } else if (numArgs == 5
+            && (pythonToCpp[4] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[4])))) {
+            overloadId = 1; // set(double,double,double,double,double)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_set_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // set(double r, double g, double b, double a)
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            double cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            double cppArg3;
+            pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // set(double,double,double,double)
+                cppSelf->set(cppArg0, cppArg1, cppArg2, cppArg3);
+            }
+            break;
+        }
+        case 1: // set(double r, double g, double b, double a, double frame)
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            double cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            double cppArg3;
+            pythonToCpp[3](pyArgs[3], &cppArg3);
+            double cppArg4;
+            pythonToCpp[4](pyArgs[4], &cppArg4);
+
+            if (!PyErr_Occurred()) {
+                // set(double,double,double,double,double)
+                cppSelf->set(cppArg0, cppArg1, cppArg2, cppArg3, cppArg4);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ColorParamFunc_set_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ColorParam.set");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_setDefaultValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setDefaultValue(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setDefaultValue(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setDefaultValue", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ColorParam::setDefaultValue(double,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setDefaultValue(double,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setDefaultValue(double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_setDefaultValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setDefaultValue(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ColorParamFunc_setDefaultValue_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setDefaultValue(double,int)
+            cppSelf->setDefaultValue(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ColorParamFunc_setDefaultValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ColorParam.setDefaultValue");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_setDisplayMaximum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setDisplayMaximum(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setDisplayMaximum(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setDisplayMaximum", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ColorParam::setDisplayMaximum(double,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setDisplayMaximum(double,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setDisplayMaximum(double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_setDisplayMaximum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setDisplayMaximum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ColorParamFunc_setDisplayMaximum_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setDisplayMaximum(double,int)
+            cppSelf->setDisplayMaximum(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ColorParamFunc_setDisplayMaximum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ColorParam.setDisplayMaximum");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_setDisplayMinimum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setDisplayMinimum(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setDisplayMinimum(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setDisplayMinimum", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ColorParam::setDisplayMinimum(double,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setDisplayMinimum(double,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setDisplayMinimum(double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_setDisplayMinimum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setDisplayMinimum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ColorParamFunc_setDisplayMinimum_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setDisplayMinimum(double,int)
+            cppSelf->setDisplayMinimum(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ColorParamFunc_setDisplayMinimum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ColorParam.setDisplayMinimum");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_setMaximum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setMaximum(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setMaximum(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setMaximum", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ColorParam::setMaximum(double,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setMaximum(double,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setMaximum(double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_setMaximum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setMaximum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ColorParamFunc_setMaximum_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setMaximum(double,int)
+            cppSelf->setMaximum(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ColorParamFunc_setMaximum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ColorParam.setMaximum");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_setMinimum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setMinimum(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setMinimum(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setMinimum", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ColorParam::setMinimum(double,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setMinimum(double,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setMinimum(double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_setMinimum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setMinimum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ColorParamFunc_setMinimum_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setMinimum(double,int)
+            cppSelf->setMinimum(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ColorParamFunc_setMinimum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ColorParam.setMinimum");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_setValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setValue(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setValue(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setValue", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ColorParam::setValue(double,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setValue(double,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setValue(double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_setValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setValue(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ColorParamFunc_setValue_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setValue(double,int)
+            cppSelf->setValue(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ColorParamFunc_setValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ColorParam.setValue");
+        return {};
+}
+
+static PyObject *Sbk_ColorParamFunc_setValueAtTime(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 3) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setValueAtTime(): too many arguments");
+        return {};
+    } else if (numArgs < 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setValueAtTime(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOO:setValueAtTime", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ColorParam::setValueAtTime(double,double,int)
+    if (numArgs >= 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        if (numArgs == 2) {
+            overloadId = 0; // setValueAtTime(double,double,int)
+        } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+            overloadId = 0; // setValueAtTime(double,double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ColorParamFunc_setValueAtTime_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ColorParam.setValueAtTime(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2]))))
+                        goto Sbk_ColorParamFunc_setValueAtTime_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        int cppArg2 = 0;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // setValueAtTime(double,double,int)
+            cppSelf->setValueAtTime(cppArg0, cppArg1, cppArg2);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ColorParamFunc_setValueAtTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ColorParam.setValueAtTime");
+        return {};
+}
+
+
+static const char *Sbk_ColorParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_ColorParam_methods[] = {
+    {"addAsDependencyOf", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_addAsDependencyOf), METH_VARARGS},
+    {"get", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_get), METH_VARARGS},
+    {"getDefaultValue", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_getDefaultValue), METH_VARARGS|METH_KEYWORDS},
+    {"getDisplayMaximum", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_getDisplayMaximum), METH_O},
+    {"getDisplayMinimum", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_getDisplayMinimum), METH_O},
+    {"getMaximum", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_getMaximum), METH_VARARGS|METH_KEYWORDS},
+    {"getMinimum", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_getMinimum), METH_VARARGS|METH_KEYWORDS},
+    {"getValue", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_getValue), METH_VARARGS|METH_KEYWORDS},
+    {"getValueAtTime", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_getValueAtTime), METH_VARARGS|METH_KEYWORDS},
+    {"restoreDefaultValue", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_restoreDefaultValue), METH_VARARGS|METH_KEYWORDS},
+    {"set", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_set), METH_VARARGS},
+    {"setDefaultValue", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_setDefaultValue), METH_VARARGS|METH_KEYWORDS},
+    {"setDisplayMaximum", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_setDisplayMaximum), METH_VARARGS|METH_KEYWORDS},
+    {"setDisplayMinimum", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_setDisplayMinimum), METH_VARARGS|METH_KEYWORDS},
+    {"setMaximum", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_setMaximum), METH_VARARGS|METH_KEYWORDS},
+    {"setMinimum", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_setMinimum), METH_VARARGS|METH_KEYWORDS},
+    {"setValue", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_setValue), METH_VARARGS|METH_KEYWORDS},
+    {"setValueAtTime", reinterpret_cast<PyCFunction>(Sbk_ColorParamFunc_setValueAtTime), METH_VARARGS|METH_KEYWORDS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_ColorParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::ColorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<ColorParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_ColorParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_ColorParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_ColorParam_Type = nullptr;
+static SbkObjectType *Sbk_ColorParam_TypeF(void)
+{
+    return _Sbk_ColorParam_Type;
+}
+
+static PyType_Slot Sbk_ColorParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_ColorParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_ColorParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_ColorParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_ColorParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_ColorParam_spec = {
+    "1:NatronEngine.ColorParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_ColorParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_ColorParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::ColorParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void ColorParam_PythonToCpp_ColorParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_ColorParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_ColorParam_PythonToCpp_ColorParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_ColorParam_TypeF())))
+        return ColorParam_PythonToCpp_ColorParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *ColorParam_PTR_CppToPython_ColorParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::ColorParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_ColorParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *ColorParam_SignatureStrings[] = {
+    "NatronEngine.ColorParam.addAsDependencyOf(self,fromExprDimension:int,param:NatronEngine.Param,thisDimension:int)->double",
+    "1:NatronEngine.ColorParam.get(self)->NatronEngine.ColorTuple",
+    "0:NatronEngine.ColorParam.get(self,frame:double)->NatronEngine.ColorTuple",
+    "NatronEngine.ColorParam.getDefaultValue(self,dimension:int=0)->double",
+    "NatronEngine.ColorParam.getDisplayMaximum(self,dimension:int)->double",
+    "NatronEngine.ColorParam.getDisplayMinimum(self,dimension:int)->double",
+    "NatronEngine.ColorParam.getMaximum(self,dimension:int=0)->double",
+    "NatronEngine.ColorParam.getMinimum(self,dimension:int=0)->double",
+    "NatronEngine.ColorParam.getValue(self,dimension:int=0)->double",
+    "NatronEngine.ColorParam.getValueAtTime(self,time:double,dimension:int=0)->double",
+    "NatronEngine.ColorParam.restoreDefaultValue(self,dimension:int=0)",
+    "1:NatronEngine.ColorParam.set(self,r:double,g:double,b:double,a:double)",
+    "0:NatronEngine.ColorParam.set(self,r:double,g:double,b:double,a:double,frame:double)",
+    "NatronEngine.ColorParam.setDefaultValue(self,value:double,dimension:int=0)",
+    "NatronEngine.ColorParam.setDisplayMaximum(self,maximum:double,dimension:int=0)",
+    "NatronEngine.ColorParam.setDisplayMinimum(self,minimum:double,dimension:int=0)",
+    "NatronEngine.ColorParam.setMaximum(self,maximum:double,dimension:int=0)",
+    "NatronEngine.ColorParam.setMinimum(self,minimum:double,dimension:int=0)",
+    "NatronEngine.ColorParam.setValue(self,value:double,dimension:int=0)",
+    "NatronEngine.ColorParam.setValueAtTime(self,value:double,time:double,dimension:int=0)",
+    nullptr}; // Sentinel
+
+void init_ColorParam(PyObject *module)
+{
+    _Sbk_ColorParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "ColorParam",
+        "ColorParam*",
+        &Sbk_ColorParam_spec,
+        &Shiboken::callCppDestructor< ::ColorParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_ColorParam_Type);
+    InitSignatureStrings(pyType, ColorParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_ColorParam_Type), Sbk_ColorParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_COLORPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_ColorParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_ColorParam_TypeF(),
+        ColorParam_PythonToCpp_ColorParam_PTR,
+        is_ColorParam_PythonToCpp_ColorParam_PTR_Convertible,
+        ColorParam_PTR_CppToPython_ColorParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "ColorParam");
+    Shiboken::Conversions::registerConverterName(converter, "ColorParam*");
+    Shiboken::Conversions::registerConverterName(converter, "ColorParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::ColorParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::ColorParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_ColorParam_TypeF(), &Sbk_ColorParam_typeDiscovery);
+
+
+    ColorParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/colorparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/colorparam_wrapper.h
@@ -1,0 +1,60 @@
+#ifndef SBK_COLORPARAMWRAPPER_H
+#define SBK_COLORPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ColorParamWrapper : public ColorParam
+{
+public:
+    ~ColorParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_ANIMATEDPARAMWRAPPER_H
+#  define SBK_ANIMATEDPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AnimatedParamWrapper : public AnimatedParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { AnimatedParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~AnimatedParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_ANIMATEDPARAMWRAPPER_H
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_COLORPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/colortuple_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/colortuple_wrapper.cpp
@@ -1,0 +1,408 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "colortuple_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_ColorTuple_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::ColorTuple >()))
+        return -1;
+
+    ::ColorTuple *cptr{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // ColorTuple()
+            cptr = new ::ColorTuple();
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::ColorTuple >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+}
+
+
+static const char *Sbk_ColorTuple_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_ColorTuple_methods[] = {
+
+    {nullptr, nullptr} // Sentinel
+};
+
+PyObject* Sbk_ColorTupleFunc___getitem__(PyObject *self, Py_ssize_t _i)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ColorTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    // Begin code injection
+    if (_i < 0 || _i >= 4) {
+        PyErr_BadArgument();
+        return 0;
+    } else {
+        double ret;
+        switch (_i) {
+        case 0:
+            ret = cppSelf->r;
+            break;
+        case 1:
+            ret = cppSelf->g;
+            break;
+        case 2:
+            ret = cppSelf->b;
+            break;
+        case 3:
+            ret = cppSelf->a;
+            break;
+
+        }
+        return  Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret);
+    }
+
+    // End of code injection
+
+}
+
+static PyObject *Sbk_ColorTuple_get_r(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::ColorTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppSelf->r);
+    return pyOut;
+}
+static int Sbk_ColorTuple_set_r(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::ColorTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'r' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'r', 'double' or convertible type expected");
+        return -1;
+    }
+
+    double& cppOut_ptr = cppSelf->r;
+    pythonToCpp(pyIn, &cppOut_ptr);
+
+    return 0;
+}
+
+static PyObject *Sbk_ColorTuple_get_g(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::ColorTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppSelf->g);
+    return pyOut;
+}
+static int Sbk_ColorTuple_set_g(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::ColorTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'g' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'g', 'double' or convertible type expected");
+        return -1;
+    }
+
+    double& cppOut_ptr = cppSelf->g;
+    pythonToCpp(pyIn, &cppOut_ptr);
+
+    return 0;
+}
+
+static PyObject *Sbk_ColorTuple_get_b(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::ColorTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppSelf->b);
+    return pyOut;
+}
+static int Sbk_ColorTuple_set_b(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::ColorTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'b' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'b', 'double' or convertible type expected");
+        return -1;
+    }
+
+    double& cppOut_ptr = cppSelf->b;
+    pythonToCpp(pyIn, &cppOut_ptr);
+
+    return 0;
+}
+
+static PyObject *Sbk_ColorTuple_get_a(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::ColorTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppSelf->a);
+    return pyOut;
+}
+static int Sbk_ColorTuple_set_a(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::ColorTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_COLORTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'a' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'a', 'double' or convertible type expected");
+        return -1;
+    }
+
+    double& cppOut_ptr = cppSelf->a;
+    pythonToCpp(pyIn, &cppOut_ptr);
+
+    return 0;
+}
+
+// Getters and Setters for ColorTuple
+static PyGetSetDef Sbk_ColorTuple_getsetlist[] = {
+    {const_cast<char *>("r"), Sbk_ColorTuple_get_r, Sbk_ColorTuple_set_r},
+    {const_cast<char *>("g"), Sbk_ColorTuple_get_g, Sbk_ColorTuple_set_g},
+    {const_cast<char *>("b"), Sbk_ColorTuple_get_b, Sbk_ColorTuple_set_b},
+    {const_cast<char *>("a"), Sbk_ColorTuple_get_a, Sbk_ColorTuple_set_a},
+    {nullptr} // Sentinel
+};
+
+} // extern "C"
+
+static int Sbk_ColorTuple_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_ColorTuple_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_ColorTuple_Type = nullptr;
+static SbkObjectType *Sbk_ColorTuple_TypeF(void)
+{
+    return _Sbk_ColorTuple_Type;
+}
+
+static PyType_Slot Sbk_ColorTuple_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    nullptr},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_ColorTuple_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_ColorTuple_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_ColorTuple_methods)},
+    {Py_tp_getset,      reinterpret_cast<void *>(Sbk_ColorTuple_getsetlist)},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_ColorTuple_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    // type supports sequence protocol
+    {Py_sq_item, (void *)&Sbk_ColorTupleFunc___getitem__},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_ColorTuple_spec = {
+    "1:NatronEngine.ColorTuple",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_ColorTuple_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void ColorTuple_PythonToCpp_ColorTuple_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_ColorTuple_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_ColorTuple_PythonToCpp_ColorTuple_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_ColorTuple_TypeF())))
+        return ColorTuple_PythonToCpp_ColorTuple_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *ColorTuple_PTR_CppToPython_ColorTuple(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::ColorTuple *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_ColorTuple_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *ColorTuple_SignatureStrings[] = {
+    "NatronEngine.ColorTuple(self)",
+    nullptr}; // Sentinel
+
+void init_ColorTuple(PyObject *module)
+{
+    _Sbk_ColorTuple_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "ColorTuple",
+        "ColorTuple*",
+        &Sbk_ColorTuple_spec,
+        &Shiboken::callCppDestructor< ::ColorTuple >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_ColorTuple_Type);
+    InitSignatureStrings(pyType, ColorTuple_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_ColorTuple_Type), Sbk_ColorTuple_PropertyStrings);
+    SbkNatronEngineTypes[SBK_COLORTUPLE_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_ColorTuple_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_ColorTuple_TypeF(),
+        ColorTuple_PythonToCpp_ColorTuple_PTR,
+        is_ColorTuple_PythonToCpp_ColorTuple_PTR_Convertible,
+        ColorTuple_PTR_CppToPython_ColorTuple);
+
+    Shiboken::Conversions::registerConverterName(converter, "ColorTuple");
+    Shiboken::Conversions::registerConverterName(converter, "ColorTuple*");
+    Shiboken::Conversions::registerConverterName(converter, "ColorTuple&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::ColorTuple).name());
+
+
+
+}

--- a/Engine/Qt5/NatronEngine/colortuple_wrapper.h
+++ b/Engine/Qt5/NatronEngine/colortuple_wrapper.h
@@ -1,0 +1,7 @@
+#ifndef SBK_COLORTUPLE_H
+#define SBK_COLORTUPLE_H
+
+#include <PyParameter.h>
+
+#endif // SBK_COLORTUPLE_H
+

--- a/Engine/Qt5/NatronEngine/double2dparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/double2dparam_wrapper.cpp
@@ -1,0 +1,494 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "double2dparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void Double2DParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void Double2DParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+Double2DParamWrapper::~Double2DParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_Double2DParamFunc_get(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Double2DParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE2DPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "get", 0, 1, &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::get()const
+    // 1: DoubleParam::get(double)const
+    if (numArgs == 0) {
+        overloadId = 0; // get()const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        overloadId = 1; // get(double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_Double2DParamFunc_get_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // get() const
+        {
+
+            if (!PyErr_Occurred()) {
+                // get()const
+                Double2DTuple* cppResult = new Double2DTuple(const_cast<const ::Double2DParam *>(cppSelf)->get());
+                pyResult = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_DOUBLE2DTUPLE_IDX]), cppResult, true, true);
+            }
+            break;
+        }
+        case 1: // get(double frame) const
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // get(double)const
+                Double2DTuple* cppResult = new Double2DTuple(const_cast<const ::Double2DParam *>(cppSelf)->get(cppArg0));
+                pyResult = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_DOUBLE2DTUPLE_IDX]), cppResult, true, true);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_Double2DParamFunc_get_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Double2DParam.get");
+        return {};
+}
+
+static PyObject *Sbk_Double2DParamFunc_set(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Double2DParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE2DPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "set", 1, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::set(double,double)
+    // 1: DoubleParam::set(double)
+    // 2: Double2DParam::set(double,double,double)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 1; // set(double)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 0; // set(double,double)
+            } else if (numArgs == 3
+                && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+                overloadId = 2; // set(double,double,double)
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_Double2DParamFunc_set_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // set(double x, double y)
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+
+            if (!PyErr_Occurred()) {
+                // set(double,double)
+                cppSelf->set(cppArg0, cppArg1);
+            }
+            break;
+        }
+        case 1: // set(double x)
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // set(double)
+                reinterpret_cast<DoubleParam *>(cppSelf)->set(cppArg0);
+            }
+            break;
+        }
+        case 2: // set(double x, double y, double frame)
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            double cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+
+            if (!PyErr_Occurred()) {
+                // set(double,double,double)
+                cppSelf->set(cppArg0, cppArg1, cppArg2);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_Double2DParamFunc_set_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Double2DParam.set");
+        return {};
+}
+
+static PyObject *Sbk_Double2DParamFunc_setCanAutoFoldDimensions(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Double2DParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE2DPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Double2DParam::setCanAutoFoldDimensions(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setCanAutoFoldDimensions(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_Double2DParamFunc_setCanAutoFoldDimensions_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setCanAutoFoldDimensions(bool)
+            cppSelf->setCanAutoFoldDimensions(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_Double2DParamFunc_setCanAutoFoldDimensions_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Double2DParam.setCanAutoFoldDimensions");
+        return {};
+}
+
+static PyObject *Sbk_Double2DParamFunc_setUsePointInteract(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Double2DParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE2DPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Double2DParam::setUsePointInteract(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setUsePointInteract(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_Double2DParamFunc_setUsePointInteract_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setUsePointInteract(bool)
+            cppSelf->setUsePointInteract(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_Double2DParamFunc_setUsePointInteract_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Double2DParam.setUsePointInteract");
+        return {};
+}
+
+
+static const char *Sbk_Double2DParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_Double2DParam_methods[] = {
+    {"get", reinterpret_cast<PyCFunction>(Sbk_Double2DParamFunc_get), METH_VARARGS},
+    {"set", reinterpret_cast<PyCFunction>(Sbk_Double2DParamFunc_set), METH_VARARGS},
+    {"setCanAutoFoldDimensions", reinterpret_cast<PyCFunction>(Sbk_Double2DParamFunc_setCanAutoFoldDimensions), METH_O},
+    {"setUsePointInteract", reinterpret_cast<PyCFunction>(Sbk_Double2DParamFunc_setUsePointInteract), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_Double2DParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::Double2DParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE2DPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<Double2DParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_Double2DParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_Double2DParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_Double2DParam_Type = nullptr;
+static SbkObjectType *Sbk_Double2DParam_TypeF(void)
+{
+    return _Sbk_Double2DParam_Type;
+}
+
+static PyType_Slot Sbk_Double2DParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_Double2DParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_Double2DParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_Double2DParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_Double2DParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_Double2DParam_spec = {
+    "1:NatronEngine.Double2DParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_Double2DParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_Double2DParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::Double2DParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void Double2DParam_PythonToCpp_Double2DParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_Double2DParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_Double2DParam_PythonToCpp_Double2DParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_Double2DParam_TypeF())))
+        return Double2DParam_PythonToCpp_Double2DParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *Double2DParam_PTR_CppToPython_Double2DParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::Double2DParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_Double2DParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *Double2DParam_SignatureStrings[] = {
+    "1:NatronEngine.Double2DParam.get(self)->NatronEngine.Double2DTuple",
+    "0:NatronEngine.Double2DParam.get(self,frame:double)->NatronEngine.Double2DTuple",
+    "2:NatronEngine.Double2DParam.set(self,x:double,y:double)",
+    "1:NatronEngine.Double2DParam.set(self,x:double)",
+    "0:NatronEngine.Double2DParam.set(self,x:double,y:double,frame:double)",
+    "NatronEngine.Double2DParam.setCanAutoFoldDimensions(self,can:bool)",
+    "NatronEngine.Double2DParam.setUsePointInteract(self,use:bool)",
+    nullptr}; // Sentinel
+
+void init_Double2DParam(PyObject *module)
+{
+    _Sbk_Double2DParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "Double2DParam",
+        "Double2DParam*",
+        &Sbk_Double2DParam_spec,
+        &Shiboken::callCppDestructor< ::Double2DParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_Double2DParam_Type);
+    InitSignatureStrings(pyType, Double2DParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_Double2DParam_Type), Sbk_Double2DParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_DOUBLE2DPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_Double2DParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_Double2DParam_TypeF(),
+        Double2DParam_PythonToCpp_Double2DParam_PTR,
+        is_Double2DParam_PythonToCpp_Double2DParam_PTR_Convertible,
+        Double2DParam_PTR_CppToPython_Double2DParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "Double2DParam");
+    Shiboken::Conversions::registerConverterName(converter, "Double2DParam*");
+    Shiboken::Conversions::registerConverterName(converter, "Double2DParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Double2DParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Double2DParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_Double2DParam_TypeF(), &Sbk_Double2DParam_typeDiscovery);
+
+
+    Double2DParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/double2dparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/double2dparam_wrapper.h
@@ -1,0 +1,78 @@
+#ifndef SBK_DOUBLE2DPARAMWRAPPER_H
+#define SBK_DOUBLE2DPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class Double2DParamWrapper : public Double2DParam
+{
+public:
+    ~Double2DParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_DOUBLEPARAMWRAPPER_H
+#  define SBK_DOUBLEPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class DoubleParamWrapper : public DoubleParam
+{
+public:
+    ~DoubleParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_DOUBLEPARAMWRAPPER_H
+
+#  ifndef SBK_ANIMATEDPARAMWRAPPER_H
+#  define SBK_ANIMATEDPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AnimatedParamWrapper : public AnimatedParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { AnimatedParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~AnimatedParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_ANIMATEDPARAMWRAPPER_H
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_DOUBLE2DPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/double2dtuple_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/double2dtuple_wrapper.cpp
@@ -1,0 +1,335 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "double2dtuple_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_Double2DTuple_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::Double2DTuple >()))
+        return -1;
+
+    ::Double2DTuple *cptr{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // Double2DTuple()
+            cptr = new ::Double2DTuple();
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::Double2DTuple >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+}
+
+
+static const char *Sbk_Double2DTuple_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_Double2DTuple_methods[] = {
+
+    {nullptr, nullptr} // Sentinel
+};
+
+PyObject* Sbk_Double2DTupleFunc___getitem__(PyObject *self, Py_ssize_t _i)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Double2DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE2DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    // Begin code injection
+    if (_i < 0 || _i >= 2) {
+    PyErr_BadArgument();
+    return 0;
+    } else {
+    double ret;
+    switch (_i) {
+    case 0:
+    ret = cppSelf->x;
+    break;
+    case 1:
+    ret = cppSelf->y;
+    break;
+    }
+    return  Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret);
+    }
+
+    // End of code injection
+
+}
+
+static PyObject *Sbk_Double2DTuple_get_x(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::Double2DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE2DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppSelf->x);
+    return pyOut;
+}
+static int Sbk_Double2DTuple_set_x(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::Double2DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE2DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'x' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'x', 'double' or convertible type expected");
+        return -1;
+    }
+
+    double& cppOut_ptr = cppSelf->x;
+    pythonToCpp(pyIn, &cppOut_ptr);
+
+    return 0;
+}
+
+static PyObject *Sbk_Double2DTuple_get_y(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::Double2DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE2DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppSelf->y);
+    return pyOut;
+}
+static int Sbk_Double2DTuple_set_y(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::Double2DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE2DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'y' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'y', 'double' or convertible type expected");
+        return -1;
+    }
+
+    double& cppOut_ptr = cppSelf->y;
+    pythonToCpp(pyIn, &cppOut_ptr);
+
+    return 0;
+}
+
+// Getters and Setters for Double2DTuple
+static PyGetSetDef Sbk_Double2DTuple_getsetlist[] = {
+    {const_cast<char *>("x"), Sbk_Double2DTuple_get_x, Sbk_Double2DTuple_set_x},
+    {const_cast<char *>("y"), Sbk_Double2DTuple_get_y, Sbk_Double2DTuple_set_y},
+    {nullptr} // Sentinel
+};
+
+} // extern "C"
+
+static int Sbk_Double2DTuple_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_Double2DTuple_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_Double2DTuple_Type = nullptr;
+static SbkObjectType *Sbk_Double2DTuple_TypeF(void)
+{
+    return _Sbk_Double2DTuple_Type;
+}
+
+static PyType_Slot Sbk_Double2DTuple_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    nullptr},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_Double2DTuple_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_Double2DTuple_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_Double2DTuple_methods)},
+    {Py_tp_getset,      reinterpret_cast<void *>(Sbk_Double2DTuple_getsetlist)},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_Double2DTuple_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    // type supports sequence protocol
+    {Py_sq_item, (void *)&Sbk_Double2DTupleFunc___getitem__},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_Double2DTuple_spec = {
+    "1:NatronEngine.Double2DTuple",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_Double2DTuple_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void Double2DTuple_PythonToCpp_Double2DTuple_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_Double2DTuple_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_Double2DTuple_PythonToCpp_Double2DTuple_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_Double2DTuple_TypeF())))
+        return Double2DTuple_PythonToCpp_Double2DTuple_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *Double2DTuple_PTR_CppToPython_Double2DTuple(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::Double2DTuple *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_Double2DTuple_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *Double2DTuple_SignatureStrings[] = {
+    "NatronEngine.Double2DTuple(self)",
+    nullptr}; // Sentinel
+
+void init_Double2DTuple(PyObject *module)
+{
+    _Sbk_Double2DTuple_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "Double2DTuple",
+        "Double2DTuple*",
+        &Sbk_Double2DTuple_spec,
+        &Shiboken::callCppDestructor< ::Double2DTuple >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_Double2DTuple_Type);
+    InitSignatureStrings(pyType, Double2DTuple_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_Double2DTuple_Type), Sbk_Double2DTuple_PropertyStrings);
+    SbkNatronEngineTypes[SBK_DOUBLE2DTUPLE_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_Double2DTuple_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_Double2DTuple_TypeF(),
+        Double2DTuple_PythonToCpp_Double2DTuple_PTR,
+        is_Double2DTuple_PythonToCpp_Double2DTuple_PTR_Convertible,
+        Double2DTuple_PTR_CppToPython_Double2DTuple);
+
+    Shiboken::Conversions::registerConverterName(converter, "Double2DTuple");
+    Shiboken::Conversions::registerConverterName(converter, "Double2DTuple*");
+    Shiboken::Conversions::registerConverterName(converter, "Double2DTuple&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Double2DTuple).name());
+
+
+
+}

--- a/Engine/Qt5/NatronEngine/double2dtuple_wrapper.h
+++ b/Engine/Qt5/NatronEngine/double2dtuple_wrapper.h
@@ -1,0 +1,7 @@
+#ifndef SBK_DOUBLE2DTUPLE_H
+#define SBK_DOUBLE2DTUPLE_H
+
+#include <PyParameter.h>
+
+#endif // SBK_DOUBLE2DTUPLE_H
+

--- a/Engine/Qt5/NatronEngine/double3dparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/double3dparam_wrapper.cpp
@@ -1,0 +1,441 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "double3dparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void Double3DParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void Double3DParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+Double3DParamWrapper::~Double3DParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_Double3DParamFunc_get(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Double3DParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE3DPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "get", 0, 1, &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::get()const
+    // 1: DoubleParam::get(double)const
+    if (numArgs == 0) {
+        overloadId = 0; // get()const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        overloadId = 1; // get(double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_Double3DParamFunc_get_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // get() const
+        {
+
+            if (!PyErr_Occurred()) {
+                // get()const
+                Double3DTuple* cppResult = new Double3DTuple(const_cast<const ::Double3DParam *>(cppSelf)->get());
+                pyResult = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_DOUBLE3DTUPLE_IDX]), cppResult, true, true);
+            }
+            break;
+        }
+        case 1: // get(double frame) const
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // get(double)const
+                Double3DTuple* cppResult = new Double3DTuple(const_cast<const ::Double3DParam *>(cppSelf)->get(cppArg0));
+                pyResult = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_DOUBLE3DTUPLE_IDX]), cppResult, true, true);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_Double3DParamFunc_get_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Double3DParam.get");
+        return {};
+}
+
+static PyObject *Sbk_Double3DParamFunc_set(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Double3DParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE3DPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "set", 1, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Double2DParam::set(double,double,double)
+    // 1: DoubleParam::set(double,double)
+    // 2: DoubleParam::set(double)
+    // 3: Double3DParam::set(double,double,double,double)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 2; // set(double)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 1; // set(double,double)
+            } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+                if (numArgs == 3) {
+                    overloadId = 0; // set(double,double,double)
+                } else if (numArgs == 4
+                    && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+                    overloadId = 3; // set(double,double,double,double)
+                }
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_Double3DParamFunc_set_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // set(double x, double y, double z)
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            double cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+
+            if (!PyErr_Occurred()) {
+                // set(double,double,double)
+                // Begin code injection
+                cppSelf->set(cppArg0,cppArg1,cppArg2);
+
+                // End of code injection
+
+            }
+            break;
+        }
+        case 1: // set(double x, double y)
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+
+            if (!PyErr_Occurred()) {
+                // set(double,double)
+                reinterpret_cast<Double2DParam *>(cppSelf)->set(cppArg0, cppArg1);
+            }
+            break;
+        }
+        case 2: // set(double x)
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // set(double)
+                reinterpret_cast<DoubleParam *>(cppSelf)->set(cppArg0);
+            }
+            break;
+        }
+        case 3: // set(double x, double y, double z, double frame)
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            double cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            double cppArg3;
+            pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // set(double,double,double,double)
+                // Begin code injection
+                cppSelf->set(cppArg0,cppArg1,cppArg2,cppArg3);
+
+                // End of code injection
+
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_Double3DParamFunc_set_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Double3DParam.set");
+        return {};
+}
+
+
+static const char *Sbk_Double3DParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_Double3DParam_methods[] = {
+    {"get", reinterpret_cast<PyCFunction>(Sbk_Double3DParamFunc_get), METH_VARARGS},
+    {"set", reinterpret_cast<PyCFunction>(Sbk_Double3DParamFunc_set), METH_VARARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_Double3DParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::Double3DParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE3DPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<Double3DParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_Double3DParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_Double3DParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_Double3DParam_Type = nullptr;
+static SbkObjectType *Sbk_Double3DParam_TypeF(void)
+{
+    return _Sbk_Double3DParam_Type;
+}
+
+static PyType_Slot Sbk_Double3DParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_Double3DParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_Double3DParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_Double3DParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_Double3DParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_Double3DParam_spec = {
+    "1:NatronEngine.Double3DParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_Double3DParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_Double3DParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::Double3DParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void Double3DParam_PythonToCpp_Double3DParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_Double3DParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_Double3DParam_PythonToCpp_Double3DParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_Double3DParam_TypeF())))
+        return Double3DParam_PythonToCpp_Double3DParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *Double3DParam_PTR_CppToPython_Double3DParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::Double3DParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_Double3DParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *Double3DParam_SignatureStrings[] = {
+    "1:NatronEngine.Double3DParam.get(self)->NatronEngine.Double3DTuple",
+    "0:NatronEngine.Double3DParam.get(self,frame:double)->NatronEngine.Double3DTuple",
+    "3:NatronEngine.Double3DParam.set(self,x:double,y:double,z:double)",
+    "2:NatronEngine.Double3DParam.set(self,x:double,y:double)",
+    "1:NatronEngine.Double3DParam.set(self,x:double)",
+    "0:NatronEngine.Double3DParam.set(self,x:double,y:double,z:double,frame:double)",
+    nullptr}; // Sentinel
+
+void init_Double3DParam(PyObject *module)
+{
+    _Sbk_Double3DParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "Double3DParam",
+        "Double3DParam*",
+        &Sbk_Double3DParam_spec,
+        &Shiboken::callCppDestructor< ::Double3DParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_DOUBLE2DPARAM_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_Double3DParam_Type);
+    InitSignatureStrings(pyType, Double3DParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_Double3DParam_Type), Sbk_Double3DParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_DOUBLE3DPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_Double3DParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_Double3DParam_TypeF(),
+        Double3DParam_PythonToCpp_Double3DParam_PTR,
+        is_Double3DParam_PythonToCpp_Double3DParam_PTR_Convertible,
+        Double3DParam_PTR_CppToPython_Double3DParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "Double3DParam");
+    Shiboken::Conversions::registerConverterName(converter, "Double3DParam*");
+    Shiboken::Conversions::registerConverterName(converter, "Double3DParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Double3DParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Double3DParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_Double3DParam_TypeF(), &Sbk_Double3DParam_typeDiscovery);
+
+
+    Double3DParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/double3dparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/double3dparam_wrapper.h
@@ -1,0 +1,96 @@
+#ifndef SBK_DOUBLE3DPARAMWRAPPER_H
+#define SBK_DOUBLE3DPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class Double3DParamWrapper : public Double3DParam
+{
+public:
+    ~Double3DParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_DOUBLE2DPARAMWRAPPER_H
+#  define SBK_DOUBLE2DPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class Double2DParamWrapper : public Double2DParam
+{
+public:
+    ~Double2DParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_DOUBLE2DPARAMWRAPPER_H
+
+#  ifndef SBK_DOUBLEPARAMWRAPPER_H
+#  define SBK_DOUBLEPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class DoubleParamWrapper : public DoubleParam
+{
+public:
+    ~DoubleParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_DOUBLEPARAMWRAPPER_H
+
+#  ifndef SBK_ANIMATEDPARAMWRAPPER_H
+#  define SBK_ANIMATEDPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AnimatedParamWrapper : public AnimatedParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { AnimatedParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~AnimatedParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_ANIMATEDPARAMWRAPPER_H
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_DOUBLE3DPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/double3dtuple_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/double3dtuple_wrapper.cpp
@@ -1,0 +1,371 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "double3dtuple_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_Double3DTuple_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::Double3DTuple >()))
+        return -1;
+
+    ::Double3DTuple *cptr{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // Double3DTuple()
+            cptr = new ::Double3DTuple();
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::Double3DTuple >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+}
+
+
+static const char *Sbk_Double3DTuple_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_Double3DTuple_methods[] = {
+
+    {nullptr, nullptr} // Sentinel
+};
+
+PyObject* Sbk_Double3DTupleFunc___getitem__(PyObject *self, Py_ssize_t _i)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Double3DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE3DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    // Begin code injection
+    if (_i < 0 || _i >= 3) {
+    PyErr_BadArgument();
+    return 0;
+    } else {
+    double ret;
+    switch (_i) {
+    case 0:
+    ret = cppSelf->x;
+    break;
+    case 1:
+    ret = cppSelf->y;
+    break;
+    case 2:
+    ret = cppSelf->z;
+    break;
+    }
+    return  Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret);
+    }
+
+    // End of code injection
+
+}
+
+static PyObject *Sbk_Double3DTuple_get_x(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::Double3DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE3DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppSelf->x);
+    return pyOut;
+}
+static int Sbk_Double3DTuple_set_x(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::Double3DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE3DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'x' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'x', 'double' or convertible type expected");
+        return -1;
+    }
+
+    double& cppOut_ptr = cppSelf->x;
+    pythonToCpp(pyIn, &cppOut_ptr);
+
+    return 0;
+}
+
+static PyObject *Sbk_Double3DTuple_get_y(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::Double3DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE3DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppSelf->y);
+    return pyOut;
+}
+static int Sbk_Double3DTuple_set_y(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::Double3DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE3DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'y' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'y', 'double' or convertible type expected");
+        return -1;
+    }
+
+    double& cppOut_ptr = cppSelf->y;
+    pythonToCpp(pyIn, &cppOut_ptr);
+
+    return 0;
+}
+
+static PyObject *Sbk_Double3DTuple_get_z(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::Double3DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE3DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppSelf->z);
+    return pyOut;
+}
+static int Sbk_Double3DTuple_set_z(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::Double3DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLE3DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'z' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'z', 'double' or convertible type expected");
+        return -1;
+    }
+
+    double& cppOut_ptr = cppSelf->z;
+    pythonToCpp(pyIn, &cppOut_ptr);
+
+    return 0;
+}
+
+// Getters and Setters for Double3DTuple
+static PyGetSetDef Sbk_Double3DTuple_getsetlist[] = {
+    {const_cast<char *>("x"), Sbk_Double3DTuple_get_x, Sbk_Double3DTuple_set_x},
+    {const_cast<char *>("y"), Sbk_Double3DTuple_get_y, Sbk_Double3DTuple_set_y},
+    {const_cast<char *>("z"), Sbk_Double3DTuple_get_z, Sbk_Double3DTuple_set_z},
+    {nullptr} // Sentinel
+};
+
+} // extern "C"
+
+static int Sbk_Double3DTuple_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_Double3DTuple_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_Double3DTuple_Type = nullptr;
+static SbkObjectType *Sbk_Double3DTuple_TypeF(void)
+{
+    return _Sbk_Double3DTuple_Type;
+}
+
+static PyType_Slot Sbk_Double3DTuple_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    nullptr},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_Double3DTuple_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_Double3DTuple_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_Double3DTuple_methods)},
+    {Py_tp_getset,      reinterpret_cast<void *>(Sbk_Double3DTuple_getsetlist)},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_Double3DTuple_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    // type supports sequence protocol
+    {Py_sq_item, (void *)&Sbk_Double3DTupleFunc___getitem__},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_Double3DTuple_spec = {
+    "1:NatronEngine.Double3DTuple",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_Double3DTuple_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void Double3DTuple_PythonToCpp_Double3DTuple_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_Double3DTuple_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_Double3DTuple_PythonToCpp_Double3DTuple_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_Double3DTuple_TypeF())))
+        return Double3DTuple_PythonToCpp_Double3DTuple_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *Double3DTuple_PTR_CppToPython_Double3DTuple(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::Double3DTuple *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_Double3DTuple_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *Double3DTuple_SignatureStrings[] = {
+    "NatronEngine.Double3DTuple(self)",
+    nullptr}; // Sentinel
+
+void init_Double3DTuple(PyObject *module)
+{
+    _Sbk_Double3DTuple_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "Double3DTuple",
+        "Double3DTuple*",
+        &Sbk_Double3DTuple_spec,
+        &Shiboken::callCppDestructor< ::Double3DTuple >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_Double3DTuple_Type);
+    InitSignatureStrings(pyType, Double3DTuple_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_Double3DTuple_Type), Sbk_Double3DTuple_PropertyStrings);
+    SbkNatronEngineTypes[SBK_DOUBLE3DTUPLE_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_Double3DTuple_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_Double3DTuple_TypeF(),
+        Double3DTuple_PythonToCpp_Double3DTuple_PTR,
+        is_Double3DTuple_PythonToCpp_Double3DTuple_PTR_Convertible,
+        Double3DTuple_PTR_CppToPython_Double3DTuple);
+
+    Shiboken::Conversions::registerConverterName(converter, "Double3DTuple");
+    Shiboken::Conversions::registerConverterName(converter, "Double3DTuple*");
+    Shiboken::Conversions::registerConverterName(converter, "Double3DTuple&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Double3DTuple).name());
+
+
+
+}

--- a/Engine/Qt5/NatronEngine/double3dtuple_wrapper.h
+++ b/Engine/Qt5/NatronEngine/double3dtuple_wrapper.h
@@ -1,0 +1,7 @@
+#ifndef SBK_DOUBLE3DTUPLE_H
+#define SBK_DOUBLE3DTUPLE_H
+
+#include <PyParameter.h>
+
+#endif // SBK_DOUBLE3DTUPLE_H
+

--- a/Engine/Qt5/NatronEngine/doubleparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/doubleparam_wrapper.cpp
@@ -1,0 +1,1593 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "doubleparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void DoubleParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void DoubleParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+DoubleParamWrapper::~DoubleParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_DoubleParamFunc_addAsDependencyOf(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "addAsDependencyOf", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::addAsDependencyOf(int,Param*,int)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+        overloadId = 0; // addAsDependencyOf(int,Param*,int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_addAsDependencyOf_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        if (!Shiboken::Object::isValid(pyArgs[1]))
+            return {};
+        ::Param *cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        int cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // addAsDependencyOf(int,Param*,int)
+            double cppResult = cppSelf->addAsDependencyOf(cppArg0, cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_DoubleParamFunc_addAsDependencyOf_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.DoubleParam.addAsDependencyOf");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_get(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "get", 0, 1, &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::get()const
+    // 1: DoubleParam::get(double)const
+    if (numArgs == 0) {
+        overloadId = 0; // get()const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        overloadId = 1; // get(double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_get_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // get() const
+        {
+
+            if (!PyErr_Occurred()) {
+                // get()const
+                double cppResult = const_cast<const ::DoubleParam *>(cppSelf)->get();
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+            }
+            break;
+        }
+        case 1: // get(double frame) const
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // get(double)const
+                double cppResult = const_cast<const ::DoubleParam *>(cppSelf)->get(cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_DoubleParamFunc_get_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.DoubleParam.get");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_getDefaultValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.getDefaultValue(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getDefaultValue", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::getDefaultValue(int)const
+    if (numArgs == 0) {
+        overloadId = 0; // getDefaultValue(int)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // getDefaultValue(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_getDefaultValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.getDefaultValue(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_DoubleParamFunc_getDefaultValue_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getDefaultValue(int)const
+            double cppResult = const_cast<const ::DoubleParam *>(cppSelf)->getDefaultValue(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_DoubleParamFunc_getDefaultValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.DoubleParam.getDefaultValue");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_getDisplayMaximum(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: DoubleParam::getDisplayMaximum(int)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // getDisplayMaximum(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_getDisplayMaximum_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getDisplayMaximum(int)const
+            double cppResult = const_cast<const ::DoubleParam *>(cppSelf)->getDisplayMaximum(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_DoubleParamFunc_getDisplayMaximum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.DoubleParam.getDisplayMaximum");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_getDisplayMinimum(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: DoubleParam::getDisplayMinimum(int)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // getDisplayMinimum(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_getDisplayMinimum_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getDisplayMinimum(int)const
+            double cppResult = const_cast<const ::DoubleParam *>(cppSelf)->getDisplayMinimum(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_DoubleParamFunc_getDisplayMinimum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.DoubleParam.getDisplayMinimum");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_getMaximum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.getMaximum(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getMaximum", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::getMaximum(int)const
+    if (numArgs == 0) {
+        overloadId = 0; // getMaximum(int)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // getMaximum(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_getMaximum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.getMaximum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_DoubleParamFunc_getMaximum_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getMaximum(int)const
+            double cppResult = const_cast<const ::DoubleParam *>(cppSelf)->getMaximum(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_DoubleParamFunc_getMaximum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.DoubleParam.getMaximum");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_getMinimum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.getMinimum(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getMinimum", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::getMinimum(int)const
+    if (numArgs == 0) {
+        overloadId = 0; // getMinimum(int)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // getMinimum(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_getMinimum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.getMinimum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_DoubleParamFunc_getMinimum_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getMinimum(int)const
+            double cppResult = const_cast<const ::DoubleParam *>(cppSelf)->getMinimum(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_DoubleParamFunc_getMinimum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.DoubleParam.getMinimum");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_getValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.getValue(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getValue", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::getValue(int)const
+    if (numArgs == 0) {
+        overloadId = 0; // getValue(int)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // getValue(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_getValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.getValue(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_DoubleParamFunc_getValue_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getValue(int)const
+            double cppResult = const_cast<const ::DoubleParam *>(cppSelf)->getValue(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_DoubleParamFunc_getValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.DoubleParam.getValue");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_getValueAtTime(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.getValueAtTime(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.getValueAtTime(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:getValueAtTime", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::getValueAtTime(double,int)const
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // getValueAtTime(double,int)const
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // getValueAtTime(double,int)const
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_getValueAtTime_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.getValueAtTime(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_DoubleParamFunc_getValueAtTime_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // getValueAtTime(double,int)const
+            double cppResult = const_cast<const ::DoubleParam *>(cppSelf)->getValueAtTime(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_DoubleParamFunc_getValueAtTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.DoubleParam.getValueAtTime");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_restoreDefaultValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.restoreDefaultValue(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:restoreDefaultValue", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::restoreDefaultValue(int)
+    if (numArgs == 0) {
+        overloadId = 0; // restoreDefaultValue(int)
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // restoreDefaultValue(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_restoreDefaultValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.restoreDefaultValue(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_DoubleParamFunc_restoreDefaultValue_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // restoreDefaultValue(int)
+            cppSelf->restoreDefaultValue(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_DoubleParamFunc_restoreDefaultValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.DoubleParam.restoreDefaultValue");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_set(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "set", 1, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::set(double)
+    // 1: DoubleParam::set(double,double)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // set(double)
+        } else if (numArgs == 2
+            && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+            overloadId = 1; // set(double,double)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_set_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // set(double x)
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // set(double)
+                cppSelf->set(cppArg0);
+            }
+            break;
+        }
+        case 1: // set(double x, double frame)
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+
+            if (!PyErr_Occurred()) {
+                // set(double,double)
+                cppSelf->set(cppArg0, cppArg1);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_DoubleParamFunc_set_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.DoubleParam.set");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_setDefaultValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setDefaultValue(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setDefaultValue(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setDefaultValue", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::setDefaultValue(double,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setDefaultValue(double,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setDefaultValue(double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_setDefaultValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setDefaultValue(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_DoubleParamFunc_setDefaultValue_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setDefaultValue(double,int)
+            cppSelf->setDefaultValue(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_DoubleParamFunc_setDefaultValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.DoubleParam.setDefaultValue");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_setDisplayMaximum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setDisplayMaximum(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setDisplayMaximum(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setDisplayMaximum", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::setDisplayMaximum(double,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setDisplayMaximum(double,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setDisplayMaximum(double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_setDisplayMaximum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setDisplayMaximum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_DoubleParamFunc_setDisplayMaximum_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setDisplayMaximum(double,int)
+            cppSelf->setDisplayMaximum(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_DoubleParamFunc_setDisplayMaximum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.DoubleParam.setDisplayMaximum");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_setDisplayMinimum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setDisplayMinimum(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setDisplayMinimum(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setDisplayMinimum", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::setDisplayMinimum(double,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setDisplayMinimum(double,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setDisplayMinimum(double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_setDisplayMinimum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setDisplayMinimum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_DoubleParamFunc_setDisplayMinimum_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setDisplayMinimum(double,int)
+            cppSelf->setDisplayMinimum(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_DoubleParamFunc_setDisplayMinimum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.DoubleParam.setDisplayMinimum");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_setMaximum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setMaximum(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setMaximum(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setMaximum", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::setMaximum(double,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setMaximum(double,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setMaximum(double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_setMaximum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setMaximum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_DoubleParamFunc_setMaximum_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setMaximum(double,int)
+            cppSelf->setMaximum(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_DoubleParamFunc_setMaximum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.DoubleParam.setMaximum");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_setMinimum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setMinimum(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setMinimum(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setMinimum", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::setMinimum(double,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setMinimum(double,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setMinimum(double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_setMinimum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setMinimum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_DoubleParamFunc_setMinimum_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setMinimum(double,int)
+            cppSelf->setMinimum(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_DoubleParamFunc_setMinimum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.DoubleParam.setMinimum");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_setValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setValue(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setValue(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setValue", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::setValue(double,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setValue(double,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setValue(double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_setValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setValue(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_DoubleParamFunc_setValue_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setValue(double,int)
+            cppSelf->setValue(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_DoubleParamFunc_setValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.DoubleParam.setValue");
+        return {};
+}
+
+static PyObject *Sbk_DoubleParamFunc_setValueAtTime(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 3) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setValueAtTime(): too many arguments");
+        return {};
+    } else if (numArgs < 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setValueAtTime(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOO:setValueAtTime", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: DoubleParam::setValueAtTime(double,double,int)
+    if (numArgs >= 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        if (numArgs == 2) {
+            overloadId = 0; // setValueAtTime(double,double,int)
+        } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+            overloadId = 0; // setValueAtTime(double,double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_DoubleParamFunc_setValueAtTime_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.DoubleParam.setValueAtTime(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2]))))
+                        goto Sbk_DoubleParamFunc_setValueAtTime_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        int cppArg2 = 0;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // setValueAtTime(double,double,int)
+            cppSelf->setValueAtTime(cppArg0, cppArg1, cppArg2);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_DoubleParamFunc_setValueAtTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.DoubleParam.setValueAtTime");
+        return {};
+}
+
+
+static const char *Sbk_DoubleParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_DoubleParam_methods[] = {
+    {"addAsDependencyOf", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_addAsDependencyOf), METH_VARARGS},
+    {"get", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_get), METH_VARARGS},
+    {"getDefaultValue", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_getDefaultValue), METH_VARARGS|METH_KEYWORDS},
+    {"getDisplayMaximum", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_getDisplayMaximum), METH_O},
+    {"getDisplayMinimum", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_getDisplayMinimum), METH_O},
+    {"getMaximum", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_getMaximum), METH_VARARGS|METH_KEYWORDS},
+    {"getMinimum", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_getMinimum), METH_VARARGS|METH_KEYWORDS},
+    {"getValue", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_getValue), METH_VARARGS|METH_KEYWORDS},
+    {"getValueAtTime", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_getValueAtTime), METH_VARARGS|METH_KEYWORDS},
+    {"restoreDefaultValue", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_restoreDefaultValue), METH_VARARGS|METH_KEYWORDS},
+    {"set", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_set), METH_VARARGS},
+    {"setDefaultValue", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_setDefaultValue), METH_VARARGS|METH_KEYWORDS},
+    {"setDisplayMaximum", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_setDisplayMaximum), METH_VARARGS|METH_KEYWORDS},
+    {"setDisplayMinimum", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_setDisplayMinimum), METH_VARARGS|METH_KEYWORDS},
+    {"setMaximum", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_setMaximum), METH_VARARGS|METH_KEYWORDS},
+    {"setMinimum", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_setMinimum), METH_VARARGS|METH_KEYWORDS},
+    {"setValue", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_setValue), METH_VARARGS|METH_KEYWORDS},
+    {"setValueAtTime", reinterpret_cast<PyCFunction>(Sbk_DoubleParamFunc_setValueAtTime), METH_VARARGS|METH_KEYWORDS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_DoubleParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::DoubleParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<DoubleParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_DoubleParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_DoubleParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_DoubleParam_Type = nullptr;
+static SbkObjectType *Sbk_DoubleParam_TypeF(void)
+{
+    return _Sbk_DoubleParam_Type;
+}
+
+static PyType_Slot Sbk_DoubleParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_DoubleParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_DoubleParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_DoubleParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_DoubleParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_DoubleParam_spec = {
+    "1:NatronEngine.DoubleParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_DoubleParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_DoubleParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::DoubleParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void DoubleParam_PythonToCpp_DoubleParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_DoubleParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_DoubleParam_PythonToCpp_DoubleParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_DoubleParam_TypeF())))
+        return DoubleParam_PythonToCpp_DoubleParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *DoubleParam_PTR_CppToPython_DoubleParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::DoubleParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_DoubleParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *DoubleParam_SignatureStrings[] = {
+    "NatronEngine.DoubleParam.addAsDependencyOf(self,fromExprDimension:int,param:NatronEngine.Param,thisDimension:int)->double",
+    "1:NatronEngine.DoubleParam.get(self)->double",
+    "0:NatronEngine.DoubleParam.get(self,frame:double)->double",
+    "NatronEngine.DoubleParam.getDefaultValue(self,dimension:int=0)->double",
+    "NatronEngine.DoubleParam.getDisplayMaximum(self,dimension:int)->double",
+    "NatronEngine.DoubleParam.getDisplayMinimum(self,dimension:int)->double",
+    "NatronEngine.DoubleParam.getMaximum(self,dimension:int=0)->double",
+    "NatronEngine.DoubleParam.getMinimum(self,dimension:int=0)->double",
+    "NatronEngine.DoubleParam.getValue(self,dimension:int=0)->double",
+    "NatronEngine.DoubleParam.getValueAtTime(self,time:double,dimension:int=0)->double",
+    "NatronEngine.DoubleParam.restoreDefaultValue(self,dimension:int=0)",
+    "1:NatronEngine.DoubleParam.set(self,x:double)",
+    "0:NatronEngine.DoubleParam.set(self,x:double,frame:double)",
+    "NatronEngine.DoubleParam.setDefaultValue(self,value:double,dimension:int=0)",
+    "NatronEngine.DoubleParam.setDisplayMaximum(self,maximum:double,dimension:int=0)",
+    "NatronEngine.DoubleParam.setDisplayMinimum(self,minimum:double,dimension:int=0)",
+    "NatronEngine.DoubleParam.setMaximum(self,maximum:double,dimension:int=0)",
+    "NatronEngine.DoubleParam.setMinimum(self,minimum:double,dimension:int=0)",
+    "NatronEngine.DoubleParam.setValue(self,value:double,dimension:int=0)",
+    "NatronEngine.DoubleParam.setValueAtTime(self,value:double,time:double,dimension:int=0)",
+    nullptr}; // Sentinel
+
+void init_DoubleParam(PyObject *module)
+{
+    _Sbk_DoubleParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "DoubleParam",
+        "DoubleParam*",
+        &Sbk_DoubleParam_spec,
+        &Shiboken::callCppDestructor< ::DoubleParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_DoubleParam_Type);
+    InitSignatureStrings(pyType, DoubleParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_DoubleParam_Type), Sbk_DoubleParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_DoubleParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_DoubleParam_TypeF(),
+        DoubleParam_PythonToCpp_DoubleParam_PTR,
+        is_DoubleParam_PythonToCpp_DoubleParam_PTR_Convertible,
+        DoubleParam_PTR_CppToPython_DoubleParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "DoubleParam");
+    Shiboken::Conversions::registerConverterName(converter, "DoubleParam*");
+    Shiboken::Conversions::registerConverterName(converter, "DoubleParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::DoubleParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::DoubleParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_DoubleParam_TypeF(), &Sbk_DoubleParam_typeDiscovery);
+
+
+    DoubleParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/doubleparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/doubleparam_wrapper.h
@@ -1,0 +1,60 @@
+#ifndef SBK_DOUBLEPARAMWRAPPER_H
+#define SBK_DOUBLEPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class DoubleParamWrapper : public DoubleParam
+{
+public:
+    ~DoubleParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_ANIMATEDPARAMWRAPPER_H
+#  define SBK_ANIMATEDPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AnimatedParamWrapper : public AnimatedParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { AnimatedParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~AnimatedParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_ANIMATEDPARAMWRAPPER_H
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_DOUBLEPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/effect_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/effect_wrapper.cpp
@@ -1,0 +1,1869 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <algorithm>
+#include <set>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "effect_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void EffectWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void EffectWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+EffectWrapper::~EffectWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_EffectFunc_addUserPlane(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "addUserPlane", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Effect::addUserPlane(QString,QStringList)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRINGLIST_IDX], (pyArgs[1])))) {
+        overloadId = 0; // addUserPlane(QString,QStringList)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_addUserPlane_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QStringList cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // addUserPlane(QString,QStringList)
+            bool cppResult = cppSelf->addUserPlane(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_EffectFunc_addUserPlane_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Effect.addUserPlane");
+        return {};
+}
+
+static PyObject *Sbk_EffectFunc_beginChanges(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // beginChanges()
+            cppSelf->beginChanges();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_EffectFunc_canConnectInput(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "canConnectInput", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Effect::canConnectInput(int,const Effect*)const
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), (pyArgs[1])))) {
+        overloadId = 0; // canConnectInput(int,const Effect*)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_canConnectInput_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        if (!Shiboken::Object::isValid(pyArgs[1]))
+            return {};
+        ::Effect *cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // canConnectInput(int,const Effect*)const
+            bool cppResult = const_cast<const ::Effect *>(cppSelf)->canConnectInput(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_EffectFunc_canConnectInput_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Effect.canConnectInput");
+        return {};
+}
+
+static PyObject *Sbk_EffectFunc_connectInput(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "connectInput", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Effect::connectInput(int,const Effect*)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), (pyArgs[1])))) {
+        overloadId = 0; // connectInput(int,const Effect*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_connectInput_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        if (!Shiboken::Object::isValid(pyArgs[1]))
+            return {};
+        ::Effect *cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // connectInput(int,const Effect*)
+            // Begin code injection
+            bool cppResult = cppSelf->connectInput(cppArg0,cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_EffectFunc_connectInput_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Effect.connectInput");
+        return {};
+}
+
+static PyObject *Sbk_EffectFunc_destroy(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.Effect.destroy(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:destroy", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Effect::destroy(bool)
+    if (numArgs == 0) {
+        overloadId = 0; // destroy(bool)
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[0])))) {
+        overloadId = 0; // destroy(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_destroy_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","autoReconnect");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.Effect.destroy(): got multiple values for keyword argument 'autoReconnect'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[0]))))
+                        goto Sbk_EffectFunc_destroy_TypeError;
+                }
+            }
+        }
+        bool cppArg0 = true;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // destroy(bool)
+            // Begin code injection
+            cppSelf->destroy(cppArg0);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_EffectFunc_destroy_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Effect.destroy");
+        return {};
+}
+
+static PyObject *Sbk_EffectFunc_disconnectInput(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Effect::disconnectInput(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // disconnectInput(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_disconnectInput_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // disconnectInput(int)
+            // Begin code injection
+            cppSelf->disconnectInput(cppArg0);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_EffectFunc_disconnectInput_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Effect.disconnectInput");
+        return {};
+}
+
+static PyObject *Sbk_EffectFunc_endChanges(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // endChanges()
+            cppSelf->endChanges();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_EffectFunc_getAvailableLayers(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Effect::getAvailableLayers(int)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // getAvailableLayers(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_getAvailableLayers_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getAvailableLayers(int)const
+            std::list<ImageLayer > cppResult = const_cast<const ::Effect *>(cppSelf)->getAvailableLayers(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_IMAGELAYER_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_EffectFunc_getAvailableLayers_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Effect.getAvailableLayers");
+        return {};
+}
+
+static PyObject *Sbk_EffectFunc_getBitDepth(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getBitDepth()const
+            NATRON_ENUM::ImageBitDepthEnum cppResult = NATRON_ENUM::ImageBitDepthEnum(const_cast<const ::Effect *>(cppSelf)->getBitDepth());
+            pyResult = Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEBITDEPTHENUM_IDX])->converter, &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_getColor(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getColor(double*,double*,double*)const
+            // Begin code injection
+            double r,g,b;
+            cppSelf->getColor(&r,&g,&b);
+            pyResult = PyTuple_New(3);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &r));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &g));
+            PyTuple_SET_ITEM(pyResult, 2, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &b));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_getCurrentTime(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getCurrentTime()const
+            int cppResult = const_cast<const ::Effect *>(cppSelf)->getCurrentTime();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_getFrameRate(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getFrameRate()const
+            double cppResult = const_cast<const ::Effect *>(cppSelf)->getFrameRate();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_getInput(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Effect::getInput(QString)const
+    // 1: Effect::getInput(int)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 1; // getInput(int)const
+    } else if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // getInput(QString)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_getInput_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // getInput(const QString & inputLabel) const
+        {
+            ::QString cppArg0;
+            pythonToCpp(pyArg, &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // getInput(QString)const
+                Effect * cppResult = const_cast<const ::Effect *>(cppSelf)->getInput(cppArg0);
+                pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), cppResult);
+
+                // Ownership transferences.
+                Shiboken::Object::getOwnership(pyResult);
+            }
+            break;
+        }
+        case 1: // getInput(int inputNumber) const
+        {
+            int cppArg0;
+            pythonToCpp(pyArg, &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // getInput(int)const
+                Effect * cppResult = const_cast<const ::Effect *>(cppSelf)->getInput(cppArg0);
+                pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), cppResult);
+
+                // Ownership transferences.
+                Shiboken::Object::getOwnership(pyResult);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_EffectFunc_getInput_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Effect.getInput");
+        return {};
+}
+
+static PyObject *Sbk_EffectFunc_getInputLabel(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Effect::getInputLabel(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // getInputLabel(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_getInputLabel_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getInputLabel(int)
+            QString cppResult = cppSelf->getInputLabel(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_EffectFunc_getInputLabel_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Effect.getInputLabel");
+        return {};
+}
+
+static PyObject *Sbk_EffectFunc_getLabel(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getLabel()const
+            QString cppResult = const_cast<const ::Effect *>(cppSelf)->getLabel();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_getMaxInputCount(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getMaxInputCount()const
+            int cppResult = const_cast<const ::Effect *>(cppSelf)->getMaxInputCount();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_getOutputFormat(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getOutputFormat()const
+            RectI* cppResult = new RectI(const_cast<const ::Effect *>(cppSelf)->getOutputFormat());
+            pyResult = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTI_IDX]), cppResult, true, true);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_getParam(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Effect::getParam(QString)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // getParam(QString)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_getParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getParam(QString)const
+            Param * cppResult = const_cast<const ::Effect *>(cppSelf)->getParam(cppArg0);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_EffectFunc_getParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Effect.getParam");
+        return {};
+}
+
+static PyObject *Sbk_EffectFunc_getParams(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getParams()const
+            // Begin code injection
+            std::list<Param*> params = cppSelf->getParams();
+            PyObject* ret = PyList_New((int) params.size());
+            int idx = 0;
+            for (std::list<Param*>::iterator it = params.begin(); it!=params.end(); ++it,++idx) {
+                PyObject* item = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), *it);
+                // Ownership transferences.
+                Shiboken::Object::getOwnership(item);
+                PyList_SET_ITEM(ret, idx, item);
+            }
+            return ret;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_getPixelAspectRatio(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getPixelAspectRatio()const
+            double cppResult = const_cast<const ::Effect *>(cppSelf)->getPixelAspectRatio();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_getPluginID(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getPluginID()const
+            QString cppResult = const_cast<const ::Effect *>(cppSelf)->getPluginID();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_getPosition(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getPosition(double*,double*)const
+            // Begin code injection
+            double x,y;
+            cppSelf->getPosition(&x,&y);
+            pyResult = PyTuple_New(2);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &x));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &y));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_getPremult(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getPremult()const
+            NATRON_ENUM::ImagePremultiplicationEnum cppResult = NATRON_ENUM::ImagePremultiplicationEnum(const_cast<const ::Effect *>(cppSelf)->getPremult());
+            pyResult = Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEPREMULTIPLICATIONENUM_IDX])->converter, &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_getRegionOfDefinition(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "getRegionOfDefinition", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Effect::getRegionOfDefinition(double,int)const
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+        overloadId = 0; // getRegionOfDefinition(double,int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_getRegionOfDefinition_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // getRegionOfDefinition(double,int)const
+            RectD* cppResult = new RectD(const_cast<const ::Effect *>(cppSelf)->getRegionOfDefinition(cppArg0, cppArg1));
+            pyResult = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTD_IDX]), cppResult, true, true);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_EffectFunc_getRegionOfDefinition_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Effect.getRegionOfDefinition");
+        return {};
+}
+
+static PyObject *Sbk_EffectFunc_getRotoContext(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getRotoContext()const
+            Roto * cppResult = const_cast<const ::Effect *>(cppSelf)->getRotoContext();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_ROTO_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_getScriptName(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getScriptName()const
+            QString cppResult = const_cast<const ::Effect *>(cppSelf)->getScriptName();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_getSize(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getSize(double*,double*)const
+            // Begin code injection
+            double x,y;
+            cppSelf->getSize(&x,&y);
+            pyResult = PyTuple_New(2);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &x));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &y));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_getTrackerContext(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getTrackerContext()const
+            Tracker * cppResult = const_cast<const ::Effect *>(cppSelf)->getTrackerContext();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_TRACKER_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_getUserPageParam(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getUserPageParam()const
+            PageParam * cppResult = const_cast<const ::Effect *>(cppSelf)->getUserPageParam();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PAGEPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_isNodeSelected(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // isNodeSelected()const
+            bool cppResult = const_cast<const ::Effect *>(cppSelf)->isNodeSelected();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_isOutputNode(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // isOutputNode()
+            bool cppResult = cppSelf->isOutputNode();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_isReaderNode(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // isReaderNode()
+            bool cppResult = cppSelf->isReaderNode();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_isWriterNode(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // isWriterNode()
+            bool cppResult = cppSelf->isWriterNode();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_EffectFunc_setColor(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setColor", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Effect::setColor(double,double,double)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+        overloadId = 0; // setColor(double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_setColor_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // setColor(double,double,double)
+            cppSelf->setColor(cppArg0, cppArg1, cppArg2);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_EffectFunc_setColor_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Effect.setColor");
+        return {};
+}
+
+static PyObject *Sbk_EffectFunc_setLabel(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Effect::setLabel(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setLabel(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_setLabel_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setLabel(QString)
+            // Begin code injection
+            cppSelf->setLabel(cppArg0);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_EffectFunc_setLabel_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Effect.setLabel");
+        return {};
+}
+
+static PyObject *Sbk_EffectFunc_setPagesOrder(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Effect::setPagesOrder(QStringList)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRINGLIST_IDX], (pyArg)))) {
+        overloadId = 0; // setPagesOrder(QStringList)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_setPagesOrder_TypeError;
+
+    // Call function/method
+    {
+        ::QStringList cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setPagesOrder(QStringList)
+            cppSelf->setPagesOrder(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_EffectFunc_setPagesOrder_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Effect.setPagesOrder");
+        return {};
+}
+
+static PyObject *Sbk_EffectFunc_setPosition(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setPosition", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Effect::setPosition(double,double)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        overloadId = 0; // setPosition(double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_setPosition_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setPosition(double,double)
+            cppSelf->setPosition(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_EffectFunc_setPosition_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Effect.setPosition");
+        return {};
+}
+
+static PyObject *Sbk_EffectFunc_setScriptName(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Effect::setScriptName(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setScriptName(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_setScriptName_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setScriptName(QString)
+            // Begin code injection
+            bool cppResult = cppSelf->setScriptName(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_EffectFunc_setScriptName_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Effect.setScriptName");
+        return {};
+}
+
+static PyObject *Sbk_EffectFunc_setSize(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setSize", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Effect::setSize(double,double)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        overloadId = 0; // setSize(double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_setSize_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setSize(double,double)
+            cppSelf->setSize(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_EffectFunc_setSize_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Effect.setSize");
+        return {};
+}
+
+static PyObject *Sbk_EffectFunc_setSubGraphEditable(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Effect::setSubGraphEditable(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setSubGraphEditable(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_EffectFunc_setSubGraphEditable_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setSubGraphEditable(bool)
+            cppSelf->setSubGraphEditable(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_EffectFunc_setSubGraphEditable_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Effect.setSubGraphEditable");
+        return {};
+}
+
+
+static const char *Sbk_Effect_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_Effect_methods[] = {
+    {"addUserPlane", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_addUserPlane), METH_VARARGS},
+    {"beginChanges", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_beginChanges), METH_NOARGS},
+    {"canConnectInput", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_canConnectInput), METH_VARARGS},
+    {"connectInput", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_connectInput), METH_VARARGS},
+    {"destroy", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_destroy), METH_VARARGS|METH_KEYWORDS},
+    {"disconnectInput", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_disconnectInput), METH_O},
+    {"endChanges", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_endChanges), METH_NOARGS},
+    {"getAvailableLayers", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getAvailableLayers), METH_O},
+    {"getBitDepth", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getBitDepth), METH_NOARGS},
+    {"getColor", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getColor), METH_NOARGS},
+    {"getCurrentTime", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getCurrentTime), METH_NOARGS},
+    {"getFrameRate", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getFrameRate), METH_NOARGS},
+    {"getInput", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getInput), METH_O},
+    {"getInputLabel", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getInputLabel), METH_O},
+    {"getLabel", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getLabel), METH_NOARGS},
+    {"getMaxInputCount", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getMaxInputCount), METH_NOARGS},
+    {"getOutputFormat", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getOutputFormat), METH_NOARGS},
+    {"getParam", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getParam), METH_O},
+    {"getParams", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getParams), METH_NOARGS},
+    {"getPixelAspectRatio", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getPixelAspectRatio), METH_NOARGS},
+    {"getPluginID", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getPluginID), METH_NOARGS},
+    {"getPosition", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getPosition), METH_NOARGS},
+    {"getPremult", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getPremult), METH_NOARGS},
+    {"getRegionOfDefinition", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getRegionOfDefinition), METH_VARARGS},
+    {"getRotoContext", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getRotoContext), METH_NOARGS},
+    {"getScriptName", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getScriptName), METH_NOARGS},
+    {"getSize", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getSize), METH_NOARGS},
+    {"getTrackerContext", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getTrackerContext), METH_NOARGS},
+    {"getUserPageParam", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_getUserPageParam), METH_NOARGS},
+    {"isNodeSelected", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_isNodeSelected), METH_NOARGS},
+    {"isOutputNode", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_isOutputNode), METH_NOARGS},
+    {"isReaderNode", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_isReaderNode), METH_NOARGS},
+    {"isWriterNode", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_isWriterNode), METH_NOARGS},
+    {"setColor", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_setColor), METH_VARARGS},
+    {"setLabel", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_setLabel), METH_O},
+    {"setPagesOrder", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_setPagesOrder), METH_O},
+    {"setPosition", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_setPosition), METH_VARARGS},
+    {"setScriptName", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_setScriptName), METH_O},
+    {"setSize", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_setSize), METH_VARARGS},
+    {"setSubGraphEditable", reinterpret_cast<PyCFunction>(Sbk_EffectFunc_setSubGraphEditable), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_Effect_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::Effect *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EFFECT_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<EffectWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_Effect_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_Effect_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+static int mi_offsets[] = { -1, -1, -1, -1, -1 };
+int *
+Sbk_Effect_mi_init(const void *cptr)
+{
+    if (mi_offsets[0] == -1) {
+        std::set<int> offsets;
+        const auto *class_ptr = reinterpret_cast<const Effect *>(cptr);
+        const auto base = reinterpret_cast<uintptr_t>(class_ptr);
+        offsets.insert(int(reinterpret_cast<uintptr_t>(static_cast<const Group *>(class_ptr)) - base));
+        offsets.insert(int(reinterpret_cast<uintptr_t>(static_cast<const Group *>(static_cast<const Effect *>(static_cast<const void *>(class_ptr)))) - base));
+        offsets.insert(int(reinterpret_cast<uintptr_t>(static_cast<const UserParamHolder *>(class_ptr)) - base));
+        offsets.insert(int(reinterpret_cast<uintptr_t>(static_cast<const UserParamHolder *>(static_cast<const Effect *>(static_cast<const void *>(class_ptr)))) - base));
+
+        offsets.erase(0);
+
+        std::copy(offsets.cbegin(), offsets.cend(), mi_offsets);
+    }
+    return mi_offsets;
+}
+static void * Sbk_EffectSpecialCastFunction(void *obj, SbkObjectType *desiredType)
+{
+    auto me = reinterpret_cast< ::Effect *>(obj);
+    if (desiredType == reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]))
+        return static_cast< ::Group *>(me);
+    else if (desiredType == reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX]))
+        return static_cast< ::UserParamHolder *>(me);
+    return me;
+}
+
+
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_Effect_Type = nullptr;
+static SbkObjectType *Sbk_Effect_TypeF(void)
+{
+    return _Sbk_Effect_Type;
+}
+
+static PyType_Slot Sbk_Effect_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_Effect_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_Effect_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_Effect_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_Effect_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_Effect_spec = {
+    "1:NatronEngine.Effect",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_Effect_slots
+};
+
+} //extern "C"
+
+static void *Sbk_Effect_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Group >()))
+        return dynamic_cast< ::Effect *>(reinterpret_cast< ::Group *>(cptr));
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::UserParamHolder >()))
+        return dynamic_cast< ::Effect *>(reinterpret_cast< ::UserParamHolder *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void Effect_PythonToCpp_Effect_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_Effect_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_Effect_PythonToCpp_Effect_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_Effect_TypeF())))
+        return Effect_PythonToCpp_Effect_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *Effect_PTR_CppToPython_Effect(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::Effect *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_Effect_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *Effect_SignatureStrings[] = {
+    "NatronEngine.Effect.addUserPlane(self,planeName:QString,channels:QStringList)->bool",
+    "NatronEngine.Effect.beginChanges(self)",
+    "NatronEngine.Effect.canConnectInput(self,inputNumber:int,node:NatronEngine.Effect)->bool",
+    "NatronEngine.Effect.connectInput(self,inputNumber:int,input:NatronEngine.Effect)->bool",
+    "NatronEngine.Effect.destroy(self,autoReconnect:bool=true)",
+    "NatronEngine.Effect.disconnectInput(self,inputNumber:int)",
+    "NatronEngine.Effect.endChanges(self)",
+    "NatronEngine.Effect.getAvailableLayers(self,inputNb:int)->std.list[NatronEngine.ImageLayer]",
+    "NatronEngine.Effect.getBitDepth(self)->NatronEngine.NATRON_ENUM.ImageBitDepthEnum",
+    "NatronEngine.Effect.getColor(self,r:double*,g:double*,b:double*)",
+    "NatronEngine.Effect.getCurrentTime(self)->int",
+    "NatronEngine.Effect.getFrameRate(self)->double",
+    "1:NatronEngine.Effect.getInput(self,inputLabel:QString)->NatronEngine.Effect",
+    "0:NatronEngine.Effect.getInput(self,inputNumber:int)->NatronEngine.Effect",
+    "NatronEngine.Effect.getInputLabel(self,inputNumber:int)->QString",
+    "NatronEngine.Effect.getLabel(self)->QString",
+    "NatronEngine.Effect.getMaxInputCount(self)->int",
+    "NatronEngine.Effect.getOutputFormat(self)->NatronEngine.RectI",
+    "NatronEngine.Effect.getParam(self,name:QString)->NatronEngine.Param",
+    "NatronEngine.Effect.getParams(self)->std.list[NatronEngine.Param]",
+    "NatronEngine.Effect.getPixelAspectRatio(self)->double",
+    "NatronEngine.Effect.getPluginID(self)->QString",
+    "NatronEngine.Effect.getPosition(self,x:double*,y:double*)",
+    "NatronEngine.Effect.getPremult(self)->NatronEngine.NATRON_ENUM.ImagePremultiplicationEnum",
+    "NatronEngine.Effect.getRegionOfDefinition(self,time:double,view:int)->NatronEngine.RectD",
+    "NatronEngine.Effect.getRotoContext(self)->NatronEngine.Roto",
+    "NatronEngine.Effect.getScriptName(self)->QString",
+    "NatronEngine.Effect.getSize(self,w:double*,h:double*)",
+    "NatronEngine.Effect.getTrackerContext(self)->NatronEngine.Tracker",
+    "NatronEngine.Effect.getUserPageParam(self)->NatronEngine.PageParam",
+    "NatronEngine.Effect.isNodeSelected(self)->bool",
+    "NatronEngine.Effect.isOutputNode(self)->bool",
+    "NatronEngine.Effect.isReaderNode(self)->bool",
+    "NatronEngine.Effect.isWriterNode(self)->bool",
+    "NatronEngine.Effect.setColor(self,r:double,g:double,b:double)",
+    "NatronEngine.Effect.setLabel(self,name:QString)",
+    "NatronEngine.Effect.setPagesOrder(self,pages:QStringList)",
+    "NatronEngine.Effect.setPosition(self,x:double,y:double)",
+    "NatronEngine.Effect.setScriptName(self,scriptName:QString)->bool",
+    "NatronEngine.Effect.setSize(self,w:double,h:double)",
+    "NatronEngine.Effect.setSubGraphEditable(self,editable:bool)",
+    nullptr}; // Sentinel
+
+void init_Effect(PyObject *module)
+{
+    PyObject *Sbk_Effect_Type_bases = PyTuple_Pack(2,
+        reinterpret_cast<PyObject *>(SbkNatronEngineTypes[SBK_GROUP_IDX]),
+        reinterpret_cast<PyObject *>(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX]));
+
+    _Sbk_Effect_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "Effect",
+        "Effect*",
+        &Sbk_Effect_spec,
+        &Shiboken::callCppDestructor< ::Effect >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]),
+        Sbk_Effect_Type_bases,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_Effect_Type);
+    InitSignatureStrings(pyType, Effect_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_Effect_Type), Sbk_Effect_PropertyStrings);
+    SbkNatronEngineTypes[SBK_EFFECT_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_Effect_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_Effect_TypeF(),
+        Effect_PythonToCpp_Effect_PTR,
+        is_Effect_PythonToCpp_Effect_PTR_Convertible,
+        Effect_PTR_CppToPython_Effect);
+
+    Shiboken::Conversions::registerConverterName(converter, "Effect");
+    Shiboken::Conversions::registerConverterName(converter, "Effect*");
+    Shiboken::Conversions::registerConverterName(converter, "Effect&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Effect).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::EffectWrapper).name());
+
+
+    MultipleInheritanceInitFunction func = Sbk_Effect_mi_init;
+    Shiboken::ObjectType::setMultipleInheritanceFunction(Sbk_Effect_TypeF(), func);
+    Shiboken::ObjectType::setCastFunction(Sbk_Effect_TypeF(), &Sbk_EffectSpecialCastFunction);
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_Effect_TypeF(), &Sbk_Effect_typeDiscovery);
+
+
+    EffectWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/effect_wrapper.h
+++ b/Engine/Qt5/NatronEngine/effect_wrapper.h
@@ -1,0 +1,47 @@
+#ifndef SBK_EFFECTWRAPPER_H
+#define SBK_EFFECTWRAPPER_H
+
+#include <PyNode.h>
+
+
+// Extra includes
+#include <PyNode.h>
+#include <list>
+#include <PyParameter.h>
+#include <PyRoto.h>
+#include <PyTracker.h>
+#include <RectD.h>
+#include <RectI.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class EffectWrapper : public Effect
+{
+public:
+    ~EffectWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_GROUPWRAPPER_H
+#  define SBK_GROUPWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class GroupWrapper : public Group
+{
+public:
+    GroupWrapper();
+    ~GroupWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_GROUPWRAPPER_H
+
+#endif // SBK_EFFECTWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/exprutils_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/exprutils_wrapper.cpp
@@ -1,0 +1,2506 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "exprutils_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+// Extra includes
+#include <PyParameter.h>
+#include <vector>
+
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_ExprUtils_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::ExprUtils >()))
+        return -1;
+
+    ::ExprUtils *cptr{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // ExprUtils()
+            cptr = new ::ExprUtils();
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::ExprUtils >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+}
+
+static PyObject *Sbk_ExprUtilsFunc_boxstep(PyObject *self, PyObject *args)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "boxstep", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::boxstep(double,double)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        overloadId = 0; // boxstep(double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_boxstep_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // boxstep(double,double)
+            double cppResult = ::ExprUtils::boxstep(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_boxstep_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ExprUtils.boxstep");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_ccellnoise(PyObject *self, PyObject *pyArg)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::ccellnoise(Double3DTuple)
+    if (true) {
+        overloadId = 0; // ccellnoise(Double3DTuple)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_ccellnoise_TypeError;
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // ccellnoise(Double3DTuple)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArg);
+            if (tupleSize != 3) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 3 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 2), &(x3));
+            Double3DTuple p = {x1, x2, x3};
+            Double3DTuple ret = ExprUtils::ccellnoise(p);
+            pyResult = PyTuple_New(3);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.x));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.y));
+            PyTuple_SET_ITEM(pyResult, 2, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.z));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_ccellnoise_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ExprUtils.ccellnoise");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_cellnoise(PyObject *self, PyObject *pyArg)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::cellnoise(Double3DTuple)
+    if (true) {
+        overloadId = 0; // cellnoise(Double3DTuple)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_cellnoise_TypeError;
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // cellnoise(Double3DTuple)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArg);
+            if (tupleSize != 3) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 3 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 2), &(x3));
+            Double3DTuple p = {x1, x2, x3};
+            double ret = ExprUtils::cellnoise(p);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret);
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_cellnoise_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ExprUtils.cellnoise");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_cfbm(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 4) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.cfbm(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.cfbm(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOOO:cfbm", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::cfbm(Double3DTuple,int,double,double)
+    if (true) {
+        if (numArgs == 1) {
+            overloadId = 0; // cfbm(Double3DTuple,int,double,double)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 0; // cfbm(Double3DTuple,int,double,double)
+            } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+                if (numArgs == 3) {
+                    overloadId = 0; // cfbm(Double3DTuple,int,double,double)
+                } else if ((pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+                    overloadId = 0; // cfbm(Double3DTuple,int,double,double)
+                }
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_cfbm_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","octaves");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.cfbm(): got multiple values for keyword argument 'octaves'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ExprUtilsFunc_cfbm_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","lacunarity");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.cfbm(): got multiple values for keyword argument 'lacunarity'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2]))))
+                        goto Sbk_ExprUtilsFunc_cfbm_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","gain");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[3]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.cfbm(): got multiple values for keyword argument 'gain'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[3] = value;
+                    if (!(pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3]))))
+                        goto Sbk_ExprUtilsFunc_cfbm_TypeError;
+                }
+            }
+        }
+        int cppArg1 = 6;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2 = 2.;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3 = 0.5;
+        if (pythonToCpp[3]) pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // cfbm(Double3DTuple,int,double,double)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArgs[1-1]);
+            if (tupleSize != 3) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 3 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 2), &(x3));
+            Double3DTuple p = {x1, x2, x3};
+            Double3DTuple ret = ExprUtils::cfbm(p, cppArg1, cppArg2, cppArg3);
+            pyResult = PyTuple_New(3);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.x));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.y));
+            PyTuple_SET_ITEM(pyResult, 2, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.z));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_cfbm_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ExprUtils.cfbm");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_cfbm4(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 4) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.cfbm4(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.cfbm4(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOOO:cfbm4", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::cfbm4(ColorTuple,int,double,double)
+    if (true) {
+        if (numArgs == 1) {
+            overloadId = 0; // cfbm4(ColorTuple,int,double,double)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 0; // cfbm4(ColorTuple,int,double,double)
+            } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+                if (numArgs == 3) {
+                    overloadId = 0; // cfbm4(ColorTuple,int,double,double)
+                } else if ((pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+                    overloadId = 0; // cfbm4(ColorTuple,int,double,double)
+                }
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_cfbm4_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","octaves");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.cfbm4(): got multiple values for keyword argument 'octaves'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ExprUtilsFunc_cfbm4_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","lacunarity");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.cfbm4(): got multiple values for keyword argument 'lacunarity'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2]))))
+                        goto Sbk_ExprUtilsFunc_cfbm4_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","gain");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[3]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.cfbm4(): got multiple values for keyword argument 'gain'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[3] = value;
+                    if (!(pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3]))))
+                        goto Sbk_ExprUtilsFunc_cfbm4_TypeError;
+                }
+            }
+        }
+        int cppArg1 = 6;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2 = 2.;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3 = 0.5;
+        if (pythonToCpp[3]) pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // cfbm4(ColorTuple,int,double,double)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArgs[1-1]);
+            if (tupleSize != 4) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 4 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 2), &(x3));
+            double x4;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 3), &(x4));
+            ColorTuple p = {x1, x2, x3, x4};
+            Double3DTuple ret = ExprUtils::cfbm4(p, cppArg1, cppArg2, cppArg3);
+            pyResult = PyTuple_New(3);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.x));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.y));
+            PyTuple_SET_ITEM(pyResult, 2, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.z));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_cfbm4_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ExprUtils.cfbm4");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_cnoise(PyObject *self, PyObject *pyArg)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::cnoise(Double3DTuple)
+    if (true) {
+        overloadId = 0; // cnoise(Double3DTuple)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_cnoise_TypeError;
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // cnoise(Double3DTuple)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArg);
+            if (tupleSize != 3) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 3 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 2), &(x3));
+            Double3DTuple p = {x1, x2, x3};
+            Double3DTuple ret = ExprUtils::cnoise(p);
+            pyResult = PyTuple_New(3);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.x));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.y));
+            PyTuple_SET_ITEM(pyResult, 2, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.z));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_cnoise_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ExprUtils.cnoise");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_cnoise4(PyObject *self, PyObject *pyArg)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::cnoise4(ColorTuple)
+    if (true) {
+        overloadId = 0; // cnoise4(ColorTuple)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_cnoise4_TypeError;
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // cnoise4(ColorTuple)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArg);
+            if (tupleSize != 4) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 4 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 2), &(x3));
+            double x4;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 3), &(x4));
+            ColorTuple p = {x1, x2, x3, x4};
+            Double3DTuple ret = ExprUtils::cnoise4(p);
+            pyResult = PyTuple_New(3);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.x));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.y));
+            PyTuple_SET_ITEM(pyResult, 2, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.z));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_cnoise4_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ExprUtils.cnoise4");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_cturbulence(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 4) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.cturbulence(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.cturbulence(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOOO:cturbulence", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::cturbulence(Double3DTuple,int,double,double)
+    if (true) {
+        if (numArgs == 1) {
+            overloadId = 0; // cturbulence(Double3DTuple,int,double,double)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 0; // cturbulence(Double3DTuple,int,double,double)
+            } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+                if (numArgs == 3) {
+                    overloadId = 0; // cturbulence(Double3DTuple,int,double,double)
+                } else if ((pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+                    overloadId = 0; // cturbulence(Double3DTuple,int,double,double)
+                }
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_cturbulence_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","octaves");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.cturbulence(): got multiple values for keyword argument 'octaves'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ExprUtilsFunc_cturbulence_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","lacunarity");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.cturbulence(): got multiple values for keyword argument 'lacunarity'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2]))))
+                        goto Sbk_ExprUtilsFunc_cturbulence_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","gain");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[3]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.cturbulence(): got multiple values for keyword argument 'gain'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[3] = value;
+                    if (!(pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3]))))
+                        goto Sbk_ExprUtilsFunc_cturbulence_TypeError;
+                }
+            }
+        }
+        int cppArg1 = 6;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2 = 2.;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3 = 0.5;
+        if (pythonToCpp[3]) pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // cturbulence(Double3DTuple,int,double,double)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArgs[1-1]);
+            if (tupleSize != 3) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 3 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 2), &(x3));
+            Double3DTuple p = {x1, x2, x3};
+            Double3DTuple ret = ExprUtils::cturbulence(p, cppArg1, cppArg2, cppArg3);
+            pyResult = PyTuple_New(3);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.x));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.y));
+            PyTuple_SET_ITEM(pyResult, 2, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.z));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_cturbulence_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ExprUtils.cturbulence");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_fbm(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 4) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.fbm(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.fbm(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOOO:fbm", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::fbm(Double3DTuple,int,double,double)
+    if (true) {
+        if (numArgs == 1) {
+            overloadId = 0; // fbm(Double3DTuple,int,double,double)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 0; // fbm(Double3DTuple,int,double,double)
+            } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+                if (numArgs == 3) {
+                    overloadId = 0; // fbm(Double3DTuple,int,double,double)
+                } else if ((pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+                    overloadId = 0; // fbm(Double3DTuple,int,double,double)
+                }
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_fbm_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","octaves");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.fbm(): got multiple values for keyword argument 'octaves'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ExprUtilsFunc_fbm_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","lacunarity");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.fbm(): got multiple values for keyword argument 'lacunarity'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2]))))
+                        goto Sbk_ExprUtilsFunc_fbm_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","gain");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[3]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.fbm(): got multiple values for keyword argument 'gain'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[3] = value;
+                    if (!(pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3]))))
+                        goto Sbk_ExprUtilsFunc_fbm_TypeError;
+                }
+            }
+        }
+        int cppArg1 = 6;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2 = 2.;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3 = 0.5;
+        if (pythonToCpp[3]) pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // fbm(Double3DTuple,int,double,double)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArgs[1-1]);
+            if (tupleSize != 3) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 3 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 2), &(x3));
+            Double3DTuple p = {x1, x2, x3};
+            double ret = ExprUtils::fbm(p, cppArg1, cppArg2, cppArg3);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret);
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_fbm_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ExprUtils.fbm");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_fbm4(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 4) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.fbm4(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.fbm4(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOOO:fbm4", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::fbm4(ColorTuple,int,double,double)
+    if (true) {
+        if (numArgs == 1) {
+            overloadId = 0; // fbm4(ColorTuple,int,double,double)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 0; // fbm4(ColorTuple,int,double,double)
+            } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+                if (numArgs == 3) {
+                    overloadId = 0; // fbm4(ColorTuple,int,double,double)
+                } else if ((pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+                    overloadId = 0; // fbm4(ColorTuple,int,double,double)
+                }
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_fbm4_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","octaves");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.fbm4(): got multiple values for keyword argument 'octaves'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ExprUtilsFunc_fbm4_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","lacunarity");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.fbm4(): got multiple values for keyword argument 'lacunarity'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2]))))
+                        goto Sbk_ExprUtilsFunc_fbm4_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","gain");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[3]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.fbm4(): got multiple values for keyword argument 'gain'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[3] = value;
+                    if (!(pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3]))))
+                        goto Sbk_ExprUtilsFunc_fbm4_TypeError;
+                }
+            }
+        }
+        int cppArg1 = 6;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2 = 2.;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3 = 0.5;
+        if (pythonToCpp[3]) pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // fbm4(ColorTuple,int,double,double)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArgs[1-1]);
+            if (tupleSize != 4) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 4 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 2), &(x3));
+            double x4;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 3), &(x4));
+            ColorTuple p = {x1, x2, x3, x4};
+            double ret = ExprUtils::fbm4(p, cppArg1, cppArg2, cppArg3);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret);
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_fbm4_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ExprUtils.fbm4");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_gaussstep(PyObject *self, PyObject *args)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "gaussstep", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::gaussstep(double,double,double)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+        overloadId = 0; // gaussstep(double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_gaussstep_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // gaussstep(double,double,double)
+            double cppResult = ::ExprUtils::gaussstep(cppArg0, cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_gaussstep_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ExprUtils.gaussstep");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_hash(PyObject *self, PyObject *pyArg)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::hash(std::vector<double>)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_DOUBLE_IDX], (pyArg)))) {
+        overloadId = 0; // hash(std::vector<double>)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_hash_TypeError;
+
+    // Call function/method
+    {
+        ::std::vector<double > cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // hash(std::vector<double>)
+            double cppResult = ::ExprUtils::hash(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_hash_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ExprUtils.hash");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_linearstep(PyObject *self, PyObject *args)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "linearstep", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::linearstep(double,double,double)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+        overloadId = 0; // linearstep(double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_linearstep_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // linearstep(double,double,double)
+            double cppResult = ::ExprUtils::linearstep(cppArg0, cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_linearstep_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ExprUtils.linearstep");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_mix(PyObject *self, PyObject *args)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "mix", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::mix(double,double,double)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+        overloadId = 0; // mix(double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_mix_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // mix(double,double,double)
+            double cppResult = ::ExprUtils::mix(cppArg0, cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_mix_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ExprUtils.mix");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_noise(PyObject *self, PyObject *pyArg)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::noise(Double2DTuple)
+    // 1: static ExprUtils::noise(double)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArg)))) {
+        overloadId = 1; // noise(double)
+    } else if (true) {
+        overloadId = 0; // noise(Double2DTuple)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_noise_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // noise(const Double2DTuple & p)
+        {
+
+            if (!PyErr_Occurred()) {
+                // noise(Double2DTuple)
+                // Begin code injection
+                int tupleSize = PyTuple_GET_SIZE(pyArg);
+                if (tupleSize != 4 && tupleSize != 3  && tupleSize != 2) {
+                 PyErr_SetString(PyExc_TypeError, "the tuple must have 2, 3 or 4 items.");
+                 return 0;
+                }
+
+                double ret = 0.;
+                double x1;
+                    Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 0), &(x1));
+                if (tupleSize == 2) {
+                 double x2;
+                    Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 1), &(x2));
+                 Double2DTuple p = {x1, x2};
+                 ret = ExprUtils::noise(p);
+                } else if (tupleSize == 3) {
+                 double x2;
+                    Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 1), &(x2));
+                 double x3;
+                    Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 2), &(x3));
+                 Double3DTuple p = {x1, x2, x3};
+                 ret = ExprUtils::noise(p);
+                } else if (tupleSize == 4) {
+                 double x2;
+                    Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 1), &(x2));
+                 double x3;
+                    Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 2), &(x3));
+                 double x4;
+                    Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 3), &(x4));
+                 ColorTuple p = {x1, x2, x3, x4};
+                 ret = ExprUtils::noise(p);
+                }
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret);
+
+                return pyResult;
+
+                // End of code injection
+
+            }
+            break;
+        }
+        case 1: // noise(double x)
+        {
+            double cppArg0;
+            pythonToCpp(pyArg, &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // noise(double)
+                double cppResult = ::ExprUtils::noise(cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_noise_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ExprUtils.noise");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_pnoise(PyObject *self, PyObject *args)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "pnoise", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::pnoise(Double3DTuple,Double3DTuple)
+    if (numArgs == 2) {
+        overloadId = 0; // pnoise(Double3DTuple,Double3DTuple)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_pnoise_TypeError;
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // pnoise(Double3DTuple,Double3DTuple)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArgs[1-1]);
+            if (tupleSize != 3) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 3 items.");
+            return 0;
+            }
+            tupleSize = PyTuple_GET_SIZE(pyArgs[2-1]);
+            if (tupleSize != 3) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 3 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 2), &(x3));
+            double p1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[2-1], 0), &(p1));
+            double p2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[2-1], 1), &(p2));
+            double p3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[2-1], 2), &(p3));
+            Double3DTuple p = {x1, x2, x3};
+            Double3DTuple period = {p1, p2, p3};
+            double ret = ExprUtils::pnoise(p, period);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret);
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_pnoise_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ExprUtils.pnoise");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_remap(PyObject *self, PyObject *args)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "remap", 5, 5, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3]), &(pyArgs[4])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::remap(double,double,double,double,double)
+    if (numArgs == 5
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))
+        && (pythonToCpp[4] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[4])))) {
+        overloadId = 0; // remap(double,double,double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_remap_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3;
+        pythonToCpp[3](pyArgs[3], &cppArg3);
+        double cppArg4;
+        pythonToCpp[4](pyArgs[4], &cppArg4);
+
+        if (!PyErr_Occurred()) {
+            // remap(double,double,double,double,double)
+            double cppResult = ::ExprUtils::remap(cppArg0, cppArg1, cppArg2, cppArg3, cppArg4);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_remap_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ExprUtils.remap");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_smoothstep(PyObject *self, PyObject *args)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "smoothstep", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::smoothstep(double,double,double)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+        overloadId = 0; // smoothstep(double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_smoothstep_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // smoothstep(double,double,double)
+            double cppResult = ::ExprUtils::smoothstep(cppArg0, cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_smoothstep_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ExprUtils.smoothstep");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_snoise(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ExprUtils *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_EXPRUTILS_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: ExprUtils::snoise(Double3DTuple)
+    if (true) {
+        overloadId = 0; // snoise(Double3DTuple)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_snoise_TypeError;
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // snoise(Double3DTuple)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArg);
+            if (tupleSize != 3) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 3 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 2), &(x3));
+            Double3DTuple p = {x1, x2, x3};
+            double ret = cppSelf->snoise(p);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret);
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_snoise_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ExprUtils.snoise");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_snoise4(PyObject *self, PyObject *pyArg)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::snoise4(ColorTuple)
+    if (true) {
+        overloadId = 0; // snoise4(ColorTuple)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_snoise4_TypeError;
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // snoise4(ColorTuple)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArg);
+            if (tupleSize != 4) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 4 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 2), &(x3));
+            double x4;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 3), &(x4));
+            ColorTuple p = {x1, x2, x3, x4};
+            double ret = ExprUtils::snoise4(p);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret);
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_snoise4_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ExprUtils.snoise4");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_turbulence(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 4) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.turbulence(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.turbulence(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOOO:turbulence", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::turbulence(Double3DTuple,int,double,double)
+    if (true) {
+        if (numArgs == 1) {
+            overloadId = 0; // turbulence(Double3DTuple,int,double,double)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 0; // turbulence(Double3DTuple,int,double,double)
+            } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+                if (numArgs == 3) {
+                    overloadId = 0; // turbulence(Double3DTuple,int,double,double)
+                } else if ((pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+                    overloadId = 0; // turbulence(Double3DTuple,int,double,double)
+                }
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_turbulence_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","octaves");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.turbulence(): got multiple values for keyword argument 'octaves'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ExprUtilsFunc_turbulence_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","lacunarity");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.turbulence(): got multiple values for keyword argument 'lacunarity'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2]))))
+                        goto Sbk_ExprUtilsFunc_turbulence_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","gain");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[3]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.turbulence(): got multiple values for keyword argument 'gain'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[3] = value;
+                    if (!(pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3]))))
+                        goto Sbk_ExprUtilsFunc_turbulence_TypeError;
+                }
+            }
+        }
+        int cppArg1 = 6;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2 = 2.;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3 = 0.5;
+        if (pythonToCpp[3]) pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // turbulence(Double3DTuple,int,double,double)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArgs[1-1]);
+            if (tupleSize != 3) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 3 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 2), &(x3));
+            Double3DTuple p = {x1, x2, x3};
+            double ret = ExprUtils::turbulence(p, cppArg1, cppArg2, cppArg3);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret);
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_turbulence_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ExprUtils.turbulence");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_vfbm(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 4) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.vfbm(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.vfbm(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOOO:vfbm", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::vfbm(Double3DTuple,int,double,double)
+    if (true) {
+        if (numArgs == 1) {
+            overloadId = 0; // vfbm(Double3DTuple,int,double,double)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 0; // vfbm(Double3DTuple,int,double,double)
+            } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+                if (numArgs == 3) {
+                    overloadId = 0; // vfbm(Double3DTuple,int,double,double)
+                } else if ((pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+                    overloadId = 0; // vfbm(Double3DTuple,int,double,double)
+                }
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_vfbm_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","octaves");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.vfbm(): got multiple values for keyword argument 'octaves'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ExprUtilsFunc_vfbm_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","lacunarity");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.vfbm(): got multiple values for keyword argument 'lacunarity'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2]))))
+                        goto Sbk_ExprUtilsFunc_vfbm_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","gain");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[3]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.vfbm(): got multiple values for keyword argument 'gain'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[3] = value;
+                    if (!(pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3]))))
+                        goto Sbk_ExprUtilsFunc_vfbm_TypeError;
+                }
+            }
+        }
+        int cppArg1 = 6;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2 = 2.;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3 = 0.5;
+        if (pythonToCpp[3]) pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // vfbm(Double3DTuple,int,double,double)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArgs[1-1]);
+            if (tupleSize != 3) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 3 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 2), &(x3));
+            Double3DTuple p = {x1, x2, x3};
+            Double3DTuple ret = ExprUtils::vfbm(p, cppArg1, cppArg2, cppArg3);
+            pyResult = PyTuple_New(3);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.x));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.y));
+            PyTuple_SET_ITEM(pyResult, 2, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.z));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_vfbm_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ExprUtils.vfbm");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_vfbm4(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 4) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.vfbm4(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.vfbm4(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOOO:vfbm4", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::vfbm4(ColorTuple,int,double,double)
+    if (true) {
+        if (numArgs == 1) {
+            overloadId = 0; // vfbm4(ColorTuple,int,double,double)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 0; // vfbm4(ColorTuple,int,double,double)
+            } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+                if (numArgs == 3) {
+                    overloadId = 0; // vfbm4(ColorTuple,int,double,double)
+                } else if ((pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+                    overloadId = 0; // vfbm4(ColorTuple,int,double,double)
+                }
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_vfbm4_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","octaves");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.vfbm4(): got multiple values for keyword argument 'octaves'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ExprUtilsFunc_vfbm4_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","lacunarity");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.vfbm4(): got multiple values for keyword argument 'lacunarity'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2]))))
+                        goto Sbk_ExprUtilsFunc_vfbm4_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","gain");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[3]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.vfbm4(): got multiple values for keyword argument 'gain'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[3] = value;
+                    if (!(pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3]))))
+                        goto Sbk_ExprUtilsFunc_vfbm4_TypeError;
+                }
+            }
+        }
+        int cppArg1 = 6;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2 = 2.;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3 = 0.5;
+        if (pythonToCpp[3]) pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // vfbm4(ColorTuple,int,double,double)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArgs[1-1]);
+            if (tupleSize != 4) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 4 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 2), &(x3));
+            double x4;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 3), &(x4));
+            ColorTuple p = {x1, x2, x3, x4};
+            Double3DTuple ret = ExprUtils::vfbm4(p, cppArg1, cppArg2, cppArg3);
+            pyResult = PyTuple_New(3);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.x));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.y));
+            PyTuple_SET_ITEM(pyResult, 2, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.z));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_vfbm4_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ExprUtils.vfbm4");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_vnoise(PyObject *self, PyObject *pyArg)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::vnoise(Double3DTuple)
+    if (true) {
+        overloadId = 0; // vnoise(Double3DTuple)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_vnoise_TypeError;
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // vnoise(Double3DTuple)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArg);
+            if (tupleSize != 3) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 3 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 2), &(x3));
+            Double3DTuple p = {x1, x2, x3};
+            Double3DTuple ret = ExprUtils::vnoise(p);
+            pyResult = PyTuple_New(3);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.x));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.y));
+            PyTuple_SET_ITEM(pyResult, 2, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.z));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_vnoise_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ExprUtils.vnoise");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_vnoise4(PyObject *self, PyObject *pyArg)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::vnoise4(ColorTuple)
+    if (true) {
+        overloadId = 0; // vnoise4(ColorTuple)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_vnoise4_TypeError;
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // vnoise4(ColorTuple)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArg);
+            if (tupleSize != 4) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 4 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 2), &(x3));
+            double x4;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArg, 3), &(x4));
+            ColorTuple p = {x1, x2, x3, x4};
+            Double3DTuple ret = ExprUtils::vnoise4(p);
+            pyResult = PyTuple_New(3);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.x));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.y));
+            PyTuple_SET_ITEM(pyResult, 2, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.z));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_vnoise4_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ExprUtils.vnoise4");
+        return {};
+}
+
+static PyObject *Sbk_ExprUtilsFunc_vturbulence(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 4) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.vturbulence(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.vturbulence(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOOO:vturbulence", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: static ExprUtils::vturbulence(Double3DTuple,int,double,double)
+    if (true) {
+        if (numArgs == 1) {
+            overloadId = 0; // vturbulence(Double3DTuple,int,double,double)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 0; // vturbulence(Double3DTuple,int,double,double)
+            } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+                if (numArgs == 3) {
+                    overloadId = 0; // vturbulence(Double3DTuple,int,double,double)
+                } else if ((pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+                    overloadId = 0; // vturbulence(Double3DTuple,int,double,double)
+                }
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ExprUtilsFunc_vturbulence_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","octaves");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.vturbulence(): got multiple values for keyword argument 'octaves'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ExprUtilsFunc_vturbulence_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","lacunarity");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.vturbulence(): got multiple values for keyword argument 'lacunarity'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2]))))
+                        goto Sbk_ExprUtilsFunc_vturbulence_TypeError;
+                }
+            }
+            keyName = Py_BuildValue("s","gain");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[3]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.ExprUtils.vturbulence(): got multiple values for keyword argument 'gain'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[3] = value;
+                    if (!(pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3]))))
+                        goto Sbk_ExprUtilsFunc_vturbulence_TypeError;
+                }
+            }
+        }
+        int cppArg1 = 6;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2 = 2.;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3 = 0.5;
+        if (pythonToCpp[3]) pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // vturbulence(Double3DTuple,int,double,double)
+            // Begin code injection
+            int tupleSize = PyTuple_GET_SIZE(pyArgs[1-1]);
+            if (tupleSize != 3) {
+            PyErr_SetString(PyExc_TypeError, "the tuple must have 3 items.");
+            return 0;
+            }
+            double x1;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 0), &(x1));
+            double x2;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 1), &(x2));
+            double x3;
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), PyTuple_GET_ITEM(pyArgs[1-1], 2), &(x3));
+            Double3DTuple p = {x1, x2, x3};
+            Double3DTuple ret = ExprUtils::vturbulence(p, cppArg1, cppArg2, cppArg3);
+            pyResult = PyTuple_New(3);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.x));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.y));
+            PyTuple_SET_ITEM(pyResult, 2, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &ret.z));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ExprUtilsFunc_vturbulence_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ExprUtils.vturbulence");
+        return {};
+}
+
+
+static const char *Sbk_ExprUtils_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_ExprUtils_methods[] = {
+    {"boxstep", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_boxstep), METH_VARARGS|METH_STATIC},
+    {"ccellnoise", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_ccellnoise), METH_O|METH_STATIC},
+    {"cellnoise", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_cellnoise), METH_O|METH_STATIC},
+    {"cfbm", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_cfbm), METH_VARARGS|METH_KEYWORDS|METH_STATIC},
+    {"cfbm4", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_cfbm4), METH_VARARGS|METH_KEYWORDS|METH_STATIC},
+    {"cnoise", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_cnoise), METH_O|METH_STATIC},
+    {"cnoise4", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_cnoise4), METH_O|METH_STATIC},
+    {"cturbulence", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_cturbulence), METH_VARARGS|METH_KEYWORDS|METH_STATIC},
+    {"fbm", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_fbm), METH_VARARGS|METH_KEYWORDS|METH_STATIC},
+    {"fbm4", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_fbm4), METH_VARARGS|METH_KEYWORDS|METH_STATIC},
+    {"gaussstep", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_gaussstep), METH_VARARGS|METH_STATIC},
+    {"hash", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_hash), METH_O|METH_STATIC},
+    {"linearstep", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_linearstep), METH_VARARGS|METH_STATIC},
+    {"mix", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_mix), METH_VARARGS|METH_STATIC},
+    {"noise", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_noise), METH_O|METH_STATIC},
+    {"pnoise", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_pnoise), METH_VARARGS|METH_STATIC},
+    {"remap", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_remap), METH_VARARGS|METH_STATIC},
+    {"smoothstep", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_smoothstep), METH_VARARGS|METH_STATIC},
+    {"snoise", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_snoise), METH_O},
+    {"snoise4", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_snoise4), METH_O|METH_STATIC},
+    {"turbulence", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_turbulence), METH_VARARGS|METH_KEYWORDS|METH_STATIC},
+    {"vfbm", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_vfbm), METH_VARARGS|METH_KEYWORDS|METH_STATIC},
+    {"vfbm4", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_vfbm4), METH_VARARGS|METH_KEYWORDS|METH_STATIC},
+    {"vnoise", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_vnoise), METH_O|METH_STATIC},
+    {"vnoise4", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_vnoise4), METH_O|METH_STATIC},
+    {"vturbulence", reinterpret_cast<PyCFunction>(Sbk_ExprUtilsFunc_vturbulence), METH_VARARGS|METH_KEYWORDS|METH_STATIC},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+} // extern "C"
+
+static int Sbk_ExprUtils_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_ExprUtils_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_ExprUtils_Type = nullptr;
+static SbkObjectType *Sbk_ExprUtils_TypeF(void)
+{
+    return _Sbk_ExprUtils_Type;
+}
+
+static PyType_Slot Sbk_ExprUtils_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    nullptr},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_ExprUtils_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_ExprUtils_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_ExprUtils_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_ExprUtils_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_ExprUtils_spec = {
+    "1:NatronEngine.ExprUtils",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_ExprUtils_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void ExprUtils_PythonToCpp_ExprUtils_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_ExprUtils_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_ExprUtils_PythonToCpp_ExprUtils_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_ExprUtils_TypeF())))
+        return ExprUtils_PythonToCpp_ExprUtils_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *ExprUtils_PTR_CppToPython_ExprUtils(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::ExprUtils *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_ExprUtils_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *ExprUtils_SignatureStrings[] = {
+    "NatronEngine.ExprUtils(self)",
+    "NatronEngine.ExprUtils.boxstep(x:double,a:double)->double",
+    "NatronEngine.ExprUtils.ccellnoise(p:NatronEngine.Double3DTuple)->NatronEngine.Double3DTuple",
+    "NatronEngine.ExprUtils.cellnoise(p:NatronEngine.Double3DTuple)->double",
+    "NatronEngine.ExprUtils.cfbm(p:NatronEngine.Double3DTuple,octaves:int=6,lacunarity:double=2.,gain:double=0.5)->NatronEngine.Double3DTuple",
+    "NatronEngine.ExprUtils.cfbm4(p:NatronEngine.ColorTuple,octaves:int=6,lacunarity:double=2.,gain:double=0.5)->NatronEngine.Double3DTuple",
+    "NatronEngine.ExprUtils.cnoise(p:NatronEngine.Double3DTuple)->NatronEngine.Double3DTuple",
+    "NatronEngine.ExprUtils.cnoise4(p:NatronEngine.ColorTuple)->NatronEngine.Double3DTuple",
+    "NatronEngine.ExprUtils.cturbulence(p:NatronEngine.Double3DTuple,octaves:int=6,lacunarity:double=2.,gain:double=0.5)->NatronEngine.Double3DTuple",
+    "NatronEngine.ExprUtils.fbm(p:NatronEngine.Double3DTuple,octaves:int=6,lacunarity:double=2.,gain:double=0.5)->double",
+    "NatronEngine.ExprUtils.fbm4(p:NatronEngine.ColorTuple,octaves:int=6,lacunarity:double=2.,gain:double=0.5)->double",
+    "NatronEngine.ExprUtils.gaussstep(x:double,a:double,b:double)->double",
+    "NatronEngine.ExprUtils.hash(args:std.vector[double])->double",
+    "NatronEngine.ExprUtils.linearstep(x:double,a:double,b:double)->double",
+    "NatronEngine.ExprUtils.mix(x:double,y:double,alpha:double)->double",
+    "1:NatronEngine.ExprUtils.noise(p:NatronEngine.Double2DTuple)->double",
+    "0:NatronEngine.ExprUtils.noise(x:double)->double",
+    "NatronEngine.ExprUtils.pnoise(p:NatronEngine.Double3DTuple,period:NatronEngine.Double3DTuple)->double",
+    "NatronEngine.ExprUtils.remap(x:double,source:double,range:double,falloff:double,interp:double)->double",
+    "NatronEngine.ExprUtils.smoothstep(x:double,a:double,b:double)->double",
+    "NatronEngine.ExprUtils.snoise(self,p:NatronEngine.Double3DTuple)->double",
+    "NatronEngine.ExprUtils.snoise4(p:NatronEngine.ColorTuple)->double",
+    "NatronEngine.ExprUtils.turbulence(p:NatronEngine.Double3DTuple,octaves:int=6,lacunarity:double=2.,gain:double=0.5)->double",
+    "NatronEngine.ExprUtils.vfbm(p:NatronEngine.Double3DTuple,octaves:int=6,lacunarity:double=2.,gain:double=0.5)->NatronEngine.Double3DTuple",
+    "NatronEngine.ExprUtils.vfbm4(p:NatronEngine.ColorTuple,octaves:int=6,lacunarity:double=2.,gain:double=0.5)->NatronEngine.Double3DTuple",
+    "NatronEngine.ExprUtils.vnoise(p:NatronEngine.Double3DTuple)->NatronEngine.Double3DTuple",
+    "NatronEngine.ExprUtils.vnoise4(p:NatronEngine.ColorTuple)->NatronEngine.Double3DTuple",
+    "NatronEngine.ExprUtils.vturbulence(p:NatronEngine.Double3DTuple,octaves:int=6,lacunarity:double=2.,gain:double=0.5)->NatronEngine.Double3DTuple",
+    nullptr}; // Sentinel
+
+void init_ExprUtils(PyObject *module)
+{
+    _Sbk_ExprUtils_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "ExprUtils",
+        "ExprUtils*",
+        &Sbk_ExprUtils_spec,
+        &Shiboken::callCppDestructor< ::ExprUtils >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_ExprUtils_Type);
+    InitSignatureStrings(pyType, ExprUtils_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_ExprUtils_Type), Sbk_ExprUtils_PropertyStrings);
+    SbkNatronEngineTypes[SBK_EXPRUTILS_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_ExprUtils_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_ExprUtils_TypeF(),
+        ExprUtils_PythonToCpp_ExprUtils_PTR,
+        is_ExprUtils_PythonToCpp_ExprUtils_PTR_Convertible,
+        ExprUtils_PTR_CppToPython_ExprUtils);
+
+    Shiboken::Conversions::registerConverterName(converter, "ExprUtils");
+    Shiboken::Conversions::registerConverterName(converter, "ExprUtils*");
+    Shiboken::Conversions::registerConverterName(converter, "ExprUtils&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::ExprUtils).name());
+
+
+
+}

--- a/Engine/Qt5/NatronEngine/exprutils_wrapper.h
+++ b/Engine/Qt5/NatronEngine/exprutils_wrapper.h
@@ -1,0 +1,7 @@
+#ifndef SBK_EXPRUTILS_H
+#define SBK_EXPRUTILS_H
+
+#include <PyExprUtils.h>
+
+#endif // SBK_EXPRUTILS_H
+

--- a/Engine/Qt5/NatronEngine/fileparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/fileparam_wrapper.cpp
@@ -1,0 +1,329 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "fileparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void FileParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void FileParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+FileParamWrapper::~FileParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_FileParamFunc_openFile(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::FileParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_FILEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // openFile()
+            cppSelf->openFile();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_FileParamFunc_reloadFile(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::FileParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_FILEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // reloadFile()
+            cppSelf->reloadFile();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_FileParamFunc_setSequenceEnabled(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::FileParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_FILEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: FileParam::setSequenceEnabled(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setSequenceEnabled(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_FileParamFunc_setSequenceEnabled_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setSequenceEnabled(bool)
+            cppSelf->setSequenceEnabled(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_FileParamFunc_setSequenceEnabled_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.FileParam.setSequenceEnabled");
+        return {};
+}
+
+
+static const char *Sbk_FileParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_FileParam_methods[] = {
+    {"openFile", reinterpret_cast<PyCFunction>(Sbk_FileParamFunc_openFile), METH_NOARGS},
+    {"reloadFile", reinterpret_cast<PyCFunction>(Sbk_FileParamFunc_reloadFile), METH_NOARGS},
+    {"setSequenceEnabled", reinterpret_cast<PyCFunction>(Sbk_FileParamFunc_setSequenceEnabled), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_FileParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::FileParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_FILEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<FileParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_FileParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_FileParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_FileParam_Type = nullptr;
+static SbkObjectType *Sbk_FileParam_TypeF(void)
+{
+    return _Sbk_FileParam_Type;
+}
+
+static PyType_Slot Sbk_FileParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_FileParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_FileParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_FileParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_FileParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_FileParam_spec = {
+    "1:NatronEngine.FileParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_FileParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_FileParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::FileParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void FileParam_PythonToCpp_FileParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_FileParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_FileParam_PythonToCpp_FileParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_FileParam_TypeF())))
+        return FileParam_PythonToCpp_FileParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *FileParam_PTR_CppToPython_FileParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::FileParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_FileParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *FileParam_SignatureStrings[] = {
+    "NatronEngine.FileParam.openFile(self)",
+    "NatronEngine.FileParam.reloadFile(self)",
+    "NatronEngine.FileParam.setSequenceEnabled(self,enabled:bool)",
+    nullptr}; // Sentinel
+
+void init_FileParam(PyObject *module)
+{
+    _Sbk_FileParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "FileParam",
+        "FileParam*",
+        &Sbk_FileParam_spec,
+        &Shiboken::callCppDestructor< ::FileParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_FileParam_Type);
+    InitSignatureStrings(pyType, FileParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_FileParam_Type), Sbk_FileParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_FILEPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_FileParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_FileParam_TypeF(),
+        FileParam_PythonToCpp_FileParam_PTR,
+        is_FileParam_PythonToCpp_FileParam_PTR_Convertible,
+        FileParam_PTR_CppToPython_FileParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "FileParam");
+    Shiboken::Conversions::registerConverterName(converter, "FileParam*");
+    Shiboken::Conversions::registerConverterName(converter, "FileParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::FileParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::FileParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_FileParam_TypeF(), &Sbk_FileParam_typeDiscovery);
+
+
+    FileParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/fileparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/fileparam_wrapper.h
@@ -1,0 +1,78 @@
+#ifndef SBK_FILEPARAMWRAPPER_H
+#define SBK_FILEPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class FileParamWrapper : public FileParam
+{
+public:
+    ~FileParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_STRINGPARAMBASEWRAPPER_H
+#  define SBK_STRINGPARAMBASEWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class StringParamBaseWrapper : public StringParamBase
+{
+public:
+    ~StringParamBaseWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_STRINGPARAMBASEWRAPPER_H
+
+#  ifndef SBK_ANIMATEDPARAMWRAPPER_H
+#  define SBK_ANIMATEDPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AnimatedParamWrapper : public AnimatedParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { AnimatedParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~AnimatedParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_ANIMATEDPARAMWRAPPER_H
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_FILEPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/floatnodecreationproperty_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/floatnodecreationproperty_wrapper.cpp
@@ -1,0 +1,467 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "floatnodecreationproperty_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void FloatNodeCreationPropertyWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void FloatNodeCreationPropertyWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+FloatNodeCreationPropertyWrapper::FloatNodeCreationPropertyWrapper(const std::vector<double > & values) : FloatNodeCreationProperty(values)
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+FloatNodeCreationPropertyWrapper::FloatNodeCreationPropertyWrapper(double value) : FloatNodeCreationProperty(value)
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+FloatNodeCreationPropertyWrapper::~FloatNodeCreationPropertyWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_FloatNodeCreationProperty_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::FloatNodeCreationProperty >()))
+        return -1;
+
+    ::FloatNodeCreationPropertyWrapper *cptr{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.FloatNodeCreationProperty(): too many arguments");
+        return -1;
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:FloatNodeCreationProperty", &(pyArgs[0])))
+        return -1;
+
+
+    // Overloaded function decisor
+    // 0: FloatNodeCreationProperty::FloatNodeCreationProperty(std::vector<double>)
+    // 1: FloatNodeCreationProperty::FloatNodeCreationProperty(double)
+    if (numArgs == 0) {
+        overloadId = 0; // FloatNodeCreationProperty(std::vector<double>)
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        overloadId = 1; // FloatNodeCreationProperty(double)
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_DOUBLE_IDX], (pyArgs[0])))) {
+        overloadId = 0; // FloatNodeCreationProperty(std::vector<double>)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_FloatNodeCreationProperty_Init_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // FloatNodeCreationProperty(const std::vector<double > & values)
+        {
+            if (kwds) {
+                PyObject *keyName = nullptr;
+                PyObject *value = nullptr;
+                keyName = Py_BuildValue("s","values");
+                if (PyDict_Contains(kwds, keyName)) {
+                    value = PyDict_GetItem(kwds, keyName);
+                    if (value && pyArgs[0]) {
+                        PyErr_SetString(PyExc_TypeError, "NatronEngine.FloatNodeCreationProperty(): got multiple values for keyword argument 'values'.");
+                        return -1;
+                    }
+                    if (value) {
+                        pyArgs[0] = value;
+                        if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_DOUBLE_IDX], (pyArgs[0]))))
+                            goto Sbk_FloatNodeCreationProperty_Init_TypeError;
+                    }
+                }
+            }
+            ::std::vector<double > cppArg0;
+            if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // FloatNodeCreationProperty(std::vector<double>)
+                cptr = new ::FloatNodeCreationPropertyWrapper(cppArg0);
+            }
+            break;
+        }
+        case 1: // FloatNodeCreationProperty(double value)
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // FloatNodeCreationProperty(double)
+                cptr = new ::FloatNodeCreationPropertyWrapper(cppArg0);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::FloatNodeCreationProperty >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    if (!cptr) goto Sbk_FloatNodeCreationProperty_Init_TypeError;
+
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    Shiboken::Object::setHasCppWrapper(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+
+    Sbk_FloatNodeCreationProperty_Init_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.FloatNodeCreationProperty");
+        return -1;
+}
+
+static PyObject *Sbk_FloatNodeCreationPropertyFunc_getValues(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::FloatNodeCreationProperty *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_FLOATNODECREATIONPROPERTY_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getValues()const
+            const std::vector<double > & cppResult = const_cast<const ::FloatNodeCreationProperty *>(cppSelf)->getValues();
+            pyResult = Shiboken::Conversions::copyToPython(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_DOUBLE_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_FloatNodeCreationPropertyFunc_setValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::FloatNodeCreationProperty *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_FLOATNODECREATIONPROPERTY_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.FloatNodeCreationProperty.setValue(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.FloatNodeCreationProperty.setValue(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setValue", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: FloatNodeCreationProperty::setValue(double,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setValue(double,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setValue(double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_FloatNodeCreationPropertyFunc_setValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","index");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.FloatNodeCreationProperty.setValue(): got multiple values for keyword argument 'index'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_FloatNodeCreationPropertyFunc_setValue_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setValue(double,int)
+            cppSelf->setValue(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_FloatNodeCreationPropertyFunc_setValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.FloatNodeCreationProperty.setValue");
+        return {};
+}
+
+
+static const char *Sbk_FloatNodeCreationProperty_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_FloatNodeCreationProperty_methods[] = {
+    {"getValues", reinterpret_cast<PyCFunction>(Sbk_FloatNodeCreationPropertyFunc_getValues), METH_NOARGS},
+    {"setValue", reinterpret_cast<PyCFunction>(Sbk_FloatNodeCreationPropertyFunc_setValue), METH_VARARGS|METH_KEYWORDS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_FloatNodeCreationProperty_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::FloatNodeCreationProperty *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_FLOATNODECREATIONPROPERTY_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<FloatNodeCreationPropertyWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_FloatNodeCreationProperty_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_FloatNodeCreationProperty_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_FloatNodeCreationProperty_Type = nullptr;
+static SbkObjectType *Sbk_FloatNodeCreationProperty_TypeF(void)
+{
+    return _Sbk_FloatNodeCreationProperty_Type;
+}
+
+static PyType_Slot Sbk_FloatNodeCreationProperty_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_FloatNodeCreationProperty_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_FloatNodeCreationProperty_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_FloatNodeCreationProperty_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_FloatNodeCreationProperty_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_FloatNodeCreationProperty_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_FloatNodeCreationProperty_spec = {
+    "1:NatronEngine.FloatNodeCreationProperty",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_FloatNodeCreationProperty_slots
+};
+
+} //extern "C"
+
+static void *Sbk_FloatNodeCreationProperty_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::NodeCreationProperty >()))
+        return dynamic_cast< ::FloatNodeCreationProperty *>(reinterpret_cast< ::NodeCreationProperty *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void FloatNodeCreationProperty_PythonToCpp_FloatNodeCreationProperty_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_FloatNodeCreationProperty_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_FloatNodeCreationProperty_PythonToCpp_FloatNodeCreationProperty_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_FloatNodeCreationProperty_TypeF())))
+        return FloatNodeCreationProperty_PythonToCpp_FloatNodeCreationProperty_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *FloatNodeCreationProperty_PTR_CppToPython_FloatNodeCreationProperty(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::FloatNodeCreationProperty *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_FloatNodeCreationProperty_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *FloatNodeCreationProperty_SignatureStrings[] = {
+    "1:NatronEngine.FloatNodeCreationProperty(self,values:std.vector[double]=std.vector< double >())",
+    "0:NatronEngine.FloatNodeCreationProperty(self,value:double)",
+    "NatronEngine.FloatNodeCreationProperty.getValues(self)->std.vector[double]",
+    "NatronEngine.FloatNodeCreationProperty.setValue(self,value:double,index:int=0)",
+    nullptr}; // Sentinel
+
+void init_FloatNodeCreationProperty(PyObject *module)
+{
+    _Sbk_FloatNodeCreationProperty_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "FloatNodeCreationProperty",
+        "FloatNodeCreationProperty*",
+        &Sbk_FloatNodeCreationProperty_spec,
+        &Shiboken::callCppDestructor< ::FloatNodeCreationProperty >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_NODECREATIONPROPERTY_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_FloatNodeCreationProperty_Type);
+    InitSignatureStrings(pyType, FloatNodeCreationProperty_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_FloatNodeCreationProperty_Type), Sbk_FloatNodeCreationProperty_PropertyStrings);
+    SbkNatronEngineTypes[SBK_FLOATNODECREATIONPROPERTY_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_FloatNodeCreationProperty_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_FloatNodeCreationProperty_TypeF(),
+        FloatNodeCreationProperty_PythonToCpp_FloatNodeCreationProperty_PTR,
+        is_FloatNodeCreationProperty_PythonToCpp_FloatNodeCreationProperty_PTR_Convertible,
+        FloatNodeCreationProperty_PTR_CppToPython_FloatNodeCreationProperty);
+
+    Shiboken::Conversions::registerConverterName(converter, "FloatNodeCreationProperty");
+    Shiboken::Conversions::registerConverterName(converter, "FloatNodeCreationProperty*");
+    Shiboken::Conversions::registerConverterName(converter, "FloatNodeCreationProperty&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::FloatNodeCreationProperty).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::FloatNodeCreationPropertyWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_FloatNodeCreationProperty_TypeF(), &Sbk_FloatNodeCreationProperty_typeDiscovery);
+
+
+    FloatNodeCreationPropertyWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/floatnodecreationproperty_wrapper.h
+++ b/Engine/Qt5/NatronEngine/floatnodecreationproperty_wrapper.h
@@ -1,0 +1,43 @@
+#ifndef SBK_FLOATNODECREATIONPROPERTYWRAPPER_H
+#define SBK_FLOATNODECREATIONPROPERTYWRAPPER_H
+
+#include <PyAppInstance.h>
+
+
+// Extra includes
+#include <vector>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class FloatNodeCreationPropertyWrapper : public FloatNodeCreationProperty
+{
+public:
+    FloatNodeCreationPropertyWrapper(const std::vector<double > & values = std::vector< double >());
+    FloatNodeCreationPropertyWrapper(double value);
+    ~FloatNodeCreationPropertyWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_NODECREATIONPROPERTYWRAPPER_H
+#  define SBK_NODECREATIONPROPERTYWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class NodeCreationPropertyWrapper : public NodeCreationProperty
+{
+public:
+    NodeCreationPropertyWrapper();
+    ~NodeCreationPropertyWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_NODECREATIONPROPERTYWRAPPER_H
+
+#endif // SBK_FLOATNODECREATIONPROPERTYWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/group_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/group_wrapper.cpp
@@ -1,0 +1,357 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "group_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void GroupWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void GroupWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+GroupWrapper::GroupWrapper() : Group()
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+GroupWrapper::~GroupWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_Group_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::Group >()))
+        return -1;
+
+    ::GroupWrapper *cptr{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // Group()
+            cptr = new ::GroupWrapper();
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::Group >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    Shiboken::Object::setHasCppWrapper(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+}
+
+static PyObject *Sbk_GroupFunc_getChildren(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Group *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_GROUP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getChildren()const
+            // Begin code injection
+            std::list<Effect*> effects = cppSelf->getChildren();
+            PyObject* ret = PyList_New((int) effects.size());
+            int idx = 0;
+            for (std::list<Effect*>::iterator it = effects.begin(); it!=effects.end(); ++it,++idx) {
+            PyObject* item = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), *it);
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(item);
+            PyList_SET_ITEM(ret, idx, item);
+            }
+            return ret;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_GroupFunc_getNode(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Group *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_GROUP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Group::getNode(QString)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // getNode(QString)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GroupFunc_getNode_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getNode(QString)const
+            Effect * cppResult = const_cast<const ::Group *>(cppSelf)->getNode(cppArg0);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_GroupFunc_getNode_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Group.getNode");
+        return {};
+}
+
+
+static const char *Sbk_Group_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_Group_methods[] = {
+    {"getChildren", reinterpret_cast<PyCFunction>(Sbk_GroupFunc_getChildren), METH_NOARGS},
+    {"getNode", reinterpret_cast<PyCFunction>(Sbk_GroupFunc_getNode), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_Group_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::Group *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_GROUP_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<GroupWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_Group_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_Group_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_Group_Type = nullptr;
+static SbkObjectType *Sbk_Group_TypeF(void)
+{
+    return _Sbk_Group_Type;
+}
+
+static PyType_Slot Sbk_Group_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_Group_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_Group_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_Group_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_Group_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_Group_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_Group_spec = {
+    "1:NatronEngine.Group",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_Group_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void Group_PythonToCpp_Group_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_Group_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_Group_PythonToCpp_Group_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_Group_TypeF())))
+        return Group_PythonToCpp_Group_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *Group_PTR_CppToPython_Group(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::Group *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_Group_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *Group_SignatureStrings[] = {
+    "NatronEngine.Group(self)",
+    "NatronEngine.Group.getChildren(self)->std.list[NatronEngine.Effect]",
+    "NatronEngine.Group.getNode(self,fullySpecifiedName:QString)->NatronEngine.Effect",
+    nullptr}; // Sentinel
+
+void init_Group(PyObject *module)
+{
+    _Sbk_Group_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "Group",
+        "Group*",
+        &Sbk_Group_spec,
+        &Shiboken::callCppDestructor< ::Group >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_Group_Type);
+    InitSignatureStrings(pyType, Group_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_Group_Type), Sbk_Group_PropertyStrings);
+    SbkNatronEngineTypes[SBK_GROUP_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_Group_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_Group_TypeF(),
+        Group_PythonToCpp_Group_PTR,
+        is_Group_PythonToCpp_Group_PTR_Convertible,
+        Group_PTR_CppToPython_Group);
+
+    Shiboken::Conversions::registerConverterName(converter, "Group");
+    Shiboken::Conversions::registerConverterName(converter, "Group*");
+    Shiboken::Conversions::registerConverterName(converter, "Group&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Group).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::GroupWrapper).name());
+
+
+
+    GroupWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/group_wrapper.h
+++ b/Engine/Qt5/NatronEngine/group_wrapper.h
@@ -1,0 +1,24 @@
+#ifndef SBK_GROUPWRAPPER_H
+#define SBK_GROUPWRAPPER_H
+
+#include <PyNodeGroup.h>
+
+
+// Extra includes
+#include <PyNode.h>
+#include <list>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class GroupWrapper : public Group
+{
+public:
+    GroupWrapper();
+    ~GroupWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#endif // SBK_GROUPWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/groupparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/groupparam_wrapper.cpp
@@ -1,0 +1,380 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "groupparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void GroupParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void GroupParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+GroupParamWrapper::~GroupParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_GroupParamFunc_addParam(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<GroupParamWrapper *>(reinterpret_cast< ::GroupParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_GROUPPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: GroupParam::addParam(const Param*)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), (pyArg)))) {
+        overloadId = 0; // addParam(const Param*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GroupParamFunc_addParam_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::Param *cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // addParam(const Param*)
+            cppSelf->addParam(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_GroupParamFunc_addParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.GroupParam.addParam");
+        return {};
+}
+
+static PyObject *Sbk_GroupParamFunc_getIsOpened(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<GroupParamWrapper *>(reinterpret_cast< ::GroupParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_GROUPPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getIsOpened()const
+            bool cppResult = const_cast<const ::GroupParamWrapper *>(cppSelf)->getIsOpened();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_GroupParamFunc_setAsTab(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<GroupParamWrapper *>(reinterpret_cast< ::GroupParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_GROUPPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // setAsTab()
+            cppSelf->setAsTab();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_GroupParamFunc_setOpened(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<GroupParamWrapper *>(reinterpret_cast< ::GroupParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_GROUPPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: GroupParam::setOpened(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setOpened(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GroupParamFunc_setOpened_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setOpened(bool)
+            // Begin code injection
+            cppSelf->setOpened(cppArg0);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_GroupParamFunc_setOpened_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.GroupParam.setOpened");
+        return {};
+}
+
+
+static const char *Sbk_GroupParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_GroupParam_methods[] = {
+    {"addParam", reinterpret_cast<PyCFunction>(Sbk_GroupParamFunc_addParam), METH_O},
+    {"getIsOpened", reinterpret_cast<PyCFunction>(Sbk_GroupParamFunc_getIsOpened), METH_NOARGS},
+    {"setAsTab", reinterpret_cast<PyCFunction>(Sbk_GroupParamFunc_setAsTab), METH_NOARGS},
+    {"setOpened", reinterpret_cast<PyCFunction>(Sbk_GroupParamFunc_setOpened), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_GroupParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::GroupParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_GROUPPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<GroupParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_GroupParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_GroupParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_GroupParam_Type = nullptr;
+static SbkObjectType *Sbk_GroupParam_TypeF(void)
+{
+    return _Sbk_GroupParam_Type;
+}
+
+static PyType_Slot Sbk_GroupParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_GroupParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_GroupParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_GroupParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_GroupParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_GroupParam_spec = {
+    "1:NatronEngine.GroupParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_GroupParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_GroupParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::GroupParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void GroupParam_PythonToCpp_GroupParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_GroupParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_GroupParam_PythonToCpp_GroupParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_GroupParam_TypeF())))
+        return GroupParam_PythonToCpp_GroupParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *GroupParam_PTR_CppToPython_GroupParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::GroupParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_GroupParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *GroupParam_SignatureStrings[] = {
+    "NatronEngine.GroupParam.addParam(self,param:NatronEngine.Param)",
+    "NatronEngine.GroupParam.getIsOpened(self)->bool",
+    "NatronEngine.GroupParam.setAsTab(self)",
+    "NatronEngine.GroupParam.setOpened(self,opened:bool)",
+    nullptr}; // Sentinel
+
+void init_GroupParam(PyObject *module)
+{
+    _Sbk_GroupParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "GroupParam",
+        "GroupParam*",
+        &Sbk_GroupParam_spec,
+        &Shiboken::callCppDestructor< ::GroupParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_GroupParam_Type);
+    InitSignatureStrings(pyType, GroupParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_GroupParam_Type), Sbk_GroupParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_GROUPPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_GroupParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_GroupParam_TypeF(),
+        GroupParam_PythonToCpp_GroupParam_PTR,
+        is_GroupParam_PythonToCpp_GroupParam_PTR_Convertible,
+        GroupParam_PTR_CppToPython_GroupParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "GroupParam");
+    Shiboken::Conversions::registerConverterName(converter, "GroupParam*");
+    Shiboken::Conversions::registerConverterName(converter, "GroupParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::GroupParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::GroupParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_GroupParam_TypeF(), &Sbk_GroupParam_typeDiscovery);
+
+
+    GroupParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/groupparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/groupparam_wrapper.h
@@ -1,0 +1,42 @@
+#ifndef SBK_GROUPPARAMWRAPPER_H
+#define SBK_GROUPPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class GroupParamWrapper : public GroupParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { GroupParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~GroupParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_GROUPPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/imagelayer_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/imagelayer_wrapper.cpp
@@ -1,0 +1,769 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "imagelayer_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+// Extra includes
+#include <PyNode.h>
+
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_ImageLayer_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::ImageLayer >()))
+        return -1;
+
+    ::ImageLayer *cptr{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "ImageLayer", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return -1;
+
+
+    // Overloaded function decisor
+    // 0: ImageLayer::ImageLayer(QString,QString,QStringList)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRINGLIST_IDX], (pyArgs[2])))) {
+        overloadId = 0; // ImageLayer(QString,QString,QStringList)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ImageLayer_Init_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        ::QStringList cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // ImageLayer(QString,QString,QStringList)
+            cptr = new ::ImageLayer(cppArg0, cppArg1, cppArg2);
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::ImageLayer >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    if (!cptr) goto Sbk_ImageLayer_Init_TypeError;
+
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+
+    Sbk_ImageLayer_Init_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ImageLayer");
+        return -1;
+}
+
+static PyObject *Sbk_ImageLayerFunc_getAlphaComponents(PyObject *self)
+{
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getAlphaComponents()
+            ImageLayer cppResult = ::ImageLayer::getAlphaComponents();
+            pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ImageLayerFunc_getBackwardMotionComponents(PyObject *self)
+{
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getBackwardMotionComponents()
+            ImageLayer cppResult = ::ImageLayer::getBackwardMotionComponents();
+            pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ImageLayerFunc_getComponentsNames(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ImageLayer *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getComponentsNames()const
+            const QStringList & cppResult = const_cast<const ::ImageLayer *>(cppSelf)->getComponentsNames();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRINGLIST_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ImageLayerFunc_getComponentsPrettyName(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ImageLayer *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getComponentsPrettyName()const
+            const QString & cppResult = const_cast<const ::ImageLayer *>(cppSelf)->getComponentsPrettyName();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ImageLayerFunc_getDisparityLeftComponents(PyObject *self)
+{
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getDisparityLeftComponents()
+            ImageLayer cppResult = ::ImageLayer::getDisparityLeftComponents();
+            pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ImageLayerFunc_getDisparityRightComponents(PyObject *self)
+{
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getDisparityRightComponents()
+            ImageLayer cppResult = ::ImageLayer::getDisparityRightComponents();
+            pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ImageLayerFunc_getForwardMotionComponents(PyObject *self)
+{
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getForwardMotionComponents()
+            ImageLayer cppResult = ::ImageLayer::getForwardMotionComponents();
+            pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ImageLayerFunc_getHash(PyObject *self, PyObject *pyArg)
+{
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: static ImageLayer::getHash(ImageLayer)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), (pyArg)))) {
+        overloadId = 0; // getHash(ImageLayer)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ImageLayerFunc_getHash_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::ImageLayer cppArg0_local = ::ImageLayer(::QString(), ::QString(), ::QStringList());
+        ::ImageLayer *cppArg0 = &cppArg0_local;
+        if (Shiboken::Conversions::isImplicitConversion(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), pythonToCpp))
+            pythonToCpp(pyArg, &cppArg0_local);
+        else
+            pythonToCpp(pyArg, &cppArg0);
+
+
+        if (!PyErr_Occurred()) {
+            // getHash(ImageLayer)
+            int cppResult = ::ImageLayer::getHash(*cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ImageLayerFunc_getHash_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ImageLayer.getHash");
+        return {};
+}
+
+static PyObject *Sbk_ImageLayerFunc_getLayerName(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ImageLayer *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getLayerName()const
+            const QString & cppResult = const_cast<const ::ImageLayer *>(cppSelf)->getLayerName();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ImageLayerFunc_getNoneComponents(PyObject *self)
+{
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getNoneComponents()
+            ImageLayer cppResult = ::ImageLayer::getNoneComponents();
+            pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ImageLayerFunc_getNumComponents(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ImageLayer *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getNumComponents()const
+            int cppResult = const_cast<const ::ImageLayer *>(cppSelf)->getNumComponents();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ImageLayerFunc_getRGBAComponents(PyObject *self)
+{
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getRGBAComponents()
+            ImageLayer cppResult = ::ImageLayer::getRGBAComponents();
+            pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ImageLayerFunc_getRGBComponents(PyObject *self)
+{
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getRGBComponents()
+            ImageLayer cppResult = ::ImageLayer::getRGBComponents();
+            pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ImageLayerFunc_isColorPlane(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ImageLayer *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // isColorPlane()const
+            bool cppResult = const_cast<const ::ImageLayer *>(cppSelf)->isColorPlane();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ImageLayer___copy__(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto &cppSelf = *reinterpret_cast< ::ImageLayer *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX], reinterpret_cast<SbkObject *>(self)));
+    PyObject *pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), &cppSelf);
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+
+static const char *Sbk_ImageLayer_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_ImageLayer_methods[] = {
+    {"getAlphaComponents", reinterpret_cast<PyCFunction>(Sbk_ImageLayerFunc_getAlphaComponents), METH_NOARGS|METH_STATIC},
+    {"getBackwardMotionComponents", reinterpret_cast<PyCFunction>(Sbk_ImageLayerFunc_getBackwardMotionComponents), METH_NOARGS|METH_STATIC},
+    {"getComponentsNames", reinterpret_cast<PyCFunction>(Sbk_ImageLayerFunc_getComponentsNames), METH_NOARGS},
+    {"getComponentsPrettyName", reinterpret_cast<PyCFunction>(Sbk_ImageLayerFunc_getComponentsPrettyName), METH_NOARGS},
+    {"getDisparityLeftComponents", reinterpret_cast<PyCFunction>(Sbk_ImageLayerFunc_getDisparityLeftComponents), METH_NOARGS|METH_STATIC},
+    {"getDisparityRightComponents", reinterpret_cast<PyCFunction>(Sbk_ImageLayerFunc_getDisparityRightComponents), METH_NOARGS|METH_STATIC},
+    {"getForwardMotionComponents", reinterpret_cast<PyCFunction>(Sbk_ImageLayerFunc_getForwardMotionComponents), METH_NOARGS|METH_STATIC},
+    {"getHash", reinterpret_cast<PyCFunction>(Sbk_ImageLayerFunc_getHash), METH_O|METH_STATIC},
+    {"getLayerName", reinterpret_cast<PyCFunction>(Sbk_ImageLayerFunc_getLayerName), METH_NOARGS},
+    {"getNoneComponents", reinterpret_cast<PyCFunction>(Sbk_ImageLayerFunc_getNoneComponents), METH_NOARGS|METH_STATIC},
+    {"getNumComponents", reinterpret_cast<PyCFunction>(Sbk_ImageLayerFunc_getNumComponents), METH_NOARGS},
+    {"getRGBAComponents", reinterpret_cast<PyCFunction>(Sbk_ImageLayerFunc_getRGBAComponents), METH_NOARGS|METH_STATIC},
+    {"getRGBComponents", reinterpret_cast<PyCFunction>(Sbk_ImageLayerFunc_getRGBComponents), METH_NOARGS|METH_STATIC},
+    {"isColorPlane", reinterpret_cast<PyCFunction>(Sbk_ImageLayerFunc_isColorPlane), METH_NOARGS},
+
+    {"__copy__", reinterpret_cast<PyCFunction>(Sbk_ImageLayer___copy__), METH_NOARGS},
+    {nullptr, nullptr} // Sentinel
+};
+
+// Rich comparison
+static PyObject * Sbk_ImageLayer_richcompare(PyObject *self, PyObject *pyArg, int op)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto &cppSelf = *reinterpret_cast< ::ImageLayer *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    PythonToCppFunc pythonToCpp;
+    SBK_UNUSED(pythonToCpp)
+
+    switch (op) {
+        case Py_NE:
+            if ((pythonToCpp = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), (pyArg)))) {
+                // operator!=(const ImageLayer & other) const
+                if (!Shiboken::Object::isValid(pyArg))
+                    return {};
+                ::ImageLayer cppArg0_local = ::ImageLayer(::QString(), ::QString(), ::QStringList());
+                ::ImageLayer *cppArg0 = &cppArg0_local;
+                if (Shiboken::Conversions::isImplicitConversion(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), pythonToCpp))
+                    pythonToCpp(pyArg, &cppArg0_local);
+                else
+                    pythonToCpp(pyArg, &cppArg0);
+
+                bool cppResult = cppSelf !=(*cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            } else {
+                pyResult = Py_True;
+                Py_INCREF(pyResult);
+            }
+
+            break;
+        case Py_LT:
+            if ((pythonToCpp = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), (pyArg)))) {
+                // operator<(const ImageLayer & other) const
+                if (!Shiboken::Object::isValid(pyArg))
+                    return {};
+                ::ImageLayer cppArg0_local = ::ImageLayer(::QString(), ::QString(), ::QStringList());
+                ::ImageLayer *cppArg0 = &cppArg0_local;
+                if (Shiboken::Conversions::isImplicitConversion(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), pythonToCpp))
+                    pythonToCpp(pyArg, &cppArg0_local);
+                else
+                    pythonToCpp(pyArg, &cppArg0);
+
+                bool cppResult = cppSelf <(*cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            } else {
+                goto Sbk_ImageLayer_RichComparison_TypeError;
+            }
+
+            break;
+        case Py_EQ:
+            if ((pythonToCpp = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), (pyArg)))) {
+                // operator==(const ImageLayer & other) const
+                if (!Shiboken::Object::isValid(pyArg))
+                    return {};
+                ::ImageLayer cppArg0_local = ::ImageLayer(::QString(), ::QString(), ::QStringList());
+                ::ImageLayer *cppArg0 = &cppArg0_local;
+                if (Shiboken::Conversions::isImplicitConversion(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), pythonToCpp))
+                    pythonToCpp(pyArg, &cppArg0_local);
+                else
+                    pythonToCpp(pyArg, &cppArg0);
+
+                bool cppResult = cppSelf ==(*cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            } else {
+                pyResult = Py_False;
+                Py_INCREF(pyResult);
+            }
+
+            break;
+        default:
+            // PYSIDE-74: By default, we redirect to object's tp_richcompare (which is `==`, `!=`).
+            return FallbackRichCompare(self, pyArg, op);
+            goto Sbk_ImageLayer_RichComparison_TypeError;
+    }
+
+    if (pyResult && !PyErr_Occurred())
+        return pyResult;
+    Sbk_ImageLayer_RichComparison_TypeError:
+    PyErr_SetString(PyExc_NotImplementedError, "operator not implemented.");
+    return {};
+
+}
+
+} // extern "C"
+
+static Py_hash_t Sbk_ImageLayer_HashFunc(PyObject *self) {
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ImageLayer *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    return Py_hash_t(ImageLayer::getHash(*cppSelf));
+}
+
+static int Sbk_ImageLayer_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_ImageLayer_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_ImageLayer_Type = nullptr;
+static SbkObjectType *Sbk_ImageLayer_TypeF(void)
+{
+    return _Sbk_ImageLayer_Type;
+}
+
+static PyType_Slot Sbk_ImageLayer_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        reinterpret_cast<void *>(&Sbk_ImageLayer_HashFunc)},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    nullptr},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_ImageLayer_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_ImageLayer_clear)},
+    {Py_tp_richcompare, reinterpret_cast<void *>(Sbk_ImageLayer_richcompare)},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_ImageLayer_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_ImageLayer_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_ImageLayer_spec = {
+    "1:NatronEngine.ImageLayer",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_ImageLayer_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void ImageLayer_PythonToCpp_ImageLayer_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_ImageLayer_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_ImageLayer_PythonToCpp_ImageLayer_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_ImageLayer_TypeF())))
+        return ImageLayer_PythonToCpp_ImageLayer_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *ImageLayer_PTR_CppToPython_ImageLayer(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::ImageLayer *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_ImageLayer_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// C++ to Python copy conversion.
+static PyObject *ImageLayer_COPY_CppToPython_ImageLayer(const void *cppIn) {
+    return Shiboken::Object::newObject(Sbk_ImageLayer_TypeF(), new ::ImageLayer(*reinterpret_cast<const ::ImageLayer *>(cppIn)), true, true);
+}
+
+// Python to C++ copy conversion.
+static void ImageLayer_PythonToCpp_ImageLayer_COPY(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::ImageLayer *>(cppOut) = *reinterpret_cast< ::ImageLayer *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX], reinterpret_cast<SbkObject *>(pyIn)));
+}
+static PythonToCppFunc is_ImageLayer_PythonToCpp_ImageLayer_COPY_Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_ImageLayer_TypeF())))
+        return ImageLayer_PythonToCpp_ImageLayer_COPY;
+    return {};
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *ImageLayer_SignatureStrings[] = {
+    "NatronEngine.ImageLayer(self,layerName:QString,componentsPrettyName:QString,componentsName:QStringList)",
+    "NatronEngine.ImageLayer.getAlphaComponents()->NatronEngine.ImageLayer",
+    "NatronEngine.ImageLayer.getBackwardMotionComponents()->NatronEngine.ImageLayer",
+    "NatronEngine.ImageLayer.getComponentsNames(self)->QStringList",
+    "NatronEngine.ImageLayer.getComponentsPrettyName(self)->QString",
+    "NatronEngine.ImageLayer.getDisparityLeftComponents()->NatronEngine.ImageLayer",
+    "NatronEngine.ImageLayer.getDisparityRightComponents()->NatronEngine.ImageLayer",
+    "NatronEngine.ImageLayer.getForwardMotionComponents()->NatronEngine.ImageLayer",
+    "NatronEngine.ImageLayer.getHash(layer:NatronEngine.ImageLayer)->int",
+    "NatronEngine.ImageLayer.getLayerName(self)->QString",
+    "NatronEngine.ImageLayer.getNoneComponents()->NatronEngine.ImageLayer",
+    "NatronEngine.ImageLayer.getNumComponents(self)->int",
+    "NatronEngine.ImageLayer.getRGBAComponents()->NatronEngine.ImageLayer",
+    "NatronEngine.ImageLayer.getRGBComponents()->NatronEngine.ImageLayer",
+    "NatronEngine.ImageLayer.isColorPlane(self)->bool",
+    "NatronEngine.ImageLayer.__copy__()",
+    nullptr}; // Sentinel
+
+void init_ImageLayer(PyObject *module)
+{
+    _Sbk_ImageLayer_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "ImageLayer",
+        "ImageLayer",
+        &Sbk_ImageLayer_spec,
+        &Shiboken::callCppDestructor< ::ImageLayer >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_ImageLayer_Type);
+    InitSignatureStrings(pyType, ImageLayer_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_ImageLayer_Type), Sbk_ImageLayer_PropertyStrings);
+    SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_ImageLayer_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_ImageLayer_TypeF(),
+        ImageLayer_PythonToCpp_ImageLayer_PTR,
+        is_ImageLayer_PythonToCpp_ImageLayer_PTR_Convertible,
+        ImageLayer_PTR_CppToPython_ImageLayer,
+        ImageLayer_COPY_CppToPython_ImageLayer);
+
+    Shiboken::Conversions::registerConverterName(converter, "ImageLayer");
+    Shiboken::Conversions::registerConverterName(converter, "ImageLayer*");
+    Shiboken::Conversions::registerConverterName(converter, "ImageLayer&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::ImageLayer).name());
+
+    // Add Python to C++ copy (value, not pointer neither reference) conversion to type converter.
+    Shiboken::Conversions::addPythonToCppValueConversion(converter,
+        ImageLayer_PythonToCpp_ImageLayer_COPY,
+        is_ImageLayer_PythonToCpp_ImageLayer_COPY_Convertible);
+
+
+}

--- a/Engine/Qt5/NatronEngine/imagelayer_wrapper.h
+++ b/Engine/Qt5/NatronEngine/imagelayer_wrapper.h
@@ -1,0 +1,7 @@
+#ifndef SBK_IMAGELAYER_H
+#define SBK_IMAGELAYER_H
+
+#include <PyNode.h>
+
+#endif // SBK_IMAGELAYER_H
+

--- a/Engine/Qt5/NatronEngine/int2dparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/int2dparam_wrapper.cpp
@@ -1,0 +1,413 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "int2dparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void Int2DParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void Int2DParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+Int2DParamWrapper::~Int2DParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_Int2DParamFunc_get(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Int2DParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT2DPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "get", 0, 1, &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::get()const
+    // 1: IntParam::get(double)const
+    if (numArgs == 0) {
+        overloadId = 0; // get()const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        overloadId = 1; // get(double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_Int2DParamFunc_get_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // get() const
+        {
+
+            if (!PyErr_Occurred()) {
+                // get()const
+                Int2DTuple* cppResult = new Int2DTuple(const_cast<const ::Int2DParam *>(cppSelf)->get());
+                pyResult = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_INT2DTUPLE_IDX]), cppResult, true, true);
+            }
+            break;
+        }
+        case 1: // get(double frame) const
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // get(double)const
+                Int2DTuple* cppResult = new Int2DTuple(const_cast<const ::Int2DParam *>(cppSelf)->get(cppArg0));
+                pyResult = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_INT2DTUPLE_IDX]), cppResult, true, true);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_Int2DParamFunc_get_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Int2DParam.get");
+        return {};
+}
+
+static PyObject *Sbk_Int2DParamFunc_set(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Int2DParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT2DPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "set", 1, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::set(int)
+    // 1: Int2DParam::set(int,int)
+    // 2: Int2DParam::set(int,int,double)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // set(int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 1; // set(int,int)
+            } else if (numArgs == 3
+                && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+                overloadId = 2; // set(int,int,double)
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_Int2DParamFunc_set_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // set(int x)
+        {
+            PyErr_Format(PyExc_TypeError, "%s is a private method.", "set(int x)");
+            return {};
+            break;
+        }
+        case 1: // set(int x, int y)
+        {
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            int cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+
+            if (!PyErr_Occurred()) {
+                // set(int,int)
+                // Begin code injection
+                cppSelf->set(cppArg0,cppArg1);
+
+                // End of code injection
+
+            }
+            break;
+        }
+        case 2: // set(int x, int y, double frame)
+        {
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            int cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            double cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+
+            if (!PyErr_Occurred()) {
+                // set(int,int,double)
+                // Begin code injection
+                cppSelf->set(cppArg0,cppArg1,cppArg2);
+
+                // End of code injection
+
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_Int2DParamFunc_set_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Int2DParam.set");
+        return {};
+}
+
+
+static const char *Sbk_Int2DParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_Int2DParam_methods[] = {
+    {"get", reinterpret_cast<PyCFunction>(Sbk_Int2DParamFunc_get), METH_VARARGS},
+    {"set", reinterpret_cast<PyCFunction>(Sbk_Int2DParamFunc_set), METH_VARARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_Int2DParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::Int2DParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT2DPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<Int2DParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_Int2DParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_Int2DParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_Int2DParam_Type = nullptr;
+static SbkObjectType *Sbk_Int2DParam_TypeF(void)
+{
+    return _Sbk_Int2DParam_Type;
+}
+
+static PyType_Slot Sbk_Int2DParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_Int2DParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_Int2DParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_Int2DParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_Int2DParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_Int2DParam_spec = {
+    "1:NatronEngine.Int2DParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_Int2DParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_Int2DParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::Int2DParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void Int2DParam_PythonToCpp_Int2DParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_Int2DParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_Int2DParam_PythonToCpp_Int2DParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_Int2DParam_TypeF())))
+        return Int2DParam_PythonToCpp_Int2DParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *Int2DParam_PTR_CppToPython_Int2DParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::Int2DParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_Int2DParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *Int2DParam_SignatureStrings[] = {
+    "1:NatronEngine.Int2DParam.get(self)->NatronEngine.Int2DTuple",
+    "0:NatronEngine.Int2DParam.get(self,frame:double)->NatronEngine.Int2DTuple",
+    "2:NatronEngine.Int2DParam.set(self,x:int)",
+    "1:NatronEngine.Int2DParam.set(self,x:int,y:int)",
+    "0:NatronEngine.Int2DParam.set(self,x:int,y:int,frame:double)",
+    nullptr}; // Sentinel
+
+void init_Int2DParam(PyObject *module)
+{
+    _Sbk_Int2DParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "Int2DParam",
+        "Int2DParam*",
+        &Sbk_Int2DParam_spec,
+        &Shiboken::callCppDestructor< ::Int2DParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_INTPARAM_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_Int2DParam_Type);
+    InitSignatureStrings(pyType, Int2DParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_Int2DParam_Type), Sbk_Int2DParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_INT2DPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_Int2DParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_Int2DParam_TypeF(),
+        Int2DParam_PythonToCpp_Int2DParam_PTR,
+        is_Int2DParam_PythonToCpp_Int2DParam_PTR_Convertible,
+        Int2DParam_PTR_CppToPython_Int2DParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "Int2DParam");
+    Shiboken::Conversions::registerConverterName(converter, "Int2DParam*");
+    Shiboken::Conversions::registerConverterName(converter, "Int2DParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Int2DParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Int2DParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_Int2DParam_TypeF(), &Sbk_Int2DParam_typeDiscovery);
+
+
+    Int2DParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/int2dparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/int2dparam_wrapper.h
@@ -1,0 +1,78 @@
+#ifndef SBK_INT2DPARAMWRAPPER_H
+#define SBK_INT2DPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class Int2DParamWrapper : public Int2DParam
+{
+public:
+    ~Int2DParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_INTPARAMWRAPPER_H
+#  define SBK_INTPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class IntParamWrapper : public IntParam
+{
+public:
+    ~IntParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_INTPARAMWRAPPER_H
+
+#  ifndef SBK_ANIMATEDPARAMWRAPPER_H
+#  define SBK_ANIMATEDPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AnimatedParamWrapper : public AnimatedParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { AnimatedParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~AnimatedParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_ANIMATEDPARAMWRAPPER_H
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_INT2DPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/int2dtuple_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/int2dtuple_wrapper.cpp
@@ -1,0 +1,339 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "int2dtuple_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_Int2DTuple_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::Int2DTuple >()))
+        return -1;
+
+    ::Int2DTuple *cptr{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // Int2DTuple()
+            cptr = new ::Int2DTuple();
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::Int2DTuple >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+}
+
+
+static const char *Sbk_Int2DTuple_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_Int2DTuple_methods[] = {
+
+    {nullptr, nullptr} // Sentinel
+};
+
+PyObject* Sbk_Int2DTupleFunc___getitem__(PyObject *self, Py_ssize_t _i)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Int2DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT2DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    // Begin code injection
+    if (_i < 0 || _i >= 2) {
+    PyErr_BadArgument();
+    return 0;
+    } else {
+    int ret;
+    switch (_i) {
+    case 0:
+    ret = cppSelf->x;
+    break;
+    case 1:
+    ret = cppSelf->y;
+    break;
+    }
+    return  Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &ret);
+    }
+
+    // End of code injection
+
+}
+
+static PyObject *Sbk_Int2DTuple_get_x(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::Int2DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT2DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int cppOut_local = cppSelf->x;
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppOut_local);
+    return pyOut;
+}
+static int Sbk_Int2DTuple_set_x(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::Int2DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT2DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'x' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'x', 'int' or convertible type expected");
+        return -1;
+    }
+
+    int cppOut_local = cppSelf->x;
+    pythonToCpp(pyIn, &cppOut_local);
+    cppSelf->x = cppOut_local;
+
+    return 0;
+}
+
+static PyObject *Sbk_Int2DTuple_get_y(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::Int2DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT2DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int cppOut_local = cppSelf->y;
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppOut_local);
+    return pyOut;
+}
+static int Sbk_Int2DTuple_set_y(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::Int2DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT2DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'y' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'y', 'int' or convertible type expected");
+        return -1;
+    }
+
+    int cppOut_local = cppSelf->y;
+    pythonToCpp(pyIn, &cppOut_local);
+    cppSelf->y = cppOut_local;
+
+    return 0;
+}
+
+// Getters and Setters for Int2DTuple
+static PyGetSetDef Sbk_Int2DTuple_getsetlist[] = {
+    {const_cast<char *>("x"), Sbk_Int2DTuple_get_x, Sbk_Int2DTuple_set_x},
+    {const_cast<char *>("y"), Sbk_Int2DTuple_get_y, Sbk_Int2DTuple_set_y},
+    {nullptr} // Sentinel
+};
+
+} // extern "C"
+
+static int Sbk_Int2DTuple_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_Int2DTuple_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_Int2DTuple_Type = nullptr;
+static SbkObjectType *Sbk_Int2DTuple_TypeF(void)
+{
+    return _Sbk_Int2DTuple_Type;
+}
+
+static PyType_Slot Sbk_Int2DTuple_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    nullptr},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_Int2DTuple_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_Int2DTuple_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_Int2DTuple_methods)},
+    {Py_tp_getset,      reinterpret_cast<void *>(Sbk_Int2DTuple_getsetlist)},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_Int2DTuple_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    // type supports sequence protocol
+    {Py_sq_item, (void *)&Sbk_Int2DTupleFunc___getitem__},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_Int2DTuple_spec = {
+    "1:NatronEngine.Int2DTuple",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_Int2DTuple_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void Int2DTuple_PythonToCpp_Int2DTuple_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_Int2DTuple_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_Int2DTuple_PythonToCpp_Int2DTuple_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_Int2DTuple_TypeF())))
+        return Int2DTuple_PythonToCpp_Int2DTuple_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *Int2DTuple_PTR_CppToPython_Int2DTuple(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::Int2DTuple *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_Int2DTuple_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *Int2DTuple_SignatureStrings[] = {
+    "NatronEngine.Int2DTuple(self)",
+    nullptr}; // Sentinel
+
+void init_Int2DTuple(PyObject *module)
+{
+    _Sbk_Int2DTuple_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "Int2DTuple",
+        "Int2DTuple*",
+        &Sbk_Int2DTuple_spec,
+        &Shiboken::callCppDestructor< ::Int2DTuple >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_Int2DTuple_Type);
+    InitSignatureStrings(pyType, Int2DTuple_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_Int2DTuple_Type), Sbk_Int2DTuple_PropertyStrings);
+    SbkNatronEngineTypes[SBK_INT2DTUPLE_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_Int2DTuple_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_Int2DTuple_TypeF(),
+        Int2DTuple_PythonToCpp_Int2DTuple_PTR,
+        is_Int2DTuple_PythonToCpp_Int2DTuple_PTR_Convertible,
+        Int2DTuple_PTR_CppToPython_Int2DTuple);
+
+    Shiboken::Conversions::registerConverterName(converter, "Int2DTuple");
+    Shiboken::Conversions::registerConverterName(converter, "Int2DTuple*");
+    Shiboken::Conversions::registerConverterName(converter, "Int2DTuple&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Int2DTuple).name());
+
+
+
+}

--- a/Engine/Qt5/NatronEngine/int2dtuple_wrapper.h
+++ b/Engine/Qt5/NatronEngine/int2dtuple_wrapper.h
@@ -1,0 +1,7 @@
+#ifndef SBK_INT2DTUPLE_H
+#define SBK_INT2DTUPLE_H
+
+#include <PyParameter.h>
+
+#endif // SBK_INT2DTUPLE_H
+

--- a/Engine/Qt5/NatronEngine/int3dparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/int3dparam_wrapper.cpp
@@ -1,0 +1,429 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "int3dparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void Int3DParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void Int3DParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+Int3DParamWrapper::~Int3DParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_Int3DParamFunc_get(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Int3DParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT3DPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "get", 0, 1, &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::get()const
+    // 1: IntParam::get(double)const
+    if (numArgs == 0) {
+        overloadId = 0; // get()const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        overloadId = 1; // get(double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_Int3DParamFunc_get_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // get() const
+        {
+
+            if (!PyErr_Occurred()) {
+                // get()const
+                Int3DTuple* cppResult = new Int3DTuple(const_cast<const ::Int3DParam *>(cppSelf)->get());
+                pyResult = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_INT3DTUPLE_IDX]), cppResult, true, true);
+            }
+            break;
+        }
+        case 1: // get(double frame) const
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // get(double)const
+                Int3DTuple* cppResult = new Int3DTuple(const_cast<const ::Int3DParam *>(cppSelf)->get(cppArg0));
+                pyResult = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_INT3DTUPLE_IDX]), cppResult, true, true);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_Int3DParamFunc_get_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Int3DParam.get");
+        return {};
+}
+
+static PyObject *Sbk_Int3DParamFunc_set(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Int3DParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT3DPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "set", 1, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Int2DParam::set(int,int)
+    // 1: IntParam::set(int)
+    // 2: Int3DParam::set(int,int,int)
+    // 3: Int3DParam::set(int,int,int,double)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 1; // set(int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 0; // set(int,int)
+            } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+                if (numArgs == 3) {
+                    overloadId = 2; // set(int,int,int)
+                } else if (numArgs == 4
+                    && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+                    overloadId = 3; // set(int,int,int,double)
+                }
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_Int3DParamFunc_set_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // set(int x, int y)
+        {
+            PyErr_Format(PyExc_TypeError, "%s is a private method.", "set(int x, int y)");
+            return {};
+            break;
+        }
+        case 1: // set(int x)
+        {
+            PyErr_Format(PyExc_TypeError, "%s is a private method.", "set(int x)");
+            return {};
+            break;
+        }
+        case 2: // set(int x, int y, int z)
+        {
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            int cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            int cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+
+            if (!PyErr_Occurred()) {
+                // set(int,int,int)
+                // Begin code injection
+                cppSelf->set(cppArg0,cppArg1,cppArg2);
+
+                // End of code injection
+
+            }
+            break;
+        }
+        case 3: // set(int x, int y, int z, double frame)
+        {
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            int cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            int cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            double cppArg3;
+            pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // set(int,int,int,double)
+                // Begin code injection
+                cppSelf->set(cppArg0,cppArg1,cppArg2,cppArg3);
+
+                // End of code injection
+
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_Int3DParamFunc_set_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Int3DParam.set");
+        return {};
+}
+
+
+static const char *Sbk_Int3DParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_Int3DParam_methods[] = {
+    {"get", reinterpret_cast<PyCFunction>(Sbk_Int3DParamFunc_get), METH_VARARGS},
+    {"set", reinterpret_cast<PyCFunction>(Sbk_Int3DParamFunc_set), METH_VARARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_Int3DParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::Int3DParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT3DPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<Int3DParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_Int3DParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_Int3DParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_Int3DParam_Type = nullptr;
+static SbkObjectType *Sbk_Int3DParam_TypeF(void)
+{
+    return _Sbk_Int3DParam_Type;
+}
+
+static PyType_Slot Sbk_Int3DParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_Int3DParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_Int3DParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_Int3DParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_Int3DParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_Int3DParam_spec = {
+    "1:NatronEngine.Int3DParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_Int3DParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_Int3DParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::Int3DParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void Int3DParam_PythonToCpp_Int3DParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_Int3DParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_Int3DParam_PythonToCpp_Int3DParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_Int3DParam_TypeF())))
+        return Int3DParam_PythonToCpp_Int3DParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *Int3DParam_PTR_CppToPython_Int3DParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::Int3DParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_Int3DParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *Int3DParam_SignatureStrings[] = {
+    "1:NatronEngine.Int3DParam.get(self)->NatronEngine.Int3DTuple",
+    "0:NatronEngine.Int3DParam.get(self,frame:double)->NatronEngine.Int3DTuple",
+    "3:NatronEngine.Int3DParam.set(self,x:int,y:int)",
+    "2:NatronEngine.Int3DParam.set(self,x:int)",
+    "1:NatronEngine.Int3DParam.set(self,x:int,y:int,z:int)",
+    "0:NatronEngine.Int3DParam.set(self,x:int,y:int,z:int,frame:double)",
+    nullptr}; // Sentinel
+
+void init_Int3DParam(PyObject *module)
+{
+    _Sbk_Int3DParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "Int3DParam",
+        "Int3DParam*",
+        &Sbk_Int3DParam_spec,
+        &Shiboken::callCppDestructor< ::Int3DParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_INT2DPARAM_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_Int3DParam_Type);
+    InitSignatureStrings(pyType, Int3DParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_Int3DParam_Type), Sbk_Int3DParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_INT3DPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_Int3DParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_Int3DParam_TypeF(),
+        Int3DParam_PythonToCpp_Int3DParam_PTR,
+        is_Int3DParam_PythonToCpp_Int3DParam_PTR_Convertible,
+        Int3DParam_PTR_CppToPython_Int3DParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "Int3DParam");
+    Shiboken::Conversions::registerConverterName(converter, "Int3DParam*");
+    Shiboken::Conversions::registerConverterName(converter, "Int3DParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Int3DParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Int3DParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_Int3DParam_TypeF(), &Sbk_Int3DParam_typeDiscovery);
+
+
+    Int3DParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/int3dparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/int3dparam_wrapper.h
@@ -1,0 +1,96 @@
+#ifndef SBK_INT3DPARAMWRAPPER_H
+#define SBK_INT3DPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class Int3DParamWrapper : public Int3DParam
+{
+public:
+    ~Int3DParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_INT2DPARAMWRAPPER_H
+#  define SBK_INT2DPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class Int2DParamWrapper : public Int2DParam
+{
+public:
+    ~Int2DParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_INT2DPARAMWRAPPER_H
+
+#  ifndef SBK_INTPARAMWRAPPER_H
+#  define SBK_INTPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class IntParamWrapper : public IntParam
+{
+public:
+    ~IntParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_INTPARAMWRAPPER_H
+
+#  ifndef SBK_ANIMATEDPARAMWRAPPER_H
+#  define SBK_ANIMATEDPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AnimatedParamWrapper : public AnimatedParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { AnimatedParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~AnimatedParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_ANIMATEDPARAMWRAPPER_H
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_INT3DPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/int3dtuple_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/int3dtuple_wrapper.cpp
@@ -1,0 +1,377 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "int3dtuple_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_Int3DTuple_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::Int3DTuple >()))
+        return -1;
+
+    ::Int3DTuple *cptr{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // Int3DTuple()
+            cptr = new ::Int3DTuple();
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::Int3DTuple >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+}
+
+
+static const char *Sbk_Int3DTuple_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_Int3DTuple_methods[] = {
+
+    {nullptr, nullptr} // Sentinel
+};
+
+PyObject* Sbk_Int3DTupleFunc___getitem__(PyObject *self, Py_ssize_t _i)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Int3DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT3DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    // Begin code injection
+    if (_i < 0 || _i >= 3) {
+    PyErr_BadArgument();
+    return 0;
+    } else {
+    int ret;
+    switch (_i) {
+    case 0:
+    ret = cppSelf->x;
+    break;
+    case 1:
+    ret = cppSelf->y;
+    break;
+    case 2:
+    ret = cppSelf->z;
+    break;
+    }
+    return  Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &ret);
+    }
+
+    // End of code injection
+
+}
+
+static PyObject *Sbk_Int3DTuple_get_x(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::Int3DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT3DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int cppOut_local = cppSelf->x;
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppOut_local);
+    return pyOut;
+}
+static int Sbk_Int3DTuple_set_x(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::Int3DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT3DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'x' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'x', 'int' or convertible type expected");
+        return -1;
+    }
+
+    int cppOut_local = cppSelf->x;
+    pythonToCpp(pyIn, &cppOut_local);
+    cppSelf->x = cppOut_local;
+
+    return 0;
+}
+
+static PyObject *Sbk_Int3DTuple_get_y(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::Int3DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT3DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int cppOut_local = cppSelf->y;
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppOut_local);
+    return pyOut;
+}
+static int Sbk_Int3DTuple_set_y(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::Int3DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT3DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'y' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'y', 'int' or convertible type expected");
+        return -1;
+    }
+
+    int cppOut_local = cppSelf->y;
+    pythonToCpp(pyIn, &cppOut_local);
+    cppSelf->y = cppOut_local;
+
+    return 0;
+}
+
+static PyObject *Sbk_Int3DTuple_get_z(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::Int3DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT3DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int cppOut_local = cppSelf->z;
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppOut_local);
+    return pyOut;
+}
+static int Sbk_Int3DTuple_set_z(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::Int3DTuple *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INT3DTUPLE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'z' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'z', 'int' or convertible type expected");
+        return -1;
+    }
+
+    int cppOut_local = cppSelf->z;
+    pythonToCpp(pyIn, &cppOut_local);
+    cppSelf->z = cppOut_local;
+
+    return 0;
+}
+
+// Getters and Setters for Int3DTuple
+static PyGetSetDef Sbk_Int3DTuple_getsetlist[] = {
+    {const_cast<char *>("x"), Sbk_Int3DTuple_get_x, Sbk_Int3DTuple_set_x},
+    {const_cast<char *>("y"), Sbk_Int3DTuple_get_y, Sbk_Int3DTuple_set_y},
+    {const_cast<char *>("z"), Sbk_Int3DTuple_get_z, Sbk_Int3DTuple_set_z},
+    {nullptr} // Sentinel
+};
+
+} // extern "C"
+
+static int Sbk_Int3DTuple_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_Int3DTuple_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_Int3DTuple_Type = nullptr;
+static SbkObjectType *Sbk_Int3DTuple_TypeF(void)
+{
+    return _Sbk_Int3DTuple_Type;
+}
+
+static PyType_Slot Sbk_Int3DTuple_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    nullptr},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_Int3DTuple_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_Int3DTuple_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_Int3DTuple_methods)},
+    {Py_tp_getset,      reinterpret_cast<void *>(Sbk_Int3DTuple_getsetlist)},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_Int3DTuple_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    // type supports sequence protocol
+    {Py_sq_item, (void *)&Sbk_Int3DTupleFunc___getitem__},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_Int3DTuple_spec = {
+    "1:NatronEngine.Int3DTuple",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_Int3DTuple_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void Int3DTuple_PythonToCpp_Int3DTuple_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_Int3DTuple_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_Int3DTuple_PythonToCpp_Int3DTuple_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_Int3DTuple_TypeF())))
+        return Int3DTuple_PythonToCpp_Int3DTuple_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *Int3DTuple_PTR_CppToPython_Int3DTuple(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::Int3DTuple *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_Int3DTuple_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *Int3DTuple_SignatureStrings[] = {
+    "NatronEngine.Int3DTuple(self)",
+    nullptr}; // Sentinel
+
+void init_Int3DTuple(PyObject *module)
+{
+    _Sbk_Int3DTuple_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "Int3DTuple",
+        "Int3DTuple*",
+        &Sbk_Int3DTuple_spec,
+        &Shiboken::callCppDestructor< ::Int3DTuple >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_Int3DTuple_Type);
+    InitSignatureStrings(pyType, Int3DTuple_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_Int3DTuple_Type), Sbk_Int3DTuple_PropertyStrings);
+    SbkNatronEngineTypes[SBK_INT3DTUPLE_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_Int3DTuple_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_Int3DTuple_TypeF(),
+        Int3DTuple_PythonToCpp_Int3DTuple_PTR,
+        is_Int3DTuple_PythonToCpp_Int3DTuple_PTR_Convertible,
+        Int3DTuple_PTR_CppToPython_Int3DTuple);
+
+    Shiboken::Conversions::registerConverterName(converter, "Int3DTuple");
+    Shiboken::Conversions::registerConverterName(converter, "Int3DTuple*");
+    Shiboken::Conversions::registerConverterName(converter, "Int3DTuple&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Int3DTuple).name());
+
+
+
+}

--- a/Engine/Qt5/NatronEngine/int3dtuple_wrapper.h
+++ b/Engine/Qt5/NatronEngine/int3dtuple_wrapper.h
@@ -1,0 +1,7 @@
+#ifndef SBK_INT3DTUPLE_H
+#define SBK_INT3DTUPLE_H
+
+#include <PyParameter.h>
+
+#endif // SBK_INT3DTUPLE_H
+

--- a/Engine/Qt5/NatronEngine/intnodecreationproperty_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/intnodecreationproperty_wrapper.cpp
@@ -1,0 +1,467 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "intnodecreationproperty_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void IntNodeCreationPropertyWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void IntNodeCreationPropertyWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+IntNodeCreationPropertyWrapper::IntNodeCreationPropertyWrapper(const std::vector<int > & values) : IntNodeCreationProperty(values)
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+IntNodeCreationPropertyWrapper::IntNodeCreationPropertyWrapper(int value) : IntNodeCreationProperty(value)
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+IntNodeCreationPropertyWrapper::~IntNodeCreationPropertyWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_IntNodeCreationProperty_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::IntNodeCreationProperty >()))
+        return -1;
+
+    ::IntNodeCreationPropertyWrapper *cptr{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntNodeCreationProperty(): too many arguments");
+        return -1;
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:IntNodeCreationProperty", &(pyArgs[0])))
+        return -1;
+
+
+    // Overloaded function decisor
+    // 0: IntNodeCreationProperty::IntNodeCreationProperty(std::vector<int>)
+    // 1: IntNodeCreationProperty::IntNodeCreationProperty(int)
+    if (numArgs == 0) {
+        overloadId = 0; // IntNodeCreationProperty(std::vector<int>)
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 1; // IntNodeCreationProperty(int)
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_INT_IDX], (pyArgs[0])))) {
+        overloadId = 0; // IntNodeCreationProperty(std::vector<int>)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntNodeCreationProperty_Init_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // IntNodeCreationProperty(const std::vector<int > & values)
+        {
+            if (kwds) {
+                PyObject *keyName = nullptr;
+                PyObject *value = nullptr;
+                keyName = Py_BuildValue("s","values");
+                if (PyDict_Contains(kwds, keyName)) {
+                    value = PyDict_GetItem(kwds, keyName);
+                    if (value && pyArgs[0]) {
+                        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntNodeCreationProperty(): got multiple values for keyword argument 'values'.");
+                        return -1;
+                    }
+                    if (value) {
+                        pyArgs[0] = value;
+                        if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_INT_IDX], (pyArgs[0]))))
+                            goto Sbk_IntNodeCreationProperty_Init_TypeError;
+                    }
+                }
+            }
+            ::std::vector<int > cppArg0;
+            if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // IntNodeCreationProperty(std::vector<int>)
+                cptr = new ::IntNodeCreationPropertyWrapper(cppArg0);
+            }
+            break;
+        }
+        case 1: // IntNodeCreationProperty(int value)
+        {
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // IntNodeCreationProperty(int)
+                cptr = new ::IntNodeCreationPropertyWrapper(cppArg0);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::IntNodeCreationProperty >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    if (!cptr) goto Sbk_IntNodeCreationProperty_Init_TypeError;
+
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    Shiboken::Object::setHasCppWrapper(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+
+    Sbk_IntNodeCreationProperty_Init_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntNodeCreationProperty");
+        return -1;
+}
+
+static PyObject *Sbk_IntNodeCreationPropertyFunc_getValues(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntNodeCreationProperty *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTNODECREATIONPROPERTY_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getValues()const
+            const std::vector<int > & cppResult = const_cast<const ::IntNodeCreationProperty *>(cppSelf)->getValues();
+            pyResult = Shiboken::Conversions::copyToPython(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_INT_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_IntNodeCreationPropertyFunc_setValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntNodeCreationProperty *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTNODECREATIONPROPERTY_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntNodeCreationProperty.setValue(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntNodeCreationProperty.setValue(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setValue", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntNodeCreationProperty::setValue(int,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setValue(int,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setValue(int,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntNodeCreationPropertyFunc_setValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","index");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.IntNodeCreationProperty.setValue(): got multiple values for keyword argument 'index'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_IntNodeCreationPropertyFunc_setValue_TypeError;
+                }
+            }
+        }
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setValue(int,int)
+            cppSelf->setValue(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_IntNodeCreationPropertyFunc_setValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntNodeCreationProperty.setValue");
+        return {};
+}
+
+
+static const char *Sbk_IntNodeCreationProperty_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_IntNodeCreationProperty_methods[] = {
+    {"getValues", reinterpret_cast<PyCFunction>(Sbk_IntNodeCreationPropertyFunc_getValues), METH_NOARGS},
+    {"setValue", reinterpret_cast<PyCFunction>(Sbk_IntNodeCreationPropertyFunc_setValue), METH_VARARGS|METH_KEYWORDS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_IntNodeCreationProperty_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::IntNodeCreationProperty *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTNODECREATIONPROPERTY_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<IntNodeCreationPropertyWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_IntNodeCreationProperty_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_IntNodeCreationProperty_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_IntNodeCreationProperty_Type = nullptr;
+static SbkObjectType *Sbk_IntNodeCreationProperty_TypeF(void)
+{
+    return _Sbk_IntNodeCreationProperty_Type;
+}
+
+static PyType_Slot Sbk_IntNodeCreationProperty_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_IntNodeCreationProperty_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_IntNodeCreationProperty_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_IntNodeCreationProperty_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_IntNodeCreationProperty_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_IntNodeCreationProperty_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_IntNodeCreationProperty_spec = {
+    "1:NatronEngine.IntNodeCreationProperty",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_IntNodeCreationProperty_slots
+};
+
+} //extern "C"
+
+static void *Sbk_IntNodeCreationProperty_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::NodeCreationProperty >()))
+        return dynamic_cast< ::IntNodeCreationProperty *>(reinterpret_cast< ::NodeCreationProperty *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void IntNodeCreationProperty_PythonToCpp_IntNodeCreationProperty_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_IntNodeCreationProperty_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_IntNodeCreationProperty_PythonToCpp_IntNodeCreationProperty_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_IntNodeCreationProperty_TypeF())))
+        return IntNodeCreationProperty_PythonToCpp_IntNodeCreationProperty_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *IntNodeCreationProperty_PTR_CppToPython_IntNodeCreationProperty(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::IntNodeCreationProperty *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_IntNodeCreationProperty_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *IntNodeCreationProperty_SignatureStrings[] = {
+    "1:NatronEngine.IntNodeCreationProperty(self,values:std.vector[int]=std.vector< int >())",
+    "0:NatronEngine.IntNodeCreationProperty(self,value:int)",
+    "NatronEngine.IntNodeCreationProperty.getValues(self)->std.vector[int]",
+    "NatronEngine.IntNodeCreationProperty.setValue(self,value:int,index:int=0)",
+    nullptr}; // Sentinel
+
+void init_IntNodeCreationProperty(PyObject *module)
+{
+    _Sbk_IntNodeCreationProperty_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "IntNodeCreationProperty",
+        "IntNodeCreationProperty*",
+        &Sbk_IntNodeCreationProperty_spec,
+        &Shiboken::callCppDestructor< ::IntNodeCreationProperty >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_NODECREATIONPROPERTY_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_IntNodeCreationProperty_Type);
+    InitSignatureStrings(pyType, IntNodeCreationProperty_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_IntNodeCreationProperty_Type), Sbk_IntNodeCreationProperty_PropertyStrings);
+    SbkNatronEngineTypes[SBK_INTNODECREATIONPROPERTY_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_IntNodeCreationProperty_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_IntNodeCreationProperty_TypeF(),
+        IntNodeCreationProperty_PythonToCpp_IntNodeCreationProperty_PTR,
+        is_IntNodeCreationProperty_PythonToCpp_IntNodeCreationProperty_PTR_Convertible,
+        IntNodeCreationProperty_PTR_CppToPython_IntNodeCreationProperty);
+
+    Shiboken::Conversions::registerConverterName(converter, "IntNodeCreationProperty");
+    Shiboken::Conversions::registerConverterName(converter, "IntNodeCreationProperty*");
+    Shiboken::Conversions::registerConverterName(converter, "IntNodeCreationProperty&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::IntNodeCreationProperty).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::IntNodeCreationPropertyWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_IntNodeCreationProperty_TypeF(), &Sbk_IntNodeCreationProperty_typeDiscovery);
+
+
+    IntNodeCreationPropertyWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/intnodecreationproperty_wrapper.h
+++ b/Engine/Qt5/NatronEngine/intnodecreationproperty_wrapper.h
@@ -1,0 +1,43 @@
+#ifndef SBK_INTNODECREATIONPROPERTYWRAPPER_H
+#define SBK_INTNODECREATIONPROPERTYWRAPPER_H
+
+#include <PyAppInstance.h>
+
+
+// Extra includes
+#include <vector>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class IntNodeCreationPropertyWrapper : public IntNodeCreationProperty
+{
+public:
+    IntNodeCreationPropertyWrapper(const std::vector<int > & values = std::vector< int >());
+    IntNodeCreationPropertyWrapper(int value);
+    ~IntNodeCreationPropertyWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_NODECREATIONPROPERTYWRAPPER_H
+#  define SBK_NODECREATIONPROPERTYWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class NodeCreationPropertyWrapper : public NodeCreationProperty
+{
+public:
+    NodeCreationPropertyWrapper();
+    ~NodeCreationPropertyWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_NODECREATIONPROPERTYWRAPPER_H
+
+#endif // SBK_INTNODECREATIONPROPERTYWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/intparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/intparam_wrapper.cpp
@@ -1,0 +1,1613 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "intparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void IntParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void IntParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+IntParamWrapper::~IntParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_IntParamFunc_addAsDependencyOf(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "addAsDependencyOf", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::addAsDependencyOf(int,Param*,int)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+        overloadId = 0; // addAsDependencyOf(int,Param*,int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_addAsDependencyOf_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        if (!Shiboken::Object::isValid(pyArgs[1]))
+            return {};
+        ::Param *cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        int cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // addAsDependencyOf(int,Param*,int)
+            int cppResult = cppSelf->addAsDependencyOf(cppArg0, cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_IntParamFunc_addAsDependencyOf_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntParam.addAsDependencyOf");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_get(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "get", 0, 1, &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::get()const
+    // 1: IntParam::get(double)const
+    if (numArgs == 0) {
+        overloadId = 0; // get()const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        overloadId = 1; // get(double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_get_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // get() const
+        {
+
+            if (!PyErr_Occurred()) {
+                // get()const
+                int cppResult = const_cast<const ::IntParam *>(cppSelf)->get();
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+            }
+            break;
+        }
+        case 1: // get(double frame) const
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // get(double)const
+                int cppResult = const_cast<const ::IntParam *>(cppSelf)->get(cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_IntParamFunc_get_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntParam.get");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_getDefaultValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.getDefaultValue(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getDefaultValue", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::getDefaultValue(int)const
+    if (numArgs == 0) {
+        overloadId = 0; // getDefaultValue(int)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // getDefaultValue(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_getDefaultValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.getDefaultValue(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_IntParamFunc_getDefaultValue_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getDefaultValue(int)const
+            int cppResult = const_cast<const ::IntParam *>(cppSelf)->getDefaultValue(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_IntParamFunc_getDefaultValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntParam.getDefaultValue");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_getDisplayMaximum(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: IntParam::getDisplayMaximum(int)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // getDisplayMaximum(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_getDisplayMaximum_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getDisplayMaximum(int)const
+            int cppResult = const_cast<const ::IntParam *>(cppSelf)->getDisplayMaximum(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_IntParamFunc_getDisplayMaximum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.IntParam.getDisplayMaximum");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_getDisplayMinimum(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: IntParam::getDisplayMinimum(int)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // getDisplayMinimum(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_getDisplayMinimum_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getDisplayMinimum(int)const
+            int cppResult = const_cast<const ::IntParam *>(cppSelf)->getDisplayMinimum(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_IntParamFunc_getDisplayMinimum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.IntParam.getDisplayMinimum");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_getMaximum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.getMaximum(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getMaximum", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::getMaximum(int)const
+    if (numArgs == 0) {
+        overloadId = 0; // getMaximum(int)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // getMaximum(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_getMaximum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.getMaximum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_IntParamFunc_getMaximum_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getMaximum(int)const
+            int cppResult = const_cast<const ::IntParam *>(cppSelf)->getMaximum(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_IntParamFunc_getMaximum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntParam.getMaximum");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_getMinimum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.getMinimum(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getMinimum", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::getMinimum(int)const
+    if (numArgs == 0) {
+        overloadId = 0; // getMinimum(int)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // getMinimum(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_getMinimum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.getMinimum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_IntParamFunc_getMinimum_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getMinimum(int)const
+            int cppResult = const_cast<const ::IntParam *>(cppSelf)->getMinimum(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_IntParamFunc_getMinimum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntParam.getMinimum");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_getValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.getValue(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getValue", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::getValue(int)const
+    if (numArgs == 0) {
+        overloadId = 0; // getValue(int)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // getValue(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_getValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.getValue(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_IntParamFunc_getValue_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getValue(int)const
+            int cppResult = const_cast<const ::IntParam *>(cppSelf)->getValue(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_IntParamFunc_getValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntParam.getValue");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_getValueAtTime(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.getValueAtTime(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.getValueAtTime(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:getValueAtTime", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::getValueAtTime(double,int)const
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // getValueAtTime(double,int)const
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // getValueAtTime(double,int)const
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_getValueAtTime_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.getValueAtTime(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_IntParamFunc_getValueAtTime_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // getValueAtTime(double,int)const
+            int cppResult = const_cast<const ::IntParam *>(cppSelf)->getValueAtTime(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_IntParamFunc_getValueAtTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntParam.getValueAtTime");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_restoreDefaultValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.restoreDefaultValue(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:restoreDefaultValue", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::restoreDefaultValue(int)
+    if (numArgs == 0) {
+        overloadId = 0; // restoreDefaultValue(int)
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // restoreDefaultValue(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_restoreDefaultValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.restoreDefaultValue(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_IntParamFunc_restoreDefaultValue_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // restoreDefaultValue(int)
+            // Begin code injection
+            cppSelf->restoreDefaultValue(cppArg0);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_IntParamFunc_restoreDefaultValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntParam.restoreDefaultValue");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_set(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "set", 1, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::set(int)
+    // 1: IntParam::set(int,double)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // set(int)
+        } else if (numArgs == 2
+            && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+            overloadId = 1; // set(int,double)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_set_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // set(int x)
+        {
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // set(int)
+                // Begin code injection
+                cppSelf->set(cppArg0);
+
+                // End of code injection
+
+            }
+            break;
+        }
+        case 1: // set(int x, double frame)
+        {
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+
+            if (!PyErr_Occurred()) {
+                // set(int,double)
+                // Begin code injection
+                cppSelf->set(cppArg0,cppArg1);
+
+                // End of code injection
+
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_IntParamFunc_set_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntParam.set");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_setDefaultValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setDefaultValue(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setDefaultValue(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setDefaultValue", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::setDefaultValue(int,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setDefaultValue(int,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setDefaultValue(int,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_setDefaultValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setDefaultValue(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_IntParamFunc_setDefaultValue_TypeError;
+                }
+            }
+        }
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setDefaultValue(int,int)
+            cppSelf->setDefaultValue(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_IntParamFunc_setDefaultValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntParam.setDefaultValue");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_setDisplayMaximum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setDisplayMaximum(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setDisplayMaximum(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setDisplayMaximum", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::setDisplayMaximum(int,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setDisplayMaximum(int,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setDisplayMaximum(int,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_setDisplayMaximum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setDisplayMaximum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_IntParamFunc_setDisplayMaximum_TypeError;
+                }
+            }
+        }
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setDisplayMaximum(int,int)
+            cppSelf->setDisplayMaximum(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_IntParamFunc_setDisplayMaximum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntParam.setDisplayMaximum");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_setDisplayMinimum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setDisplayMinimum(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setDisplayMinimum(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setDisplayMinimum", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::setDisplayMinimum(int,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setDisplayMinimum(int,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setDisplayMinimum(int,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_setDisplayMinimum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setDisplayMinimum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_IntParamFunc_setDisplayMinimum_TypeError;
+                }
+            }
+        }
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setDisplayMinimum(int,int)
+            cppSelf->setDisplayMinimum(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_IntParamFunc_setDisplayMinimum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntParam.setDisplayMinimum");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_setMaximum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setMaximum(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setMaximum(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setMaximum", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::setMaximum(int,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setMaximum(int,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setMaximum(int,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_setMaximum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setMaximum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_IntParamFunc_setMaximum_TypeError;
+                }
+            }
+        }
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setMaximum(int,int)
+            cppSelf->setMaximum(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_IntParamFunc_setMaximum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntParam.setMaximum");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_setMinimum(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setMinimum(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setMinimum(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setMinimum", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::setMinimum(int,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setMinimum(int,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setMinimum(int,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_setMinimum_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setMinimum(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_IntParamFunc_setMinimum_TypeError;
+                }
+            }
+        }
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setMinimum(int,int)
+            cppSelf->setMinimum(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_IntParamFunc_setMinimum_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntParam.setMinimum");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_setValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setValue(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setValue(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setValue", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::setValue(int,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setValue(int,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setValue(int,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_setValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setValue(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_IntParamFunc_setValue_TypeError;
+                }
+            }
+        }
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setValue(int,int)
+            // Begin code injection
+            cppSelf->setValue(cppArg0,cppArg1);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_IntParamFunc_setValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntParam.setValue");
+        return {};
+}
+
+static PyObject *Sbk_IntParamFunc_setValueAtTime(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 3) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setValueAtTime(): too many arguments");
+        return {};
+    } else if (numArgs < 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setValueAtTime(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOO:setValueAtTime", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: IntParam::setValueAtTime(int,double,int)
+    if (numArgs >= 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        if (numArgs == 2) {
+            overloadId = 0; // setValueAtTime(int,double,int)
+        } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+            overloadId = 0; // setValueAtTime(int,double,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_IntParamFunc_setValueAtTime_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[2]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.IntParam.setValueAtTime(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[2] = value;
+                    if (!(pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2]))))
+                        goto Sbk_IntParamFunc_setValueAtTime_TypeError;
+                }
+            }
+        }
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        int cppArg2 = 0;
+        if (pythonToCpp[2]) pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // setValueAtTime(int,double,int)
+            // Begin code injection
+            cppSelf->setValueAtTime(cppArg0,cppArg1,cppArg2);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_IntParamFunc_setValueAtTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.IntParam.setValueAtTime");
+        return {};
+}
+
+
+static const char *Sbk_IntParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_IntParam_methods[] = {
+    {"addAsDependencyOf", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_addAsDependencyOf), METH_VARARGS},
+    {"get", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_get), METH_VARARGS},
+    {"getDefaultValue", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_getDefaultValue), METH_VARARGS|METH_KEYWORDS},
+    {"getDisplayMaximum", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_getDisplayMaximum), METH_O},
+    {"getDisplayMinimum", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_getDisplayMinimum), METH_O},
+    {"getMaximum", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_getMaximum), METH_VARARGS|METH_KEYWORDS},
+    {"getMinimum", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_getMinimum), METH_VARARGS|METH_KEYWORDS},
+    {"getValue", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_getValue), METH_VARARGS|METH_KEYWORDS},
+    {"getValueAtTime", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_getValueAtTime), METH_VARARGS|METH_KEYWORDS},
+    {"restoreDefaultValue", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_restoreDefaultValue), METH_VARARGS|METH_KEYWORDS},
+    {"set", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_set), METH_VARARGS},
+    {"setDefaultValue", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_setDefaultValue), METH_VARARGS|METH_KEYWORDS},
+    {"setDisplayMaximum", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_setDisplayMaximum), METH_VARARGS|METH_KEYWORDS},
+    {"setDisplayMinimum", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_setDisplayMinimum), METH_VARARGS|METH_KEYWORDS},
+    {"setMaximum", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_setMaximum), METH_VARARGS|METH_KEYWORDS},
+    {"setMinimum", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_setMinimum), METH_VARARGS|METH_KEYWORDS},
+    {"setValue", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_setValue), METH_VARARGS|METH_KEYWORDS},
+    {"setValueAtTime", reinterpret_cast<PyCFunction>(Sbk_IntParamFunc_setValueAtTime), METH_VARARGS|METH_KEYWORDS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_IntParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::IntParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_INTPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<IntParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_IntParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_IntParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_IntParam_Type = nullptr;
+static SbkObjectType *Sbk_IntParam_TypeF(void)
+{
+    return _Sbk_IntParam_Type;
+}
+
+static PyType_Slot Sbk_IntParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_IntParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_IntParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_IntParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_IntParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_IntParam_spec = {
+    "1:NatronEngine.IntParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_IntParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_IntParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::IntParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void IntParam_PythonToCpp_IntParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_IntParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_IntParam_PythonToCpp_IntParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_IntParam_TypeF())))
+        return IntParam_PythonToCpp_IntParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *IntParam_PTR_CppToPython_IntParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::IntParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_IntParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *IntParam_SignatureStrings[] = {
+    "NatronEngine.IntParam.addAsDependencyOf(self,fromExprDimension:int,param:NatronEngine.Param,thisDimension:int)->int",
+    "1:NatronEngine.IntParam.get(self)->int",
+    "0:NatronEngine.IntParam.get(self,frame:double)->int",
+    "NatronEngine.IntParam.getDefaultValue(self,dimension:int=0)->int",
+    "NatronEngine.IntParam.getDisplayMaximum(self,dimension:int)->int",
+    "NatronEngine.IntParam.getDisplayMinimum(self,dimension:int)->int",
+    "NatronEngine.IntParam.getMaximum(self,dimension:int=0)->int",
+    "NatronEngine.IntParam.getMinimum(self,dimension:int=0)->int",
+    "NatronEngine.IntParam.getValue(self,dimension:int=0)->int",
+    "NatronEngine.IntParam.getValueAtTime(self,time:double,dimension:int=0)->int",
+    "NatronEngine.IntParam.restoreDefaultValue(self,dimension:int=0)",
+    "1:NatronEngine.IntParam.set(self,x:int)",
+    "0:NatronEngine.IntParam.set(self,x:int,frame:double)",
+    "NatronEngine.IntParam.setDefaultValue(self,value:int,dimension:int=0)",
+    "NatronEngine.IntParam.setDisplayMaximum(self,maximum:int,dimension:int=0)",
+    "NatronEngine.IntParam.setDisplayMinimum(self,minimum:int,dimension:int=0)",
+    "NatronEngine.IntParam.setMaximum(self,maximum:int,dimension:int=0)",
+    "NatronEngine.IntParam.setMinimum(self,minimum:int,dimension:int=0)",
+    "NatronEngine.IntParam.setValue(self,value:int,dimension:int=0)",
+    "NatronEngine.IntParam.setValueAtTime(self,value:int,time:double,dimension:int=0)",
+    nullptr}; // Sentinel
+
+void init_IntParam(PyObject *module)
+{
+    _Sbk_IntParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "IntParam",
+        "IntParam*",
+        &Sbk_IntParam_spec,
+        &Shiboken::callCppDestructor< ::IntParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_IntParam_Type);
+    InitSignatureStrings(pyType, IntParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_IntParam_Type), Sbk_IntParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_INTPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_IntParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_IntParam_TypeF(),
+        IntParam_PythonToCpp_IntParam_PTR,
+        is_IntParam_PythonToCpp_IntParam_PTR_Convertible,
+        IntParam_PTR_CppToPython_IntParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "IntParam");
+    Shiboken::Conversions::registerConverterName(converter, "IntParam*");
+    Shiboken::Conversions::registerConverterName(converter, "IntParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::IntParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::IntParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_IntParam_TypeF(), &Sbk_IntParam_typeDiscovery);
+
+
+    IntParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/intparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/intparam_wrapper.h
@@ -1,0 +1,60 @@
+#ifndef SBK_INTPARAMWRAPPER_H
+#define SBK_INTPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class IntParamWrapper : public IntParam
+{
+public:
+    ~IntParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_ANIMATEDPARAMWRAPPER_H
+#  define SBK_ANIMATEDPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AnimatedParamWrapper : public AnimatedParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { AnimatedParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~AnimatedParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_ANIMATEDPARAMWRAPPER_H
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_INTPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/itembase_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/itembase_wrapper.cpp
@@ -1,0 +1,619 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "itembase_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void ItemBaseWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void ItemBaseWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+ItemBaseWrapper::~ItemBaseWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_ItemBaseFunc_getLabel(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ItemBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ITEMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getLabel()const
+            QString cppResult = const_cast<const ::ItemBase *>(cppSelf)->getLabel();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ItemBaseFunc_getLocked(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ItemBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ITEMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getLocked()const
+            bool cppResult = const_cast<const ::ItemBase *>(cppSelf)->getLocked();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ItemBaseFunc_getLockedRecursive(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ItemBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ITEMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getLockedRecursive()const
+            bool cppResult = const_cast<const ::ItemBase *>(cppSelf)->getLockedRecursive();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ItemBaseFunc_getParam(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ItemBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ITEMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: ItemBase::getParam(QString)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // getParam(QString)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ItemBaseFunc_getParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getParam(QString)const
+            Param * cppResult = const_cast<const ::ItemBase *>(cppSelf)->getParam(cppArg0);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ItemBaseFunc_getParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ItemBase.getParam");
+        return {};
+}
+
+static PyObject *Sbk_ItemBaseFunc_getParentLayer(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ItemBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ITEMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getParentLayer()const
+            Layer * cppResult = const_cast<const ::ItemBase *>(cppSelf)->getParentLayer();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_LAYER_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ItemBaseFunc_getScriptName(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ItemBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ITEMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getScriptName()const
+            QString cppResult = const_cast<const ::ItemBase *>(cppSelf)->getScriptName();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ItemBaseFunc_getVisible(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ItemBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ITEMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getVisible()const
+            bool cppResult = const_cast<const ::ItemBase *>(cppSelf)->getVisible();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ItemBaseFunc_setLabel(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ItemBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ITEMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: ItemBase::setLabel(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setLabel(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ItemBaseFunc_setLabel_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setLabel(QString)
+            // Begin code injection
+            cppSelf->setLabel(cppArg0);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ItemBaseFunc_setLabel_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ItemBase.setLabel");
+        return {};
+}
+
+static PyObject *Sbk_ItemBaseFunc_setLocked(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ItemBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ITEMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: ItemBase::setLocked(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setLocked(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ItemBaseFunc_setLocked_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setLocked(bool)
+            cppSelf->setLocked(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ItemBaseFunc_setLocked_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ItemBase.setLocked");
+        return {};
+}
+
+static PyObject *Sbk_ItemBaseFunc_setScriptName(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ItemBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ITEMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: ItemBase::setScriptName(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setScriptName(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ItemBaseFunc_setScriptName_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setScriptName(QString)
+            // Begin code injection
+            bool cppResult = cppSelf->setScriptName(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ItemBaseFunc_setScriptName_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ItemBase.setScriptName");
+        return {};
+}
+
+static PyObject *Sbk_ItemBaseFunc_setVisible(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::ItemBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ITEMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: ItemBase::setVisible(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setVisible(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ItemBaseFunc_setVisible_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setVisible(bool)
+            cppSelf->setVisible(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ItemBaseFunc_setVisible_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ItemBase.setVisible");
+        return {};
+}
+
+
+static const char *Sbk_ItemBase_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_ItemBase_methods[] = {
+    {"getLabel", reinterpret_cast<PyCFunction>(Sbk_ItemBaseFunc_getLabel), METH_NOARGS},
+    {"getLocked", reinterpret_cast<PyCFunction>(Sbk_ItemBaseFunc_getLocked), METH_NOARGS},
+    {"getLockedRecursive", reinterpret_cast<PyCFunction>(Sbk_ItemBaseFunc_getLockedRecursive), METH_NOARGS},
+    {"getParam", reinterpret_cast<PyCFunction>(Sbk_ItemBaseFunc_getParam), METH_O},
+    {"getParentLayer", reinterpret_cast<PyCFunction>(Sbk_ItemBaseFunc_getParentLayer), METH_NOARGS},
+    {"getScriptName", reinterpret_cast<PyCFunction>(Sbk_ItemBaseFunc_getScriptName), METH_NOARGS},
+    {"getVisible", reinterpret_cast<PyCFunction>(Sbk_ItemBaseFunc_getVisible), METH_NOARGS},
+    {"setLabel", reinterpret_cast<PyCFunction>(Sbk_ItemBaseFunc_setLabel), METH_O},
+    {"setLocked", reinterpret_cast<PyCFunction>(Sbk_ItemBaseFunc_setLocked), METH_O},
+    {"setScriptName", reinterpret_cast<PyCFunction>(Sbk_ItemBaseFunc_setScriptName), METH_O},
+    {"setVisible", reinterpret_cast<PyCFunction>(Sbk_ItemBaseFunc_setVisible), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_ItemBase_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::ItemBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ITEMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<ItemBaseWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_ItemBase_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_ItemBase_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_ItemBase_Type = nullptr;
+static SbkObjectType *Sbk_ItemBase_TypeF(void)
+{
+    return _Sbk_ItemBase_Type;
+}
+
+static PyType_Slot Sbk_ItemBase_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_ItemBase_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_ItemBase_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_ItemBase_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_ItemBase_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_ItemBase_spec = {
+    "1:NatronEngine.ItemBase",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_ItemBase_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void ItemBase_PythonToCpp_ItemBase_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_ItemBase_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_ItemBase_PythonToCpp_ItemBase_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_ItemBase_TypeF())))
+        return ItemBase_PythonToCpp_ItemBase_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *ItemBase_PTR_CppToPython_ItemBase(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::ItemBase *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_ItemBase_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *ItemBase_SignatureStrings[] = {
+    "NatronEngine.ItemBase.getLabel(self)->QString",
+    "NatronEngine.ItemBase.getLocked(self)->bool",
+    "NatronEngine.ItemBase.getLockedRecursive(self)->bool",
+    "NatronEngine.ItemBase.getParam(self,name:QString)->NatronEngine.Param",
+    "NatronEngine.ItemBase.getParentLayer(self)->NatronEngine.Layer",
+    "NatronEngine.ItemBase.getScriptName(self)->QString",
+    "NatronEngine.ItemBase.getVisible(self)->bool",
+    "NatronEngine.ItemBase.setLabel(self,name:QString)",
+    "NatronEngine.ItemBase.setLocked(self,locked:bool)",
+    "NatronEngine.ItemBase.setScriptName(self,name:QString)->bool",
+    "NatronEngine.ItemBase.setVisible(self,activated:bool)",
+    nullptr}; // Sentinel
+
+void init_ItemBase(PyObject *module)
+{
+    _Sbk_ItemBase_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "ItemBase",
+        "ItemBase*",
+        &Sbk_ItemBase_spec,
+        &Shiboken::callCppDestructor< ::ItemBase >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_ItemBase_Type);
+    InitSignatureStrings(pyType, ItemBase_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_ItemBase_Type), Sbk_ItemBase_PropertyStrings);
+    SbkNatronEngineTypes[SBK_ITEMBASE_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_ItemBase_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_ItemBase_TypeF(),
+        ItemBase_PythonToCpp_ItemBase_PTR,
+        is_ItemBase_PythonToCpp_ItemBase_PTR_Convertible,
+        ItemBase_PTR_CppToPython_ItemBase);
+
+    Shiboken::Conversions::registerConverterName(converter, "ItemBase");
+    Shiboken::Conversions::registerConverterName(converter, "ItemBase*");
+    Shiboken::Conversions::registerConverterName(converter, "ItemBase&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::ItemBase).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::ItemBaseWrapper).name());
+
+
+
+    ItemBaseWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/itembase_wrapper.h
+++ b/Engine/Qt5/NatronEngine/itembase_wrapper.h
@@ -1,0 +1,23 @@
+#ifndef SBK_ITEMBASEWRAPPER_H
+#define SBK_ITEMBASEWRAPPER_H
+
+#include <PyRoto.h>
+
+
+// Extra includes
+#include <PyRoto.h>
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ItemBaseWrapper : public ItemBase
+{
+public:
+    ~ItemBaseWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#endif // SBK_ITEMBASEWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/layer_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/layer_wrapper.cpp
@@ -1,0 +1,436 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "layer_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void LayerWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void LayerWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+LayerWrapper::~LayerWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_LayerFunc_addItem(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Layer *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_LAYER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Layer::addItem(ItemBase*)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_ITEMBASE_IDX]), (pyArg)))) {
+        overloadId = 0; // addItem(ItemBase*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_LayerFunc_addItem_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::ItemBase *cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // addItem(ItemBase*)
+            // Begin code injection
+            cppSelf->addItem(cppArg0);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_LayerFunc_addItem_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Layer.addItem");
+        return {};
+}
+
+static PyObject *Sbk_LayerFunc_getChildren(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Layer *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_LAYER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getChildren()const
+            // Begin code injection
+            std::list<ItemBase*> items = cppSelf->getChildren();
+            PyObject* ret = PyList_New((int) items.size());
+            int idx = 0;
+            for (std::list<ItemBase*>::iterator it = items.begin(); it!=items.end(); ++it,++idx) {
+            PyObject* item = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_ITEMBASE_IDX]), *it);
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(item);
+            PyList_SET_ITEM(ret, idx, item);
+            }
+            return ret;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_LayerFunc_insertItem(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Layer *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_LAYER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "insertItem", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Layer::insertItem(int,ItemBase*)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_ITEMBASE_IDX]), (pyArgs[1])))) {
+        overloadId = 0; // insertItem(int,ItemBase*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_LayerFunc_insertItem_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        if (!Shiboken::Object::isValid(pyArgs[1]))
+            return {};
+        ::ItemBase *cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // insertItem(int,ItemBase*)
+            // Begin code injection
+            cppSelf->insertItem(cppArg0,cppArg1);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_LayerFunc_insertItem_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Layer.insertItem");
+        return {};
+}
+
+static PyObject *Sbk_LayerFunc_removeItem(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Layer *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_LAYER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Layer::removeItem(ItemBase*)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_ITEMBASE_IDX]), (pyArg)))) {
+        overloadId = 0; // removeItem(ItemBase*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_LayerFunc_removeItem_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::ItemBase *cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // removeItem(ItemBase*)
+            // Begin code injection
+            cppSelf->removeItem(cppArg0);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_LayerFunc_removeItem_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Layer.removeItem");
+        return {};
+}
+
+
+static const char *Sbk_Layer_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_Layer_methods[] = {
+    {"addItem", reinterpret_cast<PyCFunction>(Sbk_LayerFunc_addItem), METH_O},
+    {"getChildren", reinterpret_cast<PyCFunction>(Sbk_LayerFunc_getChildren), METH_NOARGS},
+    {"insertItem", reinterpret_cast<PyCFunction>(Sbk_LayerFunc_insertItem), METH_VARARGS},
+    {"removeItem", reinterpret_cast<PyCFunction>(Sbk_LayerFunc_removeItem), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_Layer_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::Layer *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_LAYER_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<LayerWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_Layer_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_Layer_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_Layer_Type = nullptr;
+static SbkObjectType *Sbk_Layer_TypeF(void)
+{
+    return _Sbk_Layer_Type;
+}
+
+static PyType_Slot Sbk_Layer_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_Layer_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_Layer_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_Layer_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_Layer_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_Layer_spec = {
+    "1:NatronEngine.Layer",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_Layer_slots
+};
+
+} //extern "C"
+
+static void *Sbk_Layer_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::ItemBase >()))
+        return dynamic_cast< ::Layer *>(reinterpret_cast< ::ItemBase *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void Layer_PythonToCpp_Layer_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_Layer_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_Layer_PythonToCpp_Layer_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_Layer_TypeF())))
+        return Layer_PythonToCpp_Layer_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *Layer_PTR_CppToPython_Layer(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::Layer *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_Layer_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *Layer_SignatureStrings[] = {
+    "NatronEngine.Layer.addItem(self,item:NatronEngine.ItemBase)",
+    "NatronEngine.Layer.getChildren(self)->std.list[NatronEngine.ItemBase]",
+    "NatronEngine.Layer.insertItem(self,pos:int,item:NatronEngine.ItemBase)",
+    "NatronEngine.Layer.removeItem(self,item:NatronEngine.ItemBase)",
+    nullptr}; // Sentinel
+
+void init_Layer(PyObject *module)
+{
+    _Sbk_Layer_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "Layer",
+        "Layer*",
+        &Sbk_Layer_spec,
+        &Shiboken::callCppDestructor< ::Layer >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_ITEMBASE_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_Layer_Type);
+    InitSignatureStrings(pyType, Layer_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_Layer_Type), Sbk_Layer_PropertyStrings);
+    SbkNatronEngineTypes[SBK_LAYER_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_Layer_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_Layer_TypeF(),
+        Layer_PythonToCpp_Layer_PTR,
+        is_Layer_PythonToCpp_Layer_PTR_Convertible,
+        Layer_PTR_CppToPython_Layer);
+
+    Shiboken::Conversions::registerConverterName(converter, "Layer");
+    Shiboken::Conversions::registerConverterName(converter, "Layer*");
+    Shiboken::Conversions::registerConverterName(converter, "Layer&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Layer).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::LayerWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_Layer_TypeF(), &Sbk_Layer_typeDiscovery);
+
+
+    LayerWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/layer_wrapper.h
+++ b/Engine/Qt5/NatronEngine/layer_wrapper.h
@@ -1,0 +1,42 @@
+#ifndef SBK_LAYERWRAPPER_H
+#define SBK_LAYERWRAPPER_H
+
+#include <PyRoto.h>
+
+
+// Extra includes
+#include <PyRoto.h>
+#include <list>
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class LayerWrapper : public Layer
+{
+public:
+    ~LayerWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_ITEMBASEWRAPPER_H
+#  define SBK_ITEMBASEWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ItemBaseWrapper : public ItemBase
+{
+public:
+    ~ItemBaseWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_ITEMBASEWRAPPER_H
+
+#endif // SBK_LAYERWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/natron_enum_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/natron_enum_wrapper.cpp
@@ -1,0 +1,1863 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "natron_enum_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+
+static const char *Sbk_NATRON_ENUM_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_NATRON_ENUM_methods[] = {
+
+    {nullptr, nullptr} // Sentinel
+};
+
+} // extern "C"
+
+static int Sbk_NATRON_ENUM_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_NATRON_ENUM_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_NATRON_ENUM_Type = nullptr;
+static SbkObjectType *Sbk_NATRON_ENUM_TypeF(void)
+{
+    return _Sbk_NATRON_ENUM_Type;
+}
+
+static PyType_Slot Sbk_NATRON_ENUM_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(Sbk_object_dealloc /* PYSIDE-832: Prevent replacement of "0" with subtype_dealloc. */)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    nullptr},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_NATRON_ENUM_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_NATRON_ENUM_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_NATRON_ENUM_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_NATRON_ENUM_spec = {
+    "1:NatronEngine.NATRON_ENUM",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_NATRON_ENUM_slots
+};
+
+} //extern "C"
+
+PyObject *SbkNatronEngine_NATRON_ENUM_StandardButtonEnum___and__(PyObject *self, PyObject *pyArg)
+{
+    ::NATRON_ENUM::StandardButtons cppResult, cppSelf, cppArg;
+#ifdef IS_PY3K
+    cppSelf = static_cast<::NATRON_ENUM::StandardButtons>(int(PyLong_AsLong(self)));
+    cppArg = static_cast<NATRON_ENUM::StandardButtons>(int(PyLong_AsLong(pyArg)));
+#else
+    cppSelf = static_cast<::NATRON_ENUM::StandardButtons>(int(PyInt_AsLong(self)));
+    cppArg = static_cast<NATRON_ENUM::StandardButtons>(int(PyInt_AsLong(pyArg)));
+#endif
+
+    cppResult = cppSelf & cppArg;
+    return Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_QFLAGS_NATRON_ENUM_STANDARDBUTTONENUM_IDX])->converter, &cppResult);
+}
+
+PyObject *SbkNatronEngine_NATRON_ENUM_StandardButtonEnum___or__(PyObject *self, PyObject *pyArg)
+{
+    ::NATRON_ENUM::StandardButtons cppResult, cppSelf, cppArg;
+#ifdef IS_PY3K
+    cppSelf = static_cast<::NATRON_ENUM::StandardButtons>(int(PyLong_AsLong(self)));
+    cppArg = static_cast<NATRON_ENUM::StandardButtons>(int(PyLong_AsLong(pyArg)));
+#else
+    cppSelf = static_cast<::NATRON_ENUM::StandardButtons>(int(PyInt_AsLong(self)));
+    cppArg = static_cast<NATRON_ENUM::StandardButtons>(int(PyInt_AsLong(pyArg)));
+#endif
+
+    cppResult = cppSelf | cppArg;
+    return Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_QFLAGS_NATRON_ENUM_STANDARDBUTTONENUM_IDX])->converter, &cppResult);
+}
+
+PyObject *SbkNatronEngine_NATRON_ENUM_StandardButtonEnum___xor__(PyObject *self, PyObject *pyArg)
+{
+    ::NATRON_ENUM::StandardButtons cppResult, cppSelf, cppArg;
+#ifdef IS_PY3K
+    cppSelf = static_cast<::NATRON_ENUM::StandardButtons>(int(PyLong_AsLong(self)));
+    cppArg = static_cast<NATRON_ENUM::StandardButtons>(int(PyLong_AsLong(pyArg)));
+#else
+    cppSelf = static_cast<::NATRON_ENUM::StandardButtons>(int(PyInt_AsLong(self)));
+    cppArg = static_cast<NATRON_ENUM::StandardButtons>(int(PyInt_AsLong(pyArg)));
+#endif
+
+    cppResult = cppSelf ^ cppArg;
+    return Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_QFLAGS_NATRON_ENUM_STANDARDBUTTONENUM_IDX])->converter, &cppResult);
+}
+
+PyObject *SbkNatronEngine_NATRON_ENUM_StandardButtonEnum___invert__(PyObject *self, PyObject *pyArg)
+{
+    ::NATRON_ENUM::StandardButtons cppSelf;
+    Shiboken::Conversions::pythonToCppCopy(*PepType_SGTP(SbkNatronEngineTypes[SBK_QFLAGS_NATRON_ENUM_STANDARDBUTTONENUM_IDX])->converter, self, &cppSelf);
+    ::NATRON_ENUM::StandardButtons cppResult = ~cppSelf;
+    return Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_QFLAGS_NATRON_ENUM_STANDARDBUTTONENUM_IDX])->converter, &cppResult);
+}
+
+static PyObject *SbkNatronEngine_NATRON_ENUM_StandardButtonEnum_long(PyObject *self)
+{
+    int val;
+    Shiboken::Conversions::pythonToCppCopy(*PepType_SGTP(SbkNatronEngineTypes[SBK_QFLAGS_NATRON_ENUM_STANDARDBUTTONENUM_IDX])->converter, self, &val);
+    return Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &val);
+}
+static int SbkNatronEngine_NATRON_ENUM_StandardButtonEnum__nonzero(PyObject *self)
+{
+    int val;
+    Shiboken::Conversions::pythonToCppCopy(*PepType_SGTP(SbkNatronEngineTypes[SBK_QFLAGS_NATRON_ENUM_STANDARDBUTTONENUM_IDX])->converter, self, &val);
+    return val != 0;
+}
+
+static PyType_Slot SbkNatronEngine_NATRON_ENUM_StandardButtonEnum_number_slots[] = {
+#ifdef IS_PY3K
+    {Py_nb_bool,    reinterpret_cast<void *>(SbkNatronEngine_NATRON_ENUM_StandardButtonEnum__nonzero)},
+#else
+    {Py_nb_nonzero, reinterpret_cast<void *>(SbkNatronEngine_NATRON_ENUM_StandardButtonEnum__nonzero)},
+    {Py_nb_long,    reinterpret_cast<void *>(SbkNatronEngine_NATRON_ENUM_StandardButtonEnum_long)},
+#endif
+    {Py_nb_invert,  reinterpret_cast<void *>(SbkNatronEngine_NATRON_ENUM_StandardButtonEnum___invert__)},
+    {Py_nb_and,     reinterpret_cast<void *>(SbkNatronEngine_NATRON_ENUM_StandardButtonEnum___and__)},
+    {Py_nb_xor,     reinterpret_cast<void *>(SbkNatronEngine_NATRON_ENUM_StandardButtonEnum___xor__)},
+    {Py_nb_or,      reinterpret_cast<void *>(SbkNatronEngine_NATRON_ENUM_StandardButtonEnum___or__)},
+    {Py_nb_int,     reinterpret_cast<void *>(SbkNatronEngine_NATRON_ENUM_StandardButtonEnum_long)},
+    {Py_nb_index,   reinterpret_cast<void *>(SbkNatronEngine_NATRON_ENUM_StandardButtonEnum_long)},
+#ifndef IS_PY3K
+    {Py_nb_long,    reinterpret_cast<void *>(SbkNatronEngine_NATRON_ENUM_StandardButtonEnum_long)},
+#endif
+    {0, nullptr} // sentinel
+};
+
+
+
+// Type conversion functions.
+
+// Python to C++ enum conversion.
+static void NATRON_ENUM_StatusEnum_PythonToCpp_NATRON_ENUM_StatusEnum(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::NATRON_ENUM::StatusEnum *>(cppOut) =
+        static_cast<::NATRON_ENUM::StatusEnum>(Shiboken::Enum::getValue(pyIn));
+
+}
+static PythonToCppFunc is_NATRON_ENUM_StatusEnum_PythonToCpp_NATRON_ENUM_StatusEnum_Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX]))
+        return NATRON_ENUM_StatusEnum_PythonToCpp_NATRON_ENUM_StatusEnum;
+    return {};
+}
+static PyObject *NATRON_ENUM_StatusEnum_CppToPython_NATRON_ENUM_StatusEnum(const void *cppIn) {
+    const int castCppIn = int(*reinterpret_cast<const ::NATRON_ENUM::StatusEnum *>(cppIn));
+    return Shiboken::Enum::newItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX], castCppIn);
+
+}
+
+static void NATRON_ENUM_StandardButtonEnum_PythonToCpp_NATRON_ENUM_StandardButtonEnum(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::NATRON_ENUM::StandardButtonEnum *>(cppOut) =
+        static_cast<::NATRON_ENUM::StandardButtonEnum>(Shiboken::Enum::getValue(pyIn));
+
+}
+static PythonToCppFunc is_NATRON_ENUM_StandardButtonEnum_PythonToCpp_NATRON_ENUM_StandardButtonEnum_Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX]))
+        return NATRON_ENUM_StandardButtonEnum_PythonToCpp_NATRON_ENUM_StandardButtonEnum;
+    return {};
+}
+static PyObject *NATRON_ENUM_StandardButtonEnum_CppToPython_NATRON_ENUM_StandardButtonEnum(const void *cppIn) {
+    const int castCppIn = int(*reinterpret_cast<const ::NATRON_ENUM::StandardButtonEnum *>(cppIn));
+    return Shiboken::Enum::newItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX], castCppIn);
+
+}
+
+static void QFlags_NATRON_ENUM_StandardButtonEnum__PythonToCpp_QFlags_NATRON_ENUM_StandardButtonEnum_(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::QFlags<NATRON_ENUM::StandardButtonEnum> *>(cppOut) =
+        ::QFlags<NATRON_ENUM::StandardButtonEnum>(QFlag(int(PySide::QFlags::getValue(reinterpret_cast<PySideQFlagsObject *>(pyIn)))));
+
+}
+static PythonToCppFunc is_QFlags_NATRON_ENUM_StandardButtonEnum__PythonToCpp_QFlags_NATRON_ENUM_StandardButtonEnum__Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_QFLAGS_NATRON_ENUM_STANDARDBUTTONENUM_IDX]))
+        return QFlags_NATRON_ENUM_StandardButtonEnum__PythonToCpp_QFlags_NATRON_ENUM_StandardButtonEnum_;
+    return {};
+}
+static PyObject *QFlags_NATRON_ENUM_StandardButtonEnum__CppToPython_QFlags_NATRON_ENUM_StandardButtonEnum_(const void *cppIn) {
+    const int castCppIn = int(*reinterpret_cast<const ::QFlags<NATRON_ENUM::StandardButtonEnum> *>(cppIn));
+    return reinterpret_cast<PyObject *>(PySide::QFlags::newObject(castCppIn, SbkNatronEngineTypes[SBK_QFLAGS_NATRON_ENUM_STANDARDBUTTONENUM_IDX]));
+
+}
+
+static void NATRON_ENUM_StandardButtonEnum_PythonToCpp_QFlags_NATRON_ENUM_StandardButtonEnum_(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::QFlags<NATRON_ENUM::StandardButtonEnum> *>(cppOut) =
+        ::QFlags<NATRON_ENUM::StandardButtonEnum>(QFlag(int(Shiboken::Enum::getValue(pyIn))));
+
+}
+static PythonToCppFunc is_NATRON_ENUM_StandardButtonEnum_PythonToCpp_QFlags_NATRON_ENUM_StandardButtonEnum__Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX]))
+        return NATRON_ENUM_StandardButtonEnum_PythonToCpp_QFlags_NATRON_ENUM_StandardButtonEnum_;
+    return {};
+}
+static void number_PythonToCpp_QFlags_NATRON_ENUM_StandardButtonEnum_(PyObject *pyIn, void *cppOut) {
+    Shiboken::AutoDecRef pyLong(PyNumber_Long(pyIn));
+    *reinterpret_cast<::QFlags<NATRON_ENUM::StandardButtonEnum> *>(cppOut) =
+        ::QFlags<NATRON_ENUM::StandardButtonEnum>(QFlag(int(PyLong_AsLong(pyLong.object()))));
+
+}
+static PythonToCppFunc is_number_PythonToCpp_QFlags_NATRON_ENUM_StandardButtonEnum__Convertible(PyObject *pyIn) {
+    if (PyNumber_Check(pyIn) && PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX]))
+        return number_PythonToCpp_QFlags_NATRON_ENUM_StandardButtonEnum_;
+    return {};
+}
+static void NATRON_ENUM_KeyframeTypeEnum_PythonToCpp_NATRON_ENUM_KeyframeTypeEnum(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::NATRON_ENUM::KeyframeTypeEnum *>(cppOut) =
+        static_cast<::NATRON_ENUM::KeyframeTypeEnum>(Shiboken::Enum::getValue(pyIn));
+
+}
+static PythonToCppFunc is_NATRON_ENUM_KeyframeTypeEnum_PythonToCpp_NATRON_ENUM_KeyframeTypeEnum_Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX]))
+        return NATRON_ENUM_KeyframeTypeEnum_PythonToCpp_NATRON_ENUM_KeyframeTypeEnum;
+    return {};
+}
+static PyObject *NATRON_ENUM_KeyframeTypeEnum_CppToPython_NATRON_ENUM_KeyframeTypeEnum(const void *cppIn) {
+    const int castCppIn = int(*reinterpret_cast<const ::NATRON_ENUM::KeyframeTypeEnum *>(cppIn));
+    return Shiboken::Enum::newItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX], castCppIn);
+
+}
+
+static void NATRON_ENUM_PixmapEnum_PythonToCpp_NATRON_ENUM_PixmapEnum(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::NATRON_ENUM::PixmapEnum *>(cppOut) =
+        static_cast<::NATRON_ENUM::PixmapEnum>(Shiboken::Enum::getValue(pyIn));
+
+}
+static PythonToCppFunc is_NATRON_ENUM_PixmapEnum_PythonToCpp_NATRON_ENUM_PixmapEnum_Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX]))
+        return NATRON_ENUM_PixmapEnum_PythonToCpp_NATRON_ENUM_PixmapEnum;
+    return {};
+}
+static PyObject *NATRON_ENUM_PixmapEnum_CppToPython_NATRON_ENUM_PixmapEnum(const void *cppIn) {
+    const int castCppIn = int(*reinterpret_cast<const ::NATRON_ENUM::PixmapEnum *>(cppIn));
+    return Shiboken::Enum::newItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX], castCppIn);
+
+}
+
+static void NATRON_ENUM_ValueChangedReasonEnum_PythonToCpp_NATRON_ENUM_ValueChangedReasonEnum(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::NATRON_ENUM::ValueChangedReasonEnum *>(cppOut) =
+        static_cast<::NATRON_ENUM::ValueChangedReasonEnum>(Shiboken::Enum::getValue(pyIn));
+
+}
+static PythonToCppFunc is_NATRON_ENUM_ValueChangedReasonEnum_PythonToCpp_NATRON_ENUM_ValueChangedReasonEnum_Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_NATRON_ENUM_VALUECHANGEDREASONENUM_IDX]))
+        return NATRON_ENUM_ValueChangedReasonEnum_PythonToCpp_NATRON_ENUM_ValueChangedReasonEnum;
+    return {};
+}
+static PyObject *NATRON_ENUM_ValueChangedReasonEnum_CppToPython_NATRON_ENUM_ValueChangedReasonEnum(const void *cppIn) {
+    const int castCppIn = int(*reinterpret_cast<const ::NATRON_ENUM::ValueChangedReasonEnum *>(cppIn));
+    return Shiboken::Enum::newItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VALUECHANGEDREASONENUM_IDX], castCppIn);
+
+}
+
+static void NATRON_ENUM_AnimationLevelEnum_PythonToCpp_NATRON_ENUM_AnimationLevelEnum(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::NATRON_ENUM::AnimationLevelEnum *>(cppOut) =
+        static_cast<::NATRON_ENUM::AnimationLevelEnum>(Shiboken::Enum::getValue(pyIn));
+
+}
+static PythonToCppFunc is_NATRON_ENUM_AnimationLevelEnum_PythonToCpp_NATRON_ENUM_AnimationLevelEnum_Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_NATRON_ENUM_ANIMATIONLEVELENUM_IDX]))
+        return NATRON_ENUM_AnimationLevelEnum_PythonToCpp_NATRON_ENUM_AnimationLevelEnum;
+    return {};
+}
+static PyObject *NATRON_ENUM_AnimationLevelEnum_CppToPython_NATRON_ENUM_AnimationLevelEnum(const void *cppIn) {
+    const int castCppIn = int(*reinterpret_cast<const ::NATRON_ENUM::AnimationLevelEnum *>(cppIn));
+    return Shiboken::Enum::newItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_ANIMATIONLEVELENUM_IDX], castCppIn);
+
+}
+
+static void NATRON_ENUM_ImagePremultiplicationEnum_PythonToCpp_NATRON_ENUM_ImagePremultiplicationEnum(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::NATRON_ENUM::ImagePremultiplicationEnum *>(cppOut) =
+        static_cast<::NATRON_ENUM::ImagePremultiplicationEnum>(Shiboken::Enum::getValue(pyIn));
+
+}
+static PythonToCppFunc is_NATRON_ENUM_ImagePremultiplicationEnum_PythonToCpp_NATRON_ENUM_ImagePremultiplicationEnum_Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEPREMULTIPLICATIONENUM_IDX]))
+        return NATRON_ENUM_ImagePremultiplicationEnum_PythonToCpp_NATRON_ENUM_ImagePremultiplicationEnum;
+    return {};
+}
+static PyObject *NATRON_ENUM_ImagePremultiplicationEnum_CppToPython_NATRON_ENUM_ImagePremultiplicationEnum(const void *cppIn) {
+    const int castCppIn = int(*reinterpret_cast<const ::NATRON_ENUM::ImagePremultiplicationEnum *>(cppIn));
+    return Shiboken::Enum::newItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEPREMULTIPLICATIONENUM_IDX], castCppIn);
+
+}
+
+static void NATRON_ENUM_ViewerCompositingOperatorEnum_PythonToCpp_NATRON_ENUM_ViewerCompositingOperatorEnum(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::NATRON_ENUM::ViewerCompositingOperatorEnum *>(cppOut) =
+        static_cast<::NATRON_ENUM::ViewerCompositingOperatorEnum>(Shiboken::Enum::getValue(pyIn));
+
+}
+static PythonToCppFunc is_NATRON_ENUM_ViewerCompositingOperatorEnum_PythonToCpp_NATRON_ENUM_ViewerCompositingOperatorEnum_Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX]))
+        return NATRON_ENUM_ViewerCompositingOperatorEnum_PythonToCpp_NATRON_ENUM_ViewerCompositingOperatorEnum;
+    return {};
+}
+static PyObject *NATRON_ENUM_ViewerCompositingOperatorEnum_CppToPython_NATRON_ENUM_ViewerCompositingOperatorEnum(const void *cppIn) {
+    const int castCppIn = int(*reinterpret_cast<const ::NATRON_ENUM::ViewerCompositingOperatorEnum *>(cppIn));
+    return Shiboken::Enum::newItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX], castCppIn);
+
+}
+
+static void NATRON_ENUM_ViewerColorSpaceEnum_PythonToCpp_NATRON_ENUM_ViewerColorSpaceEnum(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::NATRON_ENUM::ViewerColorSpaceEnum *>(cppOut) =
+        static_cast<::NATRON_ENUM::ViewerColorSpaceEnum>(Shiboken::Enum::getValue(pyIn));
+
+}
+static PythonToCppFunc is_NATRON_ENUM_ViewerColorSpaceEnum_PythonToCpp_NATRON_ENUM_ViewerColorSpaceEnum_Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOLORSPACEENUM_IDX]))
+        return NATRON_ENUM_ViewerColorSpaceEnum_PythonToCpp_NATRON_ENUM_ViewerColorSpaceEnum;
+    return {};
+}
+static PyObject *NATRON_ENUM_ViewerColorSpaceEnum_CppToPython_NATRON_ENUM_ViewerColorSpaceEnum(const void *cppIn) {
+    const int castCppIn = int(*reinterpret_cast<const ::NATRON_ENUM::ViewerColorSpaceEnum *>(cppIn));
+    return Shiboken::Enum::newItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOLORSPACEENUM_IDX], castCppIn);
+
+}
+
+static void NATRON_ENUM_ImageBitDepthEnum_PythonToCpp_NATRON_ENUM_ImageBitDepthEnum(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::NATRON_ENUM::ImageBitDepthEnum *>(cppOut) =
+        static_cast<::NATRON_ENUM::ImageBitDepthEnum>(Shiboken::Enum::getValue(pyIn));
+
+}
+static PythonToCppFunc is_NATRON_ENUM_ImageBitDepthEnum_PythonToCpp_NATRON_ENUM_ImageBitDepthEnum_Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEBITDEPTHENUM_IDX]))
+        return NATRON_ENUM_ImageBitDepthEnum_PythonToCpp_NATRON_ENUM_ImageBitDepthEnum;
+    return {};
+}
+static PyObject *NATRON_ENUM_ImageBitDepthEnum_CppToPython_NATRON_ENUM_ImageBitDepthEnum(const void *cppIn) {
+    const int castCppIn = int(*reinterpret_cast<const ::NATRON_ENUM::ImageBitDepthEnum *>(cppIn));
+    return Shiboken::Enum::newItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEBITDEPTHENUM_IDX], castCppIn);
+
+}
+
+static void NATRON_ENUM_OrientationEnum_PythonToCpp_NATRON_ENUM_OrientationEnum(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::NATRON_ENUM::OrientationEnum *>(cppOut) =
+        static_cast<::NATRON_ENUM::OrientationEnum>(Shiboken::Enum::getValue(pyIn));
+
+}
+static PythonToCppFunc is_NATRON_ENUM_OrientationEnum_PythonToCpp_NATRON_ENUM_OrientationEnum_Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_NATRON_ENUM_ORIENTATIONENUM_IDX]))
+        return NATRON_ENUM_OrientationEnum_PythonToCpp_NATRON_ENUM_OrientationEnum;
+    return {};
+}
+static PyObject *NATRON_ENUM_OrientationEnum_CppToPython_NATRON_ENUM_OrientationEnum(const void *cppIn) {
+    const int castCppIn = int(*reinterpret_cast<const ::NATRON_ENUM::OrientationEnum *>(cppIn));
+    return Shiboken::Enum::newItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_ORIENTATIONENUM_IDX], castCppIn);
+
+}
+
+static void NATRON_ENUM_PlaybackModeEnum_PythonToCpp_NATRON_ENUM_PlaybackModeEnum(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::NATRON_ENUM::PlaybackModeEnum *>(cppOut) =
+        static_cast<::NATRON_ENUM::PlaybackModeEnum>(Shiboken::Enum::getValue(pyIn));
+
+}
+static PythonToCppFunc is_NATRON_ENUM_PlaybackModeEnum_PythonToCpp_NATRON_ENUM_PlaybackModeEnum_Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_NATRON_ENUM_PLAYBACKMODEENUM_IDX]))
+        return NATRON_ENUM_PlaybackModeEnum_PythonToCpp_NATRON_ENUM_PlaybackModeEnum;
+    return {};
+}
+static PyObject *NATRON_ENUM_PlaybackModeEnum_CppToPython_NATRON_ENUM_PlaybackModeEnum(const void *cppIn) {
+    const int castCppIn = int(*reinterpret_cast<const ::NATRON_ENUM::PlaybackModeEnum *>(cppIn));
+    return Shiboken::Enum::newItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PLAYBACKMODEENUM_IDX], castCppIn);
+
+}
+
+static void NATRON_ENUM_DisplayChannelsEnum_PythonToCpp_NATRON_ENUM_DisplayChannelsEnum(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::NATRON_ENUM::DisplayChannelsEnum *>(cppOut) =
+        static_cast<::NATRON_ENUM::DisplayChannelsEnum>(Shiboken::Enum::getValue(pyIn));
+
+}
+static PythonToCppFunc is_NATRON_ENUM_DisplayChannelsEnum_PythonToCpp_NATRON_ENUM_DisplayChannelsEnum_Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX]))
+        return NATRON_ENUM_DisplayChannelsEnum_PythonToCpp_NATRON_ENUM_DisplayChannelsEnum;
+    return {};
+}
+static PyObject *NATRON_ENUM_DisplayChannelsEnum_CppToPython_NATRON_ENUM_DisplayChannelsEnum(const void *cppIn) {
+    const int castCppIn = int(*reinterpret_cast<const ::NATRON_ENUM::DisplayChannelsEnum *>(cppIn));
+    return Shiboken::Enum::newItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX], castCppIn);
+
+}
+
+static void NATRON_ENUM_MergingFunctionEnum_PythonToCpp_NATRON_ENUM_MergingFunctionEnum(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::NATRON_ENUM::MergingFunctionEnum *>(cppOut) =
+        static_cast<::NATRON_ENUM::MergingFunctionEnum>(Shiboken::Enum::getValue(pyIn));
+
+}
+static PythonToCppFunc is_NATRON_ENUM_MergingFunctionEnum_PythonToCpp_NATRON_ENUM_MergingFunctionEnum_Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX]))
+        return NATRON_ENUM_MergingFunctionEnum_PythonToCpp_NATRON_ENUM_MergingFunctionEnum;
+    return {};
+}
+static PyObject *NATRON_ENUM_MergingFunctionEnum_CppToPython_NATRON_ENUM_MergingFunctionEnum(const void *cppIn) {
+    const int castCppIn = int(*reinterpret_cast<const ::NATRON_ENUM::MergingFunctionEnum *>(cppIn));
+    return Shiboken::Enum::newItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX], castCppIn);
+
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *NatronEngineNATRON_ENUM_SignatureStrings[] = {
+    nullptr}; // Sentinel
+
+void init_NatronEngineNATRON_ENUM(PyObject *module)
+{
+    _Sbk_NATRON_ENUM_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "NATRON_ENUM",
+        "NATRON_ENUM",
+        &Sbk_NATRON_ENUM_spec,
+        0,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_NATRON_ENUM_Type);
+    InitSignatureStrings(pyType, NatronEngineNATRON_ENUM_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_NATRON_ENUM_Type), Sbk_NATRON_ENUM_PropertyStrings);
+    SbkNatronEngineTypes[SBK_NatronEngineNATRON_ENUM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_NATRON_ENUM_TypeF());
+
+
+    // Initialization of enums.
+
+    // Initialization of enum 'StatusEnum'.
+    SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX] = Shiboken::Enum::createScopedEnum(Sbk_NATRON_ENUM_TypeF(),
+        "StatusEnum",
+        "1:NatronEngine.NATRON_ENUM.StatusEnum",
+        "NATRON_ENUM::StatusEnum");
+    if (!SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX])
+        return;
+
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStatusOK", (long) NATRON_ENUM::StatusEnum::eStatusOK))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStatusFailed", (long) NATRON_ENUM::StatusEnum::eStatusFailed))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStatusOutOfMemory", (long) NATRON_ENUM::StatusEnum::eStatusOutOfMemory))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStatusReplyDefault", (long) NATRON_ENUM::StatusEnum::eStatusReplyDefault))
+        return;
+    // Register converter for enum 'NATRON_ENUM::StatusEnum'.
+    {
+        SbkConverter *converter = Shiboken::Conversions::createConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX],
+            NATRON_ENUM_StatusEnum_CppToPython_NATRON_ENUM_StatusEnum);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            NATRON_ENUM_StatusEnum_PythonToCpp_NATRON_ENUM_StatusEnum,
+            is_NATRON_ENUM_StatusEnum_PythonToCpp_NATRON_ENUM_StatusEnum_Convertible);
+        Shiboken::Enum::setTypeConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX], converter);
+        Shiboken::Conversions::registerConverterName(converter, "NATRON_ENUM::StatusEnum");
+        Shiboken::Conversions::registerConverterName(converter, "StatusEnum");
+    }
+    // End of 'StatusEnum' enum.
+
+    // Initialization of enum 'StandardButtonEnum'.
+    SbkNatronEngineTypes[SBK_QFLAGS_NATRON_ENUM_STANDARDBUTTONENUM_IDX] = PySide::QFlags::create("1:NatronEngine.NATRON_ENUM.StandardButtons", SbkNatronEngine_NATRON_ENUM_StandardButtonEnum_number_slots);
+    SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX] = Shiboken::Enum::createScopedEnum(Sbk_NATRON_ENUM_TypeF(),
+        "StandardButtonEnum",
+        "1:NatronEngine.NATRON_ENUM.StandardButtonEnum",
+        "NATRON_ENUM::StandardButtonEnum",
+        SbkNatronEngineTypes[SBK_QFLAGS_NATRON_ENUM_STANDARDBUTTONENUM_IDX]);
+    if (!SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX])
+        return;
+
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonNoButton", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonNoButton))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonEscape", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonEscape))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonOk", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonOk))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonSave", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonSave))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonSaveAll", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonSaveAll))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonOpen", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonOpen))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonYes", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonYes))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonYesToAll", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonYesToAll))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonNo", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonNo))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonNoToAll", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonNoToAll))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonAbort", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonAbort))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonRetry", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonRetry))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonIgnore", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonIgnore))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonClose", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonClose))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonCancel", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonCancel))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonDiscard", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonDiscard))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonHelp", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonHelp))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonApply", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonApply))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonReset", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonReset))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eStandardButtonRestoreDefaults", (long) NATRON_ENUM::StandardButtonEnum::eStandardButtonRestoreDefaults))
+        return;
+    // Register converter for enum 'NATRON_ENUM::StandardButtonEnum'.
+    {
+        SbkConverter *converter = Shiboken::Conversions::createConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+            NATRON_ENUM_StandardButtonEnum_CppToPython_NATRON_ENUM_StandardButtonEnum);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            NATRON_ENUM_StandardButtonEnum_PythonToCpp_NATRON_ENUM_StandardButtonEnum,
+            is_NATRON_ENUM_StandardButtonEnum_PythonToCpp_NATRON_ENUM_StandardButtonEnum_Convertible);
+        Shiboken::Enum::setTypeConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX], converter);
+        Shiboken::Conversions::registerConverterName(converter, "NATRON_ENUM::StandardButtonEnum");
+        Shiboken::Conversions::registerConverterName(converter, "StandardButtonEnum");
+    }
+    // Register converter for flag 'QFlags<NATRON_ENUM::StandardButtonEnum>'.
+    {
+        SbkConverter *converter = Shiboken::Conversions::createConverter(SbkNatronEngineTypes[SBK_QFLAGS_NATRON_ENUM_STANDARDBUTTONENUM_IDX],
+            QFlags_NATRON_ENUM_StandardButtonEnum__CppToPython_QFlags_NATRON_ENUM_StandardButtonEnum_);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            NATRON_ENUM_StandardButtonEnum_PythonToCpp_QFlags_NATRON_ENUM_StandardButtonEnum_,
+            is_NATRON_ENUM_StandardButtonEnum_PythonToCpp_QFlags_NATRON_ENUM_StandardButtonEnum__Convertible);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            QFlags_NATRON_ENUM_StandardButtonEnum__PythonToCpp_QFlags_NATRON_ENUM_StandardButtonEnum_,
+            is_QFlags_NATRON_ENUM_StandardButtonEnum__PythonToCpp_QFlags_NATRON_ENUM_StandardButtonEnum__Convertible);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            number_PythonToCpp_QFlags_NATRON_ENUM_StandardButtonEnum_,
+            is_number_PythonToCpp_QFlags_NATRON_ENUM_StandardButtonEnum__Convertible);
+        Shiboken::Enum::setTypeConverter(SbkNatronEngineTypes[SBK_QFLAGS_NATRON_ENUM_STANDARDBUTTONENUM_IDX], converter);
+        Shiboken::Conversions::registerConverterName(converter, "NATRON_ENUM::StandardButtons");
+        Shiboken::Conversions::registerConverterName(converter, "StandardButtons");
+    }
+    // End of 'StandardButtonEnum' enum/flags.
+
+    // Initialization of enum 'KeyframeTypeEnum'.
+    SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX] = Shiboken::Enum::createScopedEnum(Sbk_NATRON_ENUM_TypeF(),
+        "KeyframeTypeEnum",
+        "1:NatronEngine.NATRON_ENUM.KeyframeTypeEnum",
+        "NATRON_ENUM::KeyframeTypeEnum");
+    if (!SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX])
+        return;
+
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eKeyframeTypeConstant", (long) NATRON_ENUM::KeyframeTypeEnum::eKeyframeTypeConstant))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eKeyframeTypeLinear", (long) NATRON_ENUM::KeyframeTypeEnum::eKeyframeTypeLinear))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eKeyframeTypeSmooth", (long) NATRON_ENUM::KeyframeTypeEnum::eKeyframeTypeSmooth))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eKeyframeTypeCatmullRom", (long) NATRON_ENUM::KeyframeTypeEnum::eKeyframeTypeCatmullRom))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eKeyframeTypeCubic", (long) NATRON_ENUM::KeyframeTypeEnum::eKeyframeTypeCubic))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eKeyframeTypeHorizontal", (long) NATRON_ENUM::KeyframeTypeEnum::eKeyframeTypeHorizontal))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eKeyframeTypeFree", (long) NATRON_ENUM::KeyframeTypeEnum::eKeyframeTypeFree))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eKeyframeTypeBroken", (long) NATRON_ENUM::KeyframeTypeEnum::eKeyframeTypeBroken))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eKeyframeTypeNone", (long) NATRON_ENUM::KeyframeTypeEnum::eKeyframeTypeNone))
+        return;
+    // Register converter for enum 'NATRON_ENUM::KeyframeTypeEnum'.
+    {
+        SbkConverter *converter = Shiboken::Conversions::createConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX],
+            NATRON_ENUM_KeyframeTypeEnum_CppToPython_NATRON_ENUM_KeyframeTypeEnum);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            NATRON_ENUM_KeyframeTypeEnum_PythonToCpp_NATRON_ENUM_KeyframeTypeEnum,
+            is_NATRON_ENUM_KeyframeTypeEnum_PythonToCpp_NATRON_ENUM_KeyframeTypeEnum_Convertible);
+        Shiboken::Enum::setTypeConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX], converter);
+        Shiboken::Conversions::registerConverterName(converter, "NATRON_ENUM::KeyframeTypeEnum");
+        Shiboken::Conversions::registerConverterName(converter, "KeyframeTypeEnum");
+    }
+    // End of 'KeyframeTypeEnum' enum.
+
+    // Initialization of enum 'PixmapEnum'.
+    SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX] = Shiboken::Enum::createScopedEnum(Sbk_NATRON_ENUM_TypeF(),
+        "PixmapEnum",
+        "1:NatronEngine.NATRON_ENUM.PixmapEnum",
+        "NATRON_ENUM::PixmapEnum");
+    if (!SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX])
+        return;
+
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_PREVIOUS", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_PREVIOUS))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_FIRST_FRAME", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_FIRST_FRAME))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_NEXT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_NEXT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_LAST_FRAME", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_LAST_FRAME))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_NEXT_INCR", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_NEXT_INCR))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_NEXT_KEY", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_NEXT_KEY))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_PREVIOUS_INCR", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_PREVIOUS_INCR))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_PREVIOUS_KEY", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_PREVIOUS_KEY))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_REWIND_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_REWIND_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_REWIND_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_REWIND_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_PLAY_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_PLAY_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_PLAY_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_PLAY_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_STOP_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_STOP_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_STOP_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_STOP_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_PAUSE_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_PAUSE_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_PAUSE_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_PAUSE_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_LOOP_MODE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_LOOP_MODE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_BOUNCE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_BOUNCE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_PLAY_ONCE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_PLAY_ONCE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_TIMELINE_IN", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_TIMELINE_IN))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PLAYER_TIMELINE_OUT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PLAYER_TIMELINE_OUT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MAXIMIZE_WIDGET", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MAXIMIZE_WIDGET))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MINIMIZE_WIDGET", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MINIMIZE_WIDGET))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_CLOSE_WIDGET", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_CLOSE_WIDGET))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_HELP_WIDGET", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_HELP_WIDGET))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_CLOSE_PANEL", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_CLOSE_PANEL))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_HIDE_UNMODIFIED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_HIDE_UNMODIFIED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_UNHIDE_UNMODIFIED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_UNHIDE_UNMODIFIED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_GROUPBOX_FOLDED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_GROUPBOX_FOLDED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_GROUPBOX_UNFOLDED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_GROUPBOX_UNFOLDED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_UNDO", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_UNDO))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_REDO", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_REDO))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_UNDO_GRAYSCALE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_UNDO_GRAYSCALE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_REDO_GRAYSCALE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_REDO_GRAYSCALE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_RESTORE_DEFAULTS_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_RESTORE_DEFAULTS_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_RESTORE_DEFAULTS_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_RESTORE_DEFAULTS_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_TAB_WIDGET_LAYOUT_BUTTON", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_TAB_WIDGET_LAYOUT_BUTTON))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_TAB_WIDGET_LAYOUT_BUTTON_ANCHOR", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_TAB_WIDGET_LAYOUT_BUTTON_ANCHOR))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_TAB_WIDGET_SPLIT_HORIZONTALLY", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_TAB_WIDGET_SPLIT_HORIZONTALLY))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_TAB_WIDGET_SPLIT_VERTICALLY", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_TAB_WIDGET_SPLIT_VERTICALLY))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_CENTER", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_CENTER))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_CLIP_TO_PROJECT_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_CLIP_TO_PROJECT_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_CLIP_TO_PROJECT_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_CLIP_TO_PROJECT_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_FULL_FRAME_ON", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_FULL_FRAME_ON))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_FULL_FRAME_OFF", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_FULL_FRAME_OFF))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_REFRESH", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_REFRESH))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_REFRESH_ACTIVE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_REFRESH_ACTIVE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_ROI_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_ROI_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_ROI_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_ROI_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_RENDER_SCALE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_RENDER_SCALE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_RENDER_SCALE_CHECKED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_RENDER_SCALE_CHECKED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_AUTOCONTRAST_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_AUTOCONTRAST_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_AUTOCONTRAST_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_AUTOCONTRAST_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_OPEN_FILE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_OPEN_FILE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_COLORWHEEL", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_COLORWHEEL))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_OVERLAY", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_OVERLAY))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ROTO_MERGE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ROTO_MERGE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_COLOR_PICKER", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_COLOR_PICKER))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_IO_GROUPING", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_IO_GROUPING))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_3D_GROUPING", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_3D_GROUPING))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_CHANNEL_GROUPING", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_CHANNEL_GROUPING))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_GROUPING", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_GROUPING))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_COLOR_GROUPING", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_COLOR_GROUPING))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_TRANSFORM_GROUPING", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_TRANSFORM_GROUPING))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_DEEP_GROUPING", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_DEEP_GROUPING))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_FILTER_GROUPING", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_FILTER_GROUPING))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MULTIVIEW_GROUPING", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MULTIVIEW_GROUPING))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_TOOLSETS_GROUPING", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_TOOLSETS_GROUPING))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MISC_GROUPING", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MISC_GROUPING))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_OPEN_EFFECTS_GROUPING", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_OPEN_EFFECTS_GROUPING))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_TIME_GROUPING", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_TIME_GROUPING))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PAINT_GROUPING", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PAINT_GROUPING))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_KEYER_GROUPING", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_KEYER_GROUPING))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_OTHER_PLUGINS", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_OTHER_PLUGINS))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_READ_IMAGE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_READ_IMAGE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_WRITE_IMAGE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_WRITE_IMAGE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_COMBOBOX", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_COMBOBOX))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_COMBOBOX_PRESSED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_COMBOBOX_PRESSED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ADD_KEYFRAME", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ADD_KEYFRAME))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_REMOVE_KEYFRAME", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_REMOVE_KEYFRAME))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_INVERTED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_INVERTED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_UNINVERTED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_UNINVERTED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VISIBLE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VISIBLE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_UNVISIBLE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_UNVISIBLE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_LOCKED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_LOCKED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_UNLOCKED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_UNLOCKED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_LAYER", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_LAYER))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_BEZIER", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_BEZIER))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PENCIL", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PENCIL))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_CURVE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_CURVE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_BEZIER_32", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_BEZIER_32))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ELLIPSE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ELLIPSE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_RECTANGLE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_RECTANGLE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ADD_POINTS", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ADD_POINTS))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_REMOVE_POINTS", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_REMOVE_POINTS))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_CUSP_POINTS", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_CUSP_POINTS))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_SMOOTH_POINTS", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_SMOOTH_POINTS))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_REMOVE_FEATHER", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_REMOVE_FEATHER))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_OPEN_CLOSE_CURVE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_OPEN_CLOSE_CURVE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_SELECT_ALL", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_SELECT_ALL))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_SELECT_POINTS", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_SELECT_POINTS))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_SELECT_FEATHER", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_SELECT_FEATHER))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_SELECT_CURVES", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_SELECT_CURVES))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_AUTO_KEYING_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_AUTO_KEYING_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_AUTO_KEYING_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_AUTO_KEYING_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_STICKY_SELECTION_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_STICKY_SELECTION_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_STICKY_SELECTION_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_STICKY_SELECTION_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_FEATHER_LINK_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_FEATHER_LINK_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_FEATHER_LINK_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_FEATHER_LINK_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_FEATHER_VISIBLE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_FEATHER_VISIBLE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_FEATHER_UNVISIBLE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_FEATHER_UNVISIBLE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_RIPPLE_EDIT_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_RIPPLE_EDIT_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_RIPPLE_EDIT_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_RIPPLE_EDIT_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ROTOPAINT_BLUR", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ROTOPAINT_BLUR))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ROTOPAINT_BUILDUP_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ROTOPAINT_BUILDUP_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ROTOPAINT_BUILDUP_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ROTOPAINT_BUILDUP_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ROTOPAINT_BURN", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ROTOPAINT_BURN))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ROTOPAINT_CLONE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ROTOPAINT_CLONE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ROTOPAINT_DODGE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ROTOPAINT_DODGE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ROTOPAINT_ERASER", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ROTOPAINT_ERASER))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ROTOPAINT_PRESSURE_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ROTOPAINT_PRESSURE_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ROTOPAINT_PRESSURE_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ROTOPAINT_PRESSURE_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ROTOPAINT_REVEAL", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ROTOPAINT_REVEAL))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ROTOPAINT_SHARPEN", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ROTOPAINT_SHARPEN))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ROTOPAINT_SMEAR", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ROTOPAINT_SMEAR))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ROTOPAINT_SOLID", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ROTOPAINT_SOLID))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_BOLD_CHECKED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_BOLD_CHECKED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_BOLD_UNCHECKED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_BOLD_UNCHECKED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ITALIC_CHECKED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ITALIC_CHECKED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ITALIC_UNCHECKED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ITALIC_UNCHECKED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_CLEAR_ALL_ANIMATION", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_CLEAR_ALL_ANIMATION))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_CLEAR_BACKWARD_ANIMATION", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_CLEAR_BACKWARD_ANIMATION))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_CLEAR_FORWARD_ANIMATION", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_CLEAR_FORWARD_ANIMATION))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_UPDATE_VIEWER_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_UPDATE_VIEWER_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_UPDATE_VIEWER_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_UPDATE_VIEWER_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ADD_TRACK", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ADD_TRACK))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ADD_USER_KEY", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ADD_USER_KEY))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_REMOVE_USER_KEY", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_REMOVE_USER_KEY))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_SHOW_TRACK_ERROR", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_SHOW_TRACK_ERROR))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_HIDE_TRACK_ERROR", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_HIDE_TRACK_ERROR))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_RESET_TRACK_OFFSET", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_RESET_TRACK_OFFSET))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_CREATE_USER_KEY_ON_MOVE_ON", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_CREATE_USER_KEY_ON_MOVE_ON))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_CREATE_USER_KEY_ON_MOVE_OFF", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_CREATE_USER_KEY_ON_MOVE_OFF))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_RESET_USER_KEYS", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_RESET_USER_KEYS))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_CENTER_VIEWER_ON_TRACK", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_CENTER_VIEWER_ON_TRACK))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_TRACK_BACKWARD_ON", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_TRACK_BACKWARD_ON))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_TRACK_BACKWARD_OFF", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_TRACK_BACKWARD_OFF))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_TRACK_FORWARD_ON", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_TRACK_FORWARD_ON))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_TRACK_FORWARD_OFF", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_TRACK_FORWARD_OFF))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_TRACK_PREVIOUS", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_TRACK_PREVIOUS))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_TRACK_NEXT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_TRACK_NEXT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_TRACK_RANGE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_TRACK_RANGE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_TRACK_ALL_KEYS", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_TRACK_ALL_KEYS))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_TRACK_CURRENT_KEY", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_TRACK_CURRENT_KEY))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_NEXT_USER_KEY", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_NEXT_USER_KEY))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_PREV_USER_KEY", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_PREV_USER_KEY))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ENTER_GROUP", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ENTER_GROUP))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_SETTINGS", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_SETTINGS))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_FREEZE_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_FREEZE_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_FREEZE_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_FREEZE_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_ICON", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_ICON))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_CHECKERBOARD_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_CHECKERBOARD_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_CHECKERBOARD_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_CHECKERBOARD_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_ZEBRA_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_ZEBRA_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_ZEBRA_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_ZEBRA_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_GAMMA_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_GAMMA_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_GAMMA_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_GAMMA_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_GAIN_ENABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_GAIN_ENABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_VIEWER_GAIN_DISABLED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_VIEWER_GAIN_DISABLED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_SCRIPT_CLEAR_OUTPUT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_SCRIPT_CLEAR_OUTPUT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_SCRIPT_EXEC_SCRIPT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_SCRIPT_EXEC_SCRIPT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_SCRIPT_LOAD_EXEC_SCRIPT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_SCRIPT_LOAD_EXEC_SCRIPT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_SCRIPT_LOAD_SCRIPT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_SCRIPT_LOAD_SCRIPT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_SCRIPT_NEXT_SCRIPT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_SCRIPT_NEXT_SCRIPT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_SCRIPT_OUTPUT_PANE_ACTIVATED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_SCRIPT_OUTPUT_PANE_ACTIVATED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_SCRIPT_OUTPUT_PANE_DEACTIVATED", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_SCRIPT_OUTPUT_PANE_DEACTIVATED))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_SCRIPT_PREVIOUS_SCRIPT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_SCRIPT_PREVIOUS_SCRIPT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_SCRIPT_SAVE_SCRIPT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_SCRIPT_SAVE_SCRIPT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_ATOP", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_ATOP))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_AVERAGE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_AVERAGE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_COLOR", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_COLOR))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_COLOR_BURN", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_COLOR_BURN))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_COLOR_DODGE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_COLOR_DODGE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_CONJOINT_OVER", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_CONJOINT_OVER))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_COPY", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_COPY))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_DIFFERENCE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_DIFFERENCE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_DISJOINT_OVER", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_DISJOINT_OVER))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_DIVIDE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_DIVIDE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_EXCLUSION", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_EXCLUSION))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_FREEZE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_FREEZE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_FROM", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_FROM))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_GEOMETRIC", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_GEOMETRIC))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_GRAIN_EXTRACT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_GRAIN_EXTRACT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_GRAIN_MERGE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_GRAIN_MERGE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_HARD_LIGHT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_HARD_LIGHT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_HUE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_HUE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_HYPOT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_HYPOT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_IN", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_IN))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_LUMINOSITY", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_LUMINOSITY))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_MASK", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_MASK))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_MATTE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_MATTE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_MAX", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_MAX))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_MIN", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_MIN))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_MINUS", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_MINUS))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_MULTIPLY", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_MULTIPLY))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_OUT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_OUT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_OVER", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_OVER))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_OVERLAY", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_OVERLAY))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_PINLIGHT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_PINLIGHT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_PLUS", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_PLUS))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_REFLECT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_REFLECT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_SATURATION", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_SATURATION))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_SCREEN", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_SCREEN))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_SOFT_LIGHT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_SOFT_LIGHT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_STENCIL", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_STENCIL))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_UNDER", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_UNDER))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_MERGE_XOR", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_MERGE_XOR))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_ROTO_NODE_ICON", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_ROTO_NODE_ICON))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_LINK_CURSOR", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_LINK_CURSOR))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_LINK_MULT_CURSOR", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_LINK_MULT_CURSOR))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_APP_ICON", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_APP_ICON))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_INTERP_LINEAR", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_INTERP_LINEAR))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_INTERP_CURVE", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_INTERP_CURVE))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_INTERP_CONSTANT", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_INTERP_CONSTANT))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_INTERP_BREAK", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_INTERP_BREAK))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_INTERP_CURVE_C", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_INTERP_CURVE_C))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_INTERP_CURVE_H", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_INTERP_CURVE_H))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_INTERP_CURVE_R", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_INTERP_CURVE_R))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "NATRON_PIXMAP_INTERP_CURVE_Z", (long) NATRON_ENUM::PixmapEnum::NATRON_PIXMAP_INTERP_CURVE_Z))
+        return;
+    // Register converter for enum 'NATRON_ENUM::PixmapEnum'.
+    {
+        SbkConverter *converter = Shiboken::Conversions::createConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX],
+            NATRON_ENUM_PixmapEnum_CppToPython_NATRON_ENUM_PixmapEnum);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            NATRON_ENUM_PixmapEnum_PythonToCpp_NATRON_ENUM_PixmapEnum,
+            is_NATRON_ENUM_PixmapEnum_PythonToCpp_NATRON_ENUM_PixmapEnum_Convertible);
+        Shiboken::Enum::setTypeConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX], converter);
+        Shiboken::Conversions::registerConverterName(converter, "NATRON_ENUM::PixmapEnum");
+        Shiboken::Conversions::registerConverterName(converter, "PixmapEnum");
+    }
+    // End of 'PixmapEnum' enum.
+
+    // Initialization of enum 'ValueChangedReasonEnum'.
+    SbkNatronEngineTypes[SBK_NATRON_ENUM_VALUECHANGEDREASONENUM_IDX] = Shiboken::Enum::createScopedEnum(Sbk_NATRON_ENUM_TypeF(),
+        "ValueChangedReasonEnum",
+        "1:NatronEngine.NATRON_ENUM.ValueChangedReasonEnum",
+        "NATRON_ENUM::ValueChangedReasonEnum");
+    if (!SbkNatronEngineTypes[SBK_NATRON_ENUM_VALUECHANGEDREASONENUM_IDX])
+        return;
+
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VALUECHANGEDREASONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eValueChangedReasonUserEdited", (long) NATRON_ENUM::ValueChangedReasonEnum::eValueChangedReasonUserEdited))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VALUECHANGEDREASONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eValueChangedReasonPluginEdited", (long) NATRON_ENUM::ValueChangedReasonEnum::eValueChangedReasonPluginEdited))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VALUECHANGEDREASONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eValueChangedReasonNatronGuiEdited", (long) NATRON_ENUM::ValueChangedReasonEnum::eValueChangedReasonNatronGuiEdited))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VALUECHANGEDREASONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eValueChangedReasonNatronInternalEdited", (long) NATRON_ENUM::ValueChangedReasonEnum::eValueChangedReasonNatronInternalEdited))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VALUECHANGEDREASONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eValueChangedReasonTimeChanged", (long) NATRON_ENUM::ValueChangedReasonEnum::eValueChangedReasonTimeChanged))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VALUECHANGEDREASONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eValueChangedReasonSlaveRefresh", (long) NATRON_ENUM::ValueChangedReasonEnum::eValueChangedReasonSlaveRefresh))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VALUECHANGEDREASONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eValueChangedReasonRestoreDefault", (long) NATRON_ENUM::ValueChangedReasonEnum::eValueChangedReasonRestoreDefault))
+        return;
+    // Register converter for enum 'NATRON_ENUM::ValueChangedReasonEnum'.
+    {
+        SbkConverter *converter = Shiboken::Conversions::createConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_VALUECHANGEDREASONENUM_IDX],
+            NATRON_ENUM_ValueChangedReasonEnum_CppToPython_NATRON_ENUM_ValueChangedReasonEnum);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            NATRON_ENUM_ValueChangedReasonEnum_PythonToCpp_NATRON_ENUM_ValueChangedReasonEnum,
+            is_NATRON_ENUM_ValueChangedReasonEnum_PythonToCpp_NATRON_ENUM_ValueChangedReasonEnum_Convertible);
+        Shiboken::Enum::setTypeConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_VALUECHANGEDREASONENUM_IDX], converter);
+        Shiboken::Conversions::registerConverterName(converter, "NATRON_ENUM::ValueChangedReasonEnum");
+        Shiboken::Conversions::registerConverterName(converter, "ValueChangedReasonEnum");
+    }
+    // End of 'ValueChangedReasonEnum' enum.
+
+    // Initialization of enum 'AnimationLevelEnum'.
+    SbkNatronEngineTypes[SBK_NATRON_ENUM_ANIMATIONLEVELENUM_IDX] = Shiboken::Enum::createScopedEnum(Sbk_NATRON_ENUM_TypeF(),
+        "AnimationLevelEnum",
+        "1:NatronEngine.NATRON_ENUM.AnimationLevelEnum",
+        "NATRON_ENUM::AnimationLevelEnum");
+    if (!SbkNatronEngineTypes[SBK_NATRON_ENUM_ANIMATIONLEVELENUM_IDX])
+        return;
+
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_ANIMATIONLEVELENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eAnimationLevelNone", (long) NATRON_ENUM::AnimationLevelEnum::eAnimationLevelNone))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_ANIMATIONLEVELENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eAnimationLevelInterpolatedValue", (long) NATRON_ENUM::AnimationLevelEnum::eAnimationLevelInterpolatedValue))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_ANIMATIONLEVELENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eAnimationLevelOnKeyframe", (long) NATRON_ENUM::AnimationLevelEnum::eAnimationLevelOnKeyframe))
+        return;
+    // Register converter for enum 'NATRON_ENUM::AnimationLevelEnum'.
+    {
+        SbkConverter *converter = Shiboken::Conversions::createConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_ANIMATIONLEVELENUM_IDX],
+            NATRON_ENUM_AnimationLevelEnum_CppToPython_NATRON_ENUM_AnimationLevelEnum);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            NATRON_ENUM_AnimationLevelEnum_PythonToCpp_NATRON_ENUM_AnimationLevelEnum,
+            is_NATRON_ENUM_AnimationLevelEnum_PythonToCpp_NATRON_ENUM_AnimationLevelEnum_Convertible);
+        Shiboken::Enum::setTypeConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_ANIMATIONLEVELENUM_IDX], converter);
+        Shiboken::Conversions::registerConverterName(converter, "NATRON_ENUM::AnimationLevelEnum");
+        Shiboken::Conversions::registerConverterName(converter, "AnimationLevelEnum");
+    }
+    // End of 'AnimationLevelEnum' enum.
+
+    // Initialization of enum 'ImagePremultiplicationEnum'.
+    SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEPREMULTIPLICATIONENUM_IDX] = Shiboken::Enum::createScopedEnum(Sbk_NATRON_ENUM_TypeF(),
+        "ImagePremultiplicationEnum",
+        "1:NatronEngine.NATRON_ENUM.ImagePremultiplicationEnum",
+        "NATRON_ENUM::ImagePremultiplicationEnum");
+    if (!SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEPREMULTIPLICATIONENUM_IDX])
+        return;
+
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEPREMULTIPLICATIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eImagePremultiplicationOpaque", (long) NATRON_ENUM::ImagePremultiplicationEnum::eImagePremultiplicationOpaque))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEPREMULTIPLICATIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eImagePremultiplicationPremultiplied", (long) NATRON_ENUM::ImagePremultiplicationEnum::eImagePremultiplicationPremultiplied))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEPREMULTIPLICATIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eImagePremultiplicationUnPremultiplied", (long) NATRON_ENUM::ImagePremultiplicationEnum::eImagePremultiplicationUnPremultiplied))
+        return;
+    // Register converter for enum 'NATRON_ENUM::ImagePremultiplicationEnum'.
+    {
+        SbkConverter *converter = Shiboken::Conversions::createConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEPREMULTIPLICATIONENUM_IDX],
+            NATRON_ENUM_ImagePremultiplicationEnum_CppToPython_NATRON_ENUM_ImagePremultiplicationEnum);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            NATRON_ENUM_ImagePremultiplicationEnum_PythonToCpp_NATRON_ENUM_ImagePremultiplicationEnum,
+            is_NATRON_ENUM_ImagePremultiplicationEnum_PythonToCpp_NATRON_ENUM_ImagePremultiplicationEnum_Convertible);
+        Shiboken::Enum::setTypeConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEPREMULTIPLICATIONENUM_IDX], converter);
+        Shiboken::Conversions::registerConverterName(converter, "NATRON_ENUM::ImagePremultiplicationEnum");
+        Shiboken::Conversions::registerConverterName(converter, "ImagePremultiplicationEnum");
+    }
+    // End of 'ImagePremultiplicationEnum' enum.
+
+    // Initialization of enum 'ViewerCompositingOperatorEnum'.
+    SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX] = Shiboken::Enum::createScopedEnum(Sbk_NATRON_ENUM_TypeF(),
+        "ViewerCompositingOperatorEnum",
+        "1:NatronEngine.NATRON_ENUM.ViewerCompositingOperatorEnum",
+        "NATRON_ENUM::ViewerCompositingOperatorEnum");
+    if (!SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX])
+        return;
+
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eViewerCompositingOperatorNone", (long) NATRON_ENUM::ViewerCompositingOperatorEnum::eViewerCompositingOperatorNone))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eViewerCompositingOperatorWipeUnder", (long) NATRON_ENUM::ViewerCompositingOperatorEnum::eViewerCompositingOperatorWipeUnder))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eViewerCompositingOperatorWipeOver", (long) NATRON_ENUM::ViewerCompositingOperatorEnum::eViewerCompositingOperatorWipeOver))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eViewerCompositingOperatorWipeMinus", (long) NATRON_ENUM::ViewerCompositingOperatorEnum::eViewerCompositingOperatorWipeMinus))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eViewerCompositingOperatorWipeOnionSkin", (long) NATRON_ENUM::ViewerCompositingOperatorEnum::eViewerCompositingOperatorWipeOnionSkin))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eViewerCompositingOperatorStackUnder", (long) NATRON_ENUM::ViewerCompositingOperatorEnum::eViewerCompositingOperatorStackUnder))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eViewerCompositingOperatorStackOver", (long) NATRON_ENUM::ViewerCompositingOperatorEnum::eViewerCompositingOperatorStackOver))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eViewerCompositingOperatorStackMinus", (long) NATRON_ENUM::ViewerCompositingOperatorEnum::eViewerCompositingOperatorStackMinus))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eViewerCompositingOperatorStackOnionSkin", (long) NATRON_ENUM::ViewerCompositingOperatorEnum::eViewerCompositingOperatorStackOnionSkin))
+        return;
+    // Register converter for enum 'NATRON_ENUM::ViewerCompositingOperatorEnum'.
+    {
+        SbkConverter *converter = Shiboken::Conversions::createConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX],
+            NATRON_ENUM_ViewerCompositingOperatorEnum_CppToPython_NATRON_ENUM_ViewerCompositingOperatorEnum);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            NATRON_ENUM_ViewerCompositingOperatorEnum_PythonToCpp_NATRON_ENUM_ViewerCompositingOperatorEnum,
+            is_NATRON_ENUM_ViewerCompositingOperatorEnum_PythonToCpp_NATRON_ENUM_ViewerCompositingOperatorEnum_Convertible);
+        Shiboken::Enum::setTypeConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX], converter);
+        Shiboken::Conversions::registerConverterName(converter, "NATRON_ENUM::ViewerCompositingOperatorEnum");
+        Shiboken::Conversions::registerConverterName(converter, "ViewerCompositingOperatorEnum");
+    }
+    // End of 'ViewerCompositingOperatorEnum' enum.
+
+    // Initialization of enum 'ViewerColorSpaceEnum'.
+    SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOLORSPACEENUM_IDX] = Shiboken::Enum::createScopedEnum(Sbk_NATRON_ENUM_TypeF(),
+        "ViewerColorSpaceEnum",
+        "1:NatronEngine.NATRON_ENUM.ViewerColorSpaceEnum",
+        "NATRON_ENUM::ViewerColorSpaceEnum");
+    if (!SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOLORSPACEENUM_IDX])
+        return;
+
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOLORSPACEENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eViewerColorSpaceSRGB", (long) NATRON_ENUM::ViewerColorSpaceEnum::eViewerColorSpaceSRGB))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOLORSPACEENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eViewerColorSpaceLinear", (long) NATRON_ENUM::ViewerColorSpaceEnum::eViewerColorSpaceLinear))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOLORSPACEENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eViewerColorSpaceRec709", (long) NATRON_ENUM::ViewerColorSpaceEnum::eViewerColorSpaceRec709))
+        return;
+    // Register converter for enum 'NATRON_ENUM::ViewerColorSpaceEnum'.
+    {
+        SbkConverter *converter = Shiboken::Conversions::createConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOLORSPACEENUM_IDX],
+            NATRON_ENUM_ViewerColorSpaceEnum_CppToPython_NATRON_ENUM_ViewerColorSpaceEnum);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            NATRON_ENUM_ViewerColorSpaceEnum_PythonToCpp_NATRON_ENUM_ViewerColorSpaceEnum,
+            is_NATRON_ENUM_ViewerColorSpaceEnum_PythonToCpp_NATRON_ENUM_ViewerColorSpaceEnum_Convertible);
+        Shiboken::Enum::setTypeConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOLORSPACEENUM_IDX], converter);
+        Shiboken::Conversions::registerConverterName(converter, "NATRON_ENUM::ViewerColorSpaceEnum");
+        Shiboken::Conversions::registerConverterName(converter, "ViewerColorSpaceEnum");
+    }
+    // End of 'ViewerColorSpaceEnum' enum.
+
+    // Initialization of enum 'ImageBitDepthEnum'.
+    SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEBITDEPTHENUM_IDX] = Shiboken::Enum::createScopedEnum(Sbk_NATRON_ENUM_TypeF(),
+        "ImageBitDepthEnum",
+        "1:NatronEngine.NATRON_ENUM.ImageBitDepthEnum",
+        "NATRON_ENUM::ImageBitDepthEnum");
+    if (!SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEBITDEPTHENUM_IDX])
+        return;
+
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEBITDEPTHENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eImageBitDepthNone", (long) NATRON_ENUM::ImageBitDepthEnum::eImageBitDepthNone))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEBITDEPTHENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eImageBitDepthByte", (long) NATRON_ENUM::ImageBitDepthEnum::eImageBitDepthByte))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEBITDEPTHENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eImageBitDepthShort", (long) NATRON_ENUM::ImageBitDepthEnum::eImageBitDepthShort))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEBITDEPTHENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eImageBitDepthHalf", (long) NATRON_ENUM::ImageBitDepthEnum::eImageBitDepthHalf))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEBITDEPTHENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eImageBitDepthFloat", (long) NATRON_ENUM::ImageBitDepthEnum::eImageBitDepthFloat))
+        return;
+    // Register converter for enum 'NATRON_ENUM::ImageBitDepthEnum'.
+    {
+        SbkConverter *converter = Shiboken::Conversions::createConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEBITDEPTHENUM_IDX],
+            NATRON_ENUM_ImageBitDepthEnum_CppToPython_NATRON_ENUM_ImageBitDepthEnum);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            NATRON_ENUM_ImageBitDepthEnum_PythonToCpp_NATRON_ENUM_ImageBitDepthEnum,
+            is_NATRON_ENUM_ImageBitDepthEnum_PythonToCpp_NATRON_ENUM_ImageBitDepthEnum_Convertible);
+        Shiboken::Enum::setTypeConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEBITDEPTHENUM_IDX], converter);
+        Shiboken::Conversions::registerConverterName(converter, "NATRON_ENUM::ImageBitDepthEnum");
+        Shiboken::Conversions::registerConverterName(converter, "ImageBitDepthEnum");
+    }
+    // End of 'ImageBitDepthEnum' enum.
+
+    // Initialization of enum 'OrientationEnum'.
+    SbkNatronEngineTypes[SBK_NATRON_ENUM_ORIENTATIONENUM_IDX] = Shiboken::Enum::createScopedEnum(Sbk_NATRON_ENUM_TypeF(),
+        "OrientationEnum",
+        "1:NatronEngine.NATRON_ENUM.OrientationEnum",
+        "NATRON_ENUM::OrientationEnum");
+    if (!SbkNatronEngineTypes[SBK_NATRON_ENUM_ORIENTATIONENUM_IDX])
+        return;
+
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_ORIENTATIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eOrientationHorizontal", (long) NATRON_ENUM::OrientationEnum::eOrientationHorizontal))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_ORIENTATIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eOrientationVertical", (long) NATRON_ENUM::OrientationEnum::eOrientationVertical))
+        return;
+    // Register converter for enum 'NATRON_ENUM::OrientationEnum'.
+    {
+        SbkConverter *converter = Shiboken::Conversions::createConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_ORIENTATIONENUM_IDX],
+            NATRON_ENUM_OrientationEnum_CppToPython_NATRON_ENUM_OrientationEnum);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            NATRON_ENUM_OrientationEnum_PythonToCpp_NATRON_ENUM_OrientationEnum,
+            is_NATRON_ENUM_OrientationEnum_PythonToCpp_NATRON_ENUM_OrientationEnum_Convertible);
+        Shiboken::Enum::setTypeConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_ORIENTATIONENUM_IDX], converter);
+        Shiboken::Conversions::registerConverterName(converter, "NATRON_ENUM::OrientationEnum");
+        Shiboken::Conversions::registerConverterName(converter, "OrientationEnum");
+    }
+    // End of 'OrientationEnum' enum.
+
+    // Initialization of enum 'PlaybackModeEnum'.
+    SbkNatronEngineTypes[SBK_NATRON_ENUM_PLAYBACKMODEENUM_IDX] = Shiboken::Enum::createScopedEnum(Sbk_NATRON_ENUM_TypeF(),
+        "PlaybackModeEnum",
+        "1:NatronEngine.NATRON_ENUM.PlaybackModeEnum",
+        "NATRON_ENUM::PlaybackModeEnum");
+    if (!SbkNatronEngineTypes[SBK_NATRON_ENUM_PLAYBACKMODEENUM_IDX])
+        return;
+
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PLAYBACKMODEENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "ePlaybackModeLoop", (long) NATRON_ENUM::PlaybackModeEnum::ePlaybackModeLoop))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PLAYBACKMODEENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "ePlaybackModeBounce", (long) NATRON_ENUM::PlaybackModeEnum::ePlaybackModeBounce))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_PLAYBACKMODEENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "ePlaybackModeOnce", (long) NATRON_ENUM::PlaybackModeEnum::ePlaybackModeOnce))
+        return;
+    // Register converter for enum 'NATRON_ENUM::PlaybackModeEnum'.
+    {
+        SbkConverter *converter = Shiboken::Conversions::createConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_PLAYBACKMODEENUM_IDX],
+            NATRON_ENUM_PlaybackModeEnum_CppToPython_NATRON_ENUM_PlaybackModeEnum);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            NATRON_ENUM_PlaybackModeEnum_PythonToCpp_NATRON_ENUM_PlaybackModeEnum,
+            is_NATRON_ENUM_PlaybackModeEnum_PythonToCpp_NATRON_ENUM_PlaybackModeEnum_Convertible);
+        Shiboken::Enum::setTypeConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_PLAYBACKMODEENUM_IDX], converter);
+        Shiboken::Conversions::registerConverterName(converter, "NATRON_ENUM::PlaybackModeEnum");
+        Shiboken::Conversions::registerConverterName(converter, "PlaybackModeEnum");
+    }
+    // End of 'PlaybackModeEnum' enum.
+
+    // Initialization of enum 'DisplayChannelsEnum'.
+    SbkNatronEngineTypes[SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX] = Shiboken::Enum::createScopedEnum(Sbk_NATRON_ENUM_TypeF(),
+        "DisplayChannelsEnum",
+        "1:NatronEngine.NATRON_ENUM.DisplayChannelsEnum",
+        "NATRON_ENUM::DisplayChannelsEnum");
+    if (!SbkNatronEngineTypes[SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX])
+        return;
+
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eDisplayChannelsRGB", (long) NATRON_ENUM::DisplayChannelsEnum::eDisplayChannelsRGB))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eDisplayChannelsR", (long) NATRON_ENUM::DisplayChannelsEnum::eDisplayChannelsR))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eDisplayChannelsG", (long) NATRON_ENUM::DisplayChannelsEnum::eDisplayChannelsG))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eDisplayChannelsB", (long) NATRON_ENUM::DisplayChannelsEnum::eDisplayChannelsB))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eDisplayChannelsA", (long) NATRON_ENUM::DisplayChannelsEnum::eDisplayChannelsA))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eDisplayChannelsY", (long) NATRON_ENUM::DisplayChannelsEnum::eDisplayChannelsY))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eDisplayChannelsMatte", (long) NATRON_ENUM::DisplayChannelsEnum::eDisplayChannelsMatte))
+        return;
+    // Register converter for enum 'NATRON_ENUM::DisplayChannelsEnum'.
+    {
+        SbkConverter *converter = Shiboken::Conversions::createConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX],
+            NATRON_ENUM_DisplayChannelsEnum_CppToPython_NATRON_ENUM_DisplayChannelsEnum);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            NATRON_ENUM_DisplayChannelsEnum_PythonToCpp_NATRON_ENUM_DisplayChannelsEnum,
+            is_NATRON_ENUM_DisplayChannelsEnum_PythonToCpp_NATRON_ENUM_DisplayChannelsEnum_Convertible);
+        Shiboken::Enum::setTypeConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX], converter);
+        Shiboken::Conversions::registerConverterName(converter, "NATRON_ENUM::DisplayChannelsEnum");
+        Shiboken::Conversions::registerConverterName(converter, "DisplayChannelsEnum");
+    }
+    // End of 'DisplayChannelsEnum' enum.
+
+    // Initialization of enum 'MergingFunctionEnum'.
+    SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX] = Shiboken::Enum::createScopedEnum(Sbk_NATRON_ENUM_TypeF(),
+        "MergingFunctionEnum",
+        "1:NatronEngine.NATRON_ENUM.MergingFunctionEnum",
+        "NATRON_ENUM::MergingFunctionEnum");
+    if (!SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX])
+        return;
+
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeATop", (long) NATRON_ENUM::MergingFunctionEnum::eMergeATop))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeAverage", (long) NATRON_ENUM::MergingFunctionEnum::eMergeAverage))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeColor", (long) NATRON_ENUM::MergingFunctionEnum::eMergeColor))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeColorBurn", (long) NATRON_ENUM::MergingFunctionEnum::eMergeColorBurn))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeColorDodge", (long) NATRON_ENUM::MergingFunctionEnum::eMergeColorDodge))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeConjointOver", (long) NATRON_ENUM::MergingFunctionEnum::eMergeConjointOver))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeCopy", (long) NATRON_ENUM::MergingFunctionEnum::eMergeCopy))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeDifference", (long) NATRON_ENUM::MergingFunctionEnum::eMergeDifference))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeDisjointOver", (long) NATRON_ENUM::MergingFunctionEnum::eMergeDisjointOver))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeDivide", (long) NATRON_ENUM::MergingFunctionEnum::eMergeDivide))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeExclusion", (long) NATRON_ENUM::MergingFunctionEnum::eMergeExclusion))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeFreeze", (long) NATRON_ENUM::MergingFunctionEnum::eMergeFreeze))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeFrom", (long) NATRON_ENUM::MergingFunctionEnum::eMergeFrom))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeGeometric", (long) NATRON_ENUM::MergingFunctionEnum::eMergeGeometric))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeGrainExtract", (long) NATRON_ENUM::MergingFunctionEnum::eMergeGrainExtract))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeGrainMerge", (long) NATRON_ENUM::MergingFunctionEnum::eMergeGrainMerge))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeHardLight", (long) NATRON_ENUM::MergingFunctionEnum::eMergeHardLight))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeHue", (long) NATRON_ENUM::MergingFunctionEnum::eMergeHue))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeHypot", (long) NATRON_ENUM::MergingFunctionEnum::eMergeHypot))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeIn", (long) NATRON_ENUM::MergingFunctionEnum::eMergeIn))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeLuminosity", (long) NATRON_ENUM::MergingFunctionEnum::eMergeLuminosity))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeMask", (long) NATRON_ENUM::MergingFunctionEnum::eMergeMask))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeMatte", (long) NATRON_ENUM::MergingFunctionEnum::eMergeMatte))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeMax", (long) NATRON_ENUM::MergingFunctionEnum::eMergeMax))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeMin", (long) NATRON_ENUM::MergingFunctionEnum::eMergeMin))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeMinus", (long) NATRON_ENUM::MergingFunctionEnum::eMergeMinus))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeMultiply", (long) NATRON_ENUM::MergingFunctionEnum::eMergeMultiply))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeOut", (long) NATRON_ENUM::MergingFunctionEnum::eMergeOut))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeOver", (long) NATRON_ENUM::MergingFunctionEnum::eMergeOver))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeOverlay", (long) NATRON_ENUM::MergingFunctionEnum::eMergeOverlay))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergePinLight", (long) NATRON_ENUM::MergingFunctionEnum::eMergePinLight))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergePlus", (long) NATRON_ENUM::MergingFunctionEnum::eMergePlus))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeReflect", (long) NATRON_ENUM::MergingFunctionEnum::eMergeReflect))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeSaturation", (long) NATRON_ENUM::MergingFunctionEnum::eMergeSaturation))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeScreen", (long) NATRON_ENUM::MergingFunctionEnum::eMergeScreen))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeSoftLight", (long) NATRON_ENUM::MergingFunctionEnum::eMergeSoftLight))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeStencil", (long) NATRON_ENUM::MergingFunctionEnum::eMergeStencil))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeUnder", (long) NATRON_ENUM::MergingFunctionEnum::eMergeUnder))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+        Sbk_NATRON_ENUM_TypeF(), "eMergeXOR", (long) NATRON_ENUM::MergingFunctionEnum::eMergeXOR))
+        return;
+    // Register converter for enum 'NATRON_ENUM::MergingFunctionEnum'.
+    {
+        SbkConverter *converter = Shiboken::Conversions::createConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX],
+            NATRON_ENUM_MergingFunctionEnum_CppToPython_NATRON_ENUM_MergingFunctionEnum);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            NATRON_ENUM_MergingFunctionEnum_PythonToCpp_NATRON_ENUM_MergingFunctionEnum,
+            is_NATRON_ENUM_MergingFunctionEnum_PythonToCpp_NATRON_ENUM_MergingFunctionEnum_Convertible);
+        Shiboken::Enum::setTypeConverter(SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX], converter);
+        Shiboken::Conversions::registerConverterName(converter, "NATRON_ENUM::MergingFunctionEnum");
+        Shiboken::Conversions::registerConverterName(converter, "MergingFunctionEnum");
+    }
+    // End of 'MergingFunctionEnum' enum.
+
+
+    qRegisterMetaType< ::NATRON_ENUM::StatusEnum >("NATRON_ENUM::StatusEnum");
+    qRegisterMetaType< ::NATRON_ENUM::StandardButtonEnum >("NATRON_ENUM::StandardButtonEnum");
+    qRegisterMetaType< ::NATRON_ENUM::StandardButtons >("NATRON_ENUM::StandardButtons");
+    qRegisterMetaType< ::NATRON_ENUM::KeyframeTypeEnum >("NATRON_ENUM::KeyframeTypeEnum");
+    qRegisterMetaType< ::NATRON_ENUM::PixmapEnum >("NATRON_ENUM::PixmapEnum");
+    qRegisterMetaType< ::NATRON_ENUM::ValueChangedReasonEnum >("NATRON_ENUM::ValueChangedReasonEnum");
+    qRegisterMetaType< ::NATRON_ENUM::AnimationLevelEnum >("NATRON_ENUM::AnimationLevelEnum");
+    qRegisterMetaType< ::NATRON_ENUM::ImagePremultiplicationEnum >("NATRON_ENUM::ImagePremultiplicationEnum");
+    qRegisterMetaType< ::NATRON_ENUM::ViewerCompositingOperatorEnum >("NATRON_ENUM::ViewerCompositingOperatorEnum");
+    qRegisterMetaType< ::NATRON_ENUM::ViewerColorSpaceEnum >("NATRON_ENUM::ViewerColorSpaceEnum");
+    qRegisterMetaType< ::NATRON_ENUM::ImageBitDepthEnum >("NATRON_ENUM::ImageBitDepthEnum");
+    qRegisterMetaType< ::NATRON_ENUM::OrientationEnum >("NATRON_ENUM::OrientationEnum");
+    qRegisterMetaType< ::NATRON_ENUM::PlaybackModeEnum >("NATRON_ENUM::PlaybackModeEnum");
+    qRegisterMetaType< ::NATRON_ENUM::DisplayChannelsEnum >("NATRON_ENUM::DisplayChannelsEnum");
+    qRegisterMetaType< ::NATRON_ENUM::MergingFunctionEnum >("NATRON_ENUM::MergingFunctionEnum");
+}

--- a/Engine/Qt5/NatronEngine/natron_enum_wrapper.h
+++ b/Engine/Qt5/NatronEngine/natron_enum_wrapper.h
@@ -1,0 +1,7 @@
+#ifndef SBK_NATRON_ENUM_H
+#define SBK_NATRON_ENUM_H
+
+#include <Enums.h>
+
+#endif // SBK_NATRON_ENUM_H
+

--- a/Engine/Qt5/NatronEngine/natronengine_module_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/natronengine_module_wrapper.cpp
@@ -1,0 +1,1067 @@
+
+#include <sbkpython.h>
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#include <algorithm>
+#include <signature.h>
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+#include "natronengine_python.h"
+
+
+
+// Extra includes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+// Current module's type array.
+PyTypeObject **SbkNatronEngineTypes = nullptr;
+// Current module's PyObject pointer.
+PyObject *SbkNatronEngineModuleObject = nullptr;
+// Current module's converter array.
+SbkConverter **SbkNatronEngineTypeConverters = nullptr;
+void cleanTypesAttributes(void) {
+    if (PY_VERSION_HEX >= 0x03000000 && PY_VERSION_HEX < 0x03060000)
+        return; // PYSIDE-953: testbinding crashes in Python 3.5 when hasattr touches types!
+    for (int i = 0, imax = SBK_NatronEngine_IDX_COUNT; i < imax; i++) {
+        PyObject *pyType = reinterpret_cast<PyObject *>(SbkNatronEngineTypes[i]);
+        Shiboken::AutoDecRef attrName(Py_BuildValue("s", "staticMetaObject"));
+        if (pyType && PyObject_HasAttr(pyType, attrName))
+            PyObject_SetAttr(pyType, attrName, Py_None);
+    }
+}
+// Global functions ------------------------------------------------------------
+
+static PyMethodDef NatronEngine_methods[] = {
+    {0} // Sentinel
+};
+
+// Classes initialization functions ------------------------------------------------------------
+void init_UserParamHolder(PyObject *module);
+void init_Tracker(PyObject *module);
+void init_Track(PyObject *module);
+void init_Roto(PyObject *module);
+void init_RectI(PyObject *module);
+void init_RectD(PyObject *module);
+void init_PyCoreApplication(PyObject *module);
+void init_Param(PyObject *module);
+void init_SeparatorParam(PyObject *module);
+void init_ParametricParam(PyObject *module);
+void init_PageParam(PyObject *module);
+void init_NodeCreationProperty(PyObject *module);
+void init_StringNodeCreationProperty(PyObject *module);
+void init_NatronEngineNATRON_ENUM(PyObject *module);
+void init_ItemBase(PyObject *module);
+void init_Layer(PyObject *module);
+void init_IntNodeCreationProperty(PyObject *module);
+void init_Int3DTuple(PyObject *module);
+void init_Int2DTuple(PyObject *module);
+void init_ImageLayer(PyObject *module);
+void init_GroupParam(PyObject *module);
+void init_Group(PyObject *module);
+void init_FloatNodeCreationProperty(PyObject *module);
+void init_ExprUtils(PyObject *module);
+void init_Effect(PyObject *module);
+void init_Double3DTuple(PyObject *module);
+void init_Double2DTuple(PyObject *module);
+void init_ColorTuple(PyObject *module);
+void init_ButtonParam(PyObject *module);
+void init_BoolNodeCreationProperty(PyObject *module);
+void init_BezierCurve(PyObject *module);
+void init_AppSettings(PyObject *module);
+void init_App(PyObject *module);
+void init_AnimatedParam(PyObject *module);
+void init_DoubleParam(PyObject *module);
+void init_Double2DParam(PyObject *module);
+void init_Double3DParam(PyObject *module);
+void init_StringParamBase(PyObject *module);
+void init_OutputFileParam(PyObject *module);
+void init_StringParam(PyObject *module);
+void init_PathParam(PyObject *module);
+void init_FileParam(PyObject *module);
+void init_IntParam(PyObject *module);
+void init_Int2DParam(PyObject *module);
+void init_Int3DParam(PyObject *module);
+void init_ColorParam(PyObject *module);
+void init_ChoiceParam(PyObject *module);
+void init_BooleanParam(PyObject *module);
+
+// Required modules' type and converter arrays.
+PyTypeObject **SbkPySide2_QtCoreTypes;
+SbkConverter **SbkPySide2_QtCoreTypeConverters;
+
+// Module initialization ------------------------------------------------------------
+
+// Primitive Type converters.
+
+// C++ to Python conversion for type 'std::size_t'.
+static PyObject *std_size_t_CppToPython_std_size_t(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::size_t *>(const_cast<void *>(cppIn));
+    return PyLong_FromSize_t(cppInRef);
+
+}
+// Python to C++ conversions for type 'std::size_t'.
+static void PyLong_PythonToCpp_std_size_t(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::std::size_t *>(cppOut) = std::size_t(PyLong_AsSsize_t(pyIn));
+
+}
+static PythonToCppFunc is_PyLong_PythonToCpp_std_size_t_Convertible(PyObject *pyIn) {
+    if (PyLong_Check(pyIn))
+        return PyLong_PythonToCpp_std_size_t;
+    return {};
+}
+
+
+// Container Type converters.
+
+// C++ to Python conversion for type 'const std::map<QString,NodeCreationProperty* > &'.
+static PyObject *conststd_map_QString_NodeCreationPropertyPTR_REF_CppToPython_conststd_map_QString_NodeCreationPropertyPTR_REF(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::map<QString,NodeCreationProperty* > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdMapToPyDict - START
+    PyObject* pyOut = PyDict_New();
+    ::std::map<QString,NodeCreationProperty* >::const_iterator it = cppInRef.begin();
+    for (; it != cppInRef.end(); ++it) {
+    ::QString key = it->first;
+    ::NodeCreationProperty* value = it->second;
+    PyObject* pyKey = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &key);
+    PyObject* pyValue = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_NODECREATIONPROPERTY_IDX]), value);
+    PyDict_SetItem(pyOut, pyKey, pyValue);
+    Py_DECREF(pyKey);
+    Py_DECREF(pyValue);
+    }
+    return pyOut;
+    // TEMPLATE - stdMapToPyDict - END
+
+}
+static void conststd_map_QString_NodeCreationPropertyPTR_REF_PythonToCpp_conststd_map_QString_NodeCreationPropertyPTR_REF(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::map<QString,NodeCreationProperty* > *>(cppOut);
+    // TEMPLATE - pyDictToStdMap - START
+    PyObject* key;
+    PyObject* value;
+    Py_ssize_t pos = 0;
+    while (PyDict_Next(pyIn, &pos, &key, &value)) {
+    ::QString cppKey;
+        Shiboken::Conversions::pythonToCppCopy(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], key, &(cppKey));
+    ::NodeCreationProperty* cppValue{nullptr};
+        Shiboken::Conversions::pythonToCppPointer(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_NODECREATIONPROPERTY_IDX]), value, &(cppValue));
+    cppOutRef.insert(std::make_pair(cppKey, cppValue));
+    }
+    // TEMPLATE - pyDictToStdMap - END
+
+}
+static PythonToCppFunc is_conststd_map_QString_NodeCreationPropertyPTR_REF_PythonToCpp_conststd_map_QString_NodeCreationPropertyPTR_REF_Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleDictTypes(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], false, *PepType_SGTP(SbkNatronEngineTypes[SBK_NODECREATIONPROPERTY_IDX])->converter, true, pyIn))
+        return conststd_map_QString_NodeCreationPropertyPTR_REF_PythonToCpp_conststd_map_QString_NodeCreationPropertyPTR_REF;
+    return {};
+}
+
+// C++ to Python conversion for type 'std::list<Effect* >'.
+static PyObject *std_list_EffectPTR__CppToPython_std_list_EffectPTR_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::list<Effect* > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdListToPyList - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::std::list<Effect* >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+    ::Effect* cppItem(*it);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdListToPyList - END
+
+}
+static void std_list_EffectPTR__PythonToCpp_std_list_EffectPTR_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::list<Effect* > *>(cppOut);
+    // TEMPLATE - pyListToStdList - START
+    for (int i = 0; i < PySequence_Size(pyIn); i++) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, i));
+    ::Effect* cppItem{nullptr};
+        Shiboken::Conversions::pythonToCppPointer(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pyListToStdList - END
+
+}
+static PythonToCppFunc is_std_list_EffectPTR__PythonToCpp_std_list_EffectPTR__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::checkSequenceTypes(SbkNatronEngineTypes[SBK_EFFECT_IDX], pyIn))
+        return std_list_EffectPTR__PythonToCpp_std_list_EffectPTR_;
+    return {};
+}
+
+// C++ to Python conversion for type 'std::list<QString >'.
+static PyObject *std_list_QString__CppToPython_std_list_QString_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::list<QString > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdListToPyList - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::std::list<QString >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+    ::QString cppItem(*it);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdListToPyList - END
+
+}
+static void std_list_QString__PythonToCpp_std_list_QString_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::list<QString > *>(cppOut);
+    // TEMPLATE - pyListToStdList - START
+    for (int i = 0; i < PySequence_Size(pyIn); i++) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, i));
+    ::QString cppItem;
+        Shiboken::Conversions::pythonToCppCopy(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pyListToStdList - END
+
+}
+static PythonToCppFunc is_std_list_QString__PythonToCpp_std_list_QString__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], pyIn))
+        return std_list_QString__PythonToCpp_std_list_QString_;
+    return {};
+}
+
+// C++ to Python conversion for type 'const std::list<int > &'.
+static PyObject *conststd_list_int_REF_CppToPython_conststd_list_int_REF(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::list<int > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdListToPyList - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::std::list<int >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+    int cppItem(*it);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdListToPyList - END
+
+}
+static void conststd_list_int_REF_PythonToCpp_conststd_list_int_REF(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::list<int > *>(cppOut);
+    // TEMPLATE - pyListToStdList - START
+    for (int i = 0; i < PySequence_Size(pyIn); i++) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, i));
+    int cppItem;
+        Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<int>(), pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pyListToStdList - END
+
+}
+static PythonToCppFunc is_conststd_list_int_REF_PythonToCpp_conststd_list_int_REF_Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(Shiboken::Conversions::PrimitiveTypeConverter<int>(), pyIn))
+        return conststd_list_int_REF_PythonToCpp_conststd_list_int_REF;
+    return {};
+}
+
+// C++ to Python conversion for type 'std::list<Param* >'.
+static PyObject *std_list_ParamPTR__CppToPython_std_list_ParamPTR_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::list<Param* > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdListToPyList - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::std::list<Param* >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+    ::Param* cppItem(*it);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdListToPyList - END
+
+}
+static void std_list_ParamPTR__PythonToCpp_std_list_ParamPTR_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::list<Param* > *>(cppOut);
+    // TEMPLATE - pyListToStdList - START
+    for (int i = 0; i < PySequence_Size(pyIn); i++) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, i));
+    ::Param* cppItem{nullptr};
+        Shiboken::Conversions::pythonToCppPointer(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pyListToStdList - END
+
+}
+static PythonToCppFunc is_std_list_ParamPTR__PythonToCpp_std_list_ParamPTR__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::checkSequenceTypes(SbkNatronEngineTypes[SBK_PARAM_IDX], pyIn))
+        return std_list_ParamPTR__PythonToCpp_std_list_ParamPTR_;
+    return {};
+}
+
+// C++ to Python conversion for type 'std::list<double > *'.
+static PyObject *std_list_double_PTR_CppToPython_std_list_double_PTR(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::list<double > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdListToPyList - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::std::list<double >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+    double cppItem(*it);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdListToPyList - END
+
+}
+static void std_list_double_PTR_PythonToCpp_std_list_double_PTR(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::list<double > *>(cppOut);
+    // TEMPLATE - pyListToStdList - START
+    for (int i = 0; i < PySequence_Size(pyIn); i++) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, i));
+    double cppItem;
+        Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pyListToStdList - END
+
+}
+static PythonToCppFunc is_std_list_double_PTR_PythonToCpp_std_list_double_PTR_Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(Shiboken::Conversions::PrimitiveTypeConverter<double>(), pyIn))
+        return std_list_double_PTR_PythonToCpp_std_list_double_PTR;
+    return {};
+}
+
+// C++ to Python conversion for type 'const std::vector<bool > &'.
+static PyObject *conststd_vector_bool_REF_CppToPython_conststd_vector_bool_REF(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::vector<bool > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdVectorToPyList - START
+    ::std::vector<bool >::size_type vectorSize = cppInRef.size();
+    PyObject* pyOut = PyList_New((int) vectorSize);
+    for (::std::vector<bool >::size_type idx = 0; idx < vectorSize; ++idx) {
+    bool cppItem(cppInRef[idx]);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdVectorToPyList - END
+
+}
+static void conststd_vector_bool_REF_PythonToCpp_conststd_vector_bool_REF(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::vector<bool > *>(cppOut);
+    // TEMPLATE - pySeqToStdVector - START
+    int vectorSize = PySequence_Size(pyIn);
+    cppOutRef.reserve(vectorSize);
+    for (int idx = 0; idx < vectorSize; ++idx) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, idx));
+    bool cppItem;
+        Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pySeqToStdVector - END
+
+}
+static PythonToCppFunc is_conststd_vector_bool_REF_PythonToCpp_conststd_vector_bool_REF_Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), pyIn))
+        return conststd_vector_bool_REF_PythonToCpp_conststd_vector_bool_REF;
+    return {};
+}
+
+// C++ to Python conversion for type 'std::pair<QString,QString >'.
+static PyObject *std_pair_QString_QString__CppToPython_std_pair_QString_QString_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::pair<QString,QString > *>(const_cast<void *>(cppIn));
+    PyObject* pyOut = PyTuple_New(2);
+    PyTuple_SET_ITEM(pyOut, 0, Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppInRef.first));
+    PyTuple_SET_ITEM(pyOut, 1, Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppInRef.second));
+    return pyOut;
+
+}
+static void std_pair_QString_QString__PythonToCpp_std_pair_QString_QString_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::pair<QString,QString > *>(cppOut);
+    Shiboken::Conversions::pythonToCppCopy(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], PySequence_Fast_GET_ITEM(pyIn, 0), &(cppOutRef.first));
+    Shiboken::Conversions::pythonToCppCopy(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], PySequence_Fast_GET_ITEM(pyIn, 1), &(cppOutRef.second));
+
+}
+static PythonToCppFunc is_std_pair_QString_QString__PythonToCpp_std_pair_QString_QString__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertiblePairTypes(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], false, SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], false, pyIn))
+        return std_pair_QString_QString__PythonToCpp_std_pair_QString_QString_;
+    return {};
+}
+
+// C++ to Python conversion for type 'const std::list<std::pair< QString,QString > > &'.
+static PyObject *conststd_list_std_pair_QString_QString__REF_CppToPython_conststd_list_std_pair_QString_QString__REF(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::list<std::pair< QString,QString > > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdListToPyList - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::std::list<std::pair< QString,QString > >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+    ::std::pair<QString,QString > cppItem(*it);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_PAIR_QSTRING_QSTRING_IDX], &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdListToPyList - END
+
+}
+static void conststd_list_std_pair_QString_QString__REF_PythonToCpp_conststd_list_std_pair_QString_QString__REF(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::list<std::pair< QString,QString > > *>(cppOut);
+    // TEMPLATE - pyListToStdList - START
+    for (int i = 0; i < PySequence_Size(pyIn); i++) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, i));
+    ::std::pair<QString,QString > cppItem;
+        Shiboken::Conversions::pythonToCppCopy(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_PAIR_QSTRING_QSTRING_IDX], pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pyListToStdList - END
+
+}
+static PythonToCppFunc is_conststd_list_std_pair_QString_QString__REF_PythonToCpp_conststd_list_std_pair_QString_QString__REF_Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_PAIR_QSTRING_QSTRING_IDX], pyIn))
+        return conststd_list_std_pair_QString_QString__REF_PythonToCpp_conststd_list_std_pair_QString_QString__REF;
+    return {};
+}
+
+// C++ to Python conversion for type 'std::list<ImageLayer >'.
+static PyObject *std_list_ImageLayer__CppToPython_std_list_ImageLayer_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::list<ImageLayer > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdListToPyList - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::std::list<ImageLayer >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+    ::ImageLayer cppItem(*it);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdListToPyList - END
+
+}
+static void std_list_ImageLayer__PythonToCpp_std_list_ImageLayer_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::list<ImageLayer > *>(cppOut);
+    // TEMPLATE - pyListToStdList - START
+    for (int i = 0; i < PySequence_Size(pyIn); i++) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, i));
+    ::ImageLayer cppItem = ::ImageLayer(::QString(), ::QString(), ::QStringList());
+        Shiboken::Conversions::pythonToCppCopy(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pyListToStdList - END
+
+}
+static PythonToCppFunc is_std_list_ImageLayer__PythonToCpp_std_list_ImageLayer__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]), pyIn))
+        return std_list_ImageLayer__PythonToCpp_std_list_ImageLayer_;
+    return {};
+}
+
+// C++ to Python conversion for type 'const std::vector<double > &'.
+static PyObject *conststd_vector_double_REF_CppToPython_conststd_vector_double_REF(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::vector<double > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdVectorToPyList - START
+    ::std::vector<double >::size_type vectorSize = cppInRef.size();
+    PyObject* pyOut = PyList_New((int) vectorSize);
+    for (::std::vector<double >::size_type idx = 0; idx < vectorSize; ++idx) {
+    double cppItem(cppInRef[idx]);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdVectorToPyList - END
+
+}
+static void conststd_vector_double_REF_PythonToCpp_conststd_vector_double_REF(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::vector<double > *>(cppOut);
+    // TEMPLATE - pySeqToStdVector - START
+    int vectorSize = PySequence_Size(pyIn);
+    cppOutRef.reserve(vectorSize);
+    for (int idx = 0; idx < vectorSize; ++idx) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, idx));
+    double cppItem;
+        Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<double>(), pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pySeqToStdVector - END
+
+}
+static PythonToCppFunc is_conststd_vector_double_REF_PythonToCpp_conststd_vector_double_REF_Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(Shiboken::Conversions::PrimitiveTypeConverter<double>(), pyIn))
+        return conststd_vector_double_REF_PythonToCpp_conststd_vector_double_REF;
+    return {};
+}
+
+// C++ to Python conversion for type 'const std::vector<int > &'.
+static PyObject *conststd_vector_int_REF_CppToPython_conststd_vector_int_REF(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::vector<int > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdVectorToPyList - START
+    ::std::vector<int >::size_type vectorSize = cppInRef.size();
+    PyObject* pyOut = PyList_New((int) vectorSize);
+    for (::std::vector<int >::size_type idx = 0; idx < vectorSize; ++idx) {
+    int cppItem(cppInRef[idx]);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdVectorToPyList - END
+
+}
+static void conststd_vector_int_REF_PythonToCpp_conststd_vector_int_REF(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::vector<int > *>(cppOut);
+    // TEMPLATE - pySeqToStdVector - START
+    int vectorSize = PySequence_Size(pyIn);
+    cppOutRef.reserve(vectorSize);
+    for (int idx = 0; idx < vectorSize; ++idx) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, idx));
+    int cppItem;
+        Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<int>(), pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pySeqToStdVector - END
+
+}
+static PythonToCppFunc is_conststd_vector_int_REF_PythonToCpp_conststd_vector_int_REF_Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(Shiboken::Conversions::PrimitiveTypeConverter<int>(), pyIn))
+        return conststd_vector_int_REF_PythonToCpp_conststd_vector_int_REF;
+    return {};
+}
+
+// C++ to Python conversion for type 'std::list<ItemBase* >'.
+static PyObject *std_list_ItemBasePTR__CppToPython_std_list_ItemBasePTR_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::list<ItemBase* > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdListToPyList - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::std::list<ItemBase* >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+    ::ItemBase* cppItem(*it);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_ITEMBASE_IDX]), cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdListToPyList - END
+
+}
+static void std_list_ItemBasePTR__PythonToCpp_std_list_ItemBasePTR_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::list<ItemBase* > *>(cppOut);
+    // TEMPLATE - pyListToStdList - START
+    for (int i = 0; i < PySequence_Size(pyIn); i++) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, i));
+    ::ItemBase* cppItem{nullptr};
+        Shiboken::Conversions::pythonToCppPointer(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_ITEMBASE_IDX]), pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pyListToStdList - END
+
+}
+static PythonToCppFunc is_std_list_ItemBasePTR__PythonToCpp_std_list_ItemBasePTR__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::checkSequenceTypes(SbkNatronEngineTypes[SBK_ITEMBASE_IDX], pyIn))
+        return std_list_ItemBasePTR__PythonToCpp_std_list_ItemBasePTR_;
+    return {};
+}
+
+// C++ to Python conversion for type 'std::vector<std::string >'.
+static PyObject *std_vector_std_string__CppToPython_std_vector_std_string_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::vector<std::string > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdVectorToPyList - START
+    ::std::vector<std::string >::size_type vectorSize = cppInRef.size();
+    PyObject* pyOut = PyList_New((int) vectorSize);
+    for (::std::vector<std::string >::size_type idx = 0; idx < vectorSize; ++idx) {
+    ::std::string cppItem(cppInRef[idx]);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<std::string>(), &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdVectorToPyList - END
+
+}
+static void std_vector_std_string__PythonToCpp_std_vector_std_string_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::vector<std::string > *>(cppOut);
+    // TEMPLATE - pySeqToStdVector - START
+    int vectorSize = PySequence_Size(pyIn);
+    cppOutRef.reserve(vectorSize);
+    for (int idx = 0; idx < vectorSize; ++idx) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, idx));
+    ::std::string cppItem;
+        Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<std::string>(), pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pySeqToStdVector - END
+
+}
+static PythonToCppFunc is_std_vector_std_string__PythonToCpp_std_vector_std_string__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(Shiboken::Conversions::PrimitiveTypeConverter<std::string>(), pyIn))
+        return std_vector_std_string__PythonToCpp_std_vector_std_string_;
+    return {};
+}
+
+// C++ to Python conversion for type 'std::list<std::vector< std::string > > *'.
+static PyObject *std_list_std_vector_std_string__PTR_CppToPython_std_list_std_vector_std_string__PTR(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::list<std::vector< std::string > > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdListToPyList - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::std::list<std::vector< std::string > >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+    ::std::vector<std::string > cppItem(*it);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_STD_STRING_IDX], &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdListToPyList - END
+
+}
+static void std_list_std_vector_std_string__PTR_PythonToCpp_std_list_std_vector_std_string__PTR(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::list<std::vector< std::string > > *>(cppOut);
+    // TEMPLATE - pyListToStdList - START
+    for (int i = 0; i < PySequence_Size(pyIn); i++) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, i));
+    ::std::vector<std::string > cppItem;
+        Shiboken::Conversions::pythonToCppCopy(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_STD_STRING_IDX], pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pyListToStdList - END
+
+}
+static PythonToCppFunc is_std_list_std_vector_std_string__PTR_PythonToCpp_std_list_std_vector_std_string__PTR_Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_STD_STRING_IDX], pyIn))
+        return std_list_std_vector_std_string__PTR_PythonToCpp_std_list_std_vector_std_string__PTR;
+    return {};
+}
+
+// C++ to Python conversion for type 'std::vector<RectI >'.
+static PyObject *std_vector_RectI__CppToPython_std_vector_RectI_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::vector<RectI > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdVectorToPyList - START
+    ::std::vector<RectI >::size_type vectorSize = cppInRef.size();
+    PyObject* pyOut = PyList_New((int) vectorSize);
+    for (::std::vector<RectI >::size_type idx = 0; idx < vectorSize; ++idx) {
+    ::RectI cppItem(cppInRef[idx]);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTI_IDX]), &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdVectorToPyList - END
+
+}
+static void std_vector_RectI__PythonToCpp_std_vector_RectI_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::vector<RectI > *>(cppOut);
+    // TEMPLATE - pySeqToStdVector - START
+    int vectorSize = PySequence_Size(pyIn);
+    cppOutRef.reserve(vectorSize);
+    for (int idx = 0; idx < vectorSize; ++idx) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, idx));
+    ::RectI cppItem;
+        Shiboken::Conversions::pythonToCppCopy(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTI_IDX]), pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pySeqToStdVector - END
+
+}
+static PythonToCppFunc is_std_vector_RectI__PythonToCpp_std_vector_RectI__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTI_IDX]), pyIn))
+        return std_vector_RectI__PythonToCpp_std_vector_RectI_;
+    return {};
+}
+
+// C++ to Python conversion for type 'std::list<Track* > *'.
+static PyObject *std_list_TrackPTR_PTR_CppToPython_std_list_TrackPTR_PTR(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::list<Track* > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdListToPyList - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::std::list<Track* >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+    ::Track* cppItem(*it);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_TRACK_IDX]), cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdListToPyList - END
+
+}
+static void std_list_TrackPTR_PTR_PythonToCpp_std_list_TrackPTR_PTR(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::list<Track* > *>(cppOut);
+    // TEMPLATE - pyListToStdList - START
+    for (int i = 0; i < PySequence_Size(pyIn); i++) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, i));
+    ::Track* cppItem{nullptr};
+        Shiboken::Conversions::pythonToCppPointer(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_TRACK_IDX]), pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pyListToStdList - END
+
+}
+static PythonToCppFunc is_std_list_TrackPTR_PTR_PythonToCpp_std_list_TrackPTR_PTR_Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::checkSequenceTypes(SbkNatronEngineTypes[SBK_TRACK_IDX], pyIn))
+        return std_list_TrackPTR_PTR_PythonToCpp_std_list_TrackPTR_PTR;
+    return {};
+}
+
+// C++ to Python conversion for type 'QList<QVariant >'.
+static PyObject *_QList_QVariant__CppToPython__QList_QVariant_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::QList<QVariant > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - cpplist_to_pylist_conversion - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::QList<QVariant >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+        ::QVariant cppItem(*it);
+        PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QVARIANT_IDX], &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - cpplist_to_pylist_conversion - END
+
+}
+static void _QList_QVariant__PythonToCpp__QList_QVariant_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::QList<QVariant > *>(cppOut);
+    // TEMPLATE - pyseq_to_cpplist_conversion - START
+    // PYSIDE-795: Turn all sequences into iterables.
+    Shiboken::AutoDecRef it(PyObject_GetIter(pyIn));
+    PyObject *(*iternext)(PyObject *) = *Py_TYPE(it)->tp_iternext;
+    for (;;) {
+        Shiboken::AutoDecRef pyItem(iternext(it));
+        if (pyItem.isNull()) {
+            if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_StopIteration))
+                PyErr_Clear();
+            break;
+        }
+        ::QVariant cppItem;
+        Shiboken::Conversions::pythonToCppCopy(SbkPySide2_QtCoreTypeConverters[SBK_QVARIANT_IDX], pyItem, &(cppItem));
+        cppOutRef << cppItem;
+    }
+    // TEMPLATE - pyseq_to_cpplist_conversion - END
+
+}
+static PythonToCppFunc is__QList_QVariant__PythonToCpp__QList_QVariant__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(SbkPySide2_QtCoreTypeConverters[SBK_QVARIANT_IDX], pyIn))
+        return _QList_QVariant__PythonToCpp__QList_QVariant_;
+    return {};
+}
+
+// C++ to Python conversion for type 'QList<QString >'.
+static PyObject *_QList_QString__CppToPython__QList_QString_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::QList<QString > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - cpplist_to_pylist_conversion - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::QList<QString >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+        ::QString cppItem(*it);
+        PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - cpplist_to_pylist_conversion - END
+
+}
+static void _QList_QString__PythonToCpp__QList_QString_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::QList<QString > *>(cppOut);
+    // TEMPLATE - pyseq_to_cpplist_conversion - START
+    // PYSIDE-795: Turn all sequences into iterables.
+    Shiboken::AutoDecRef it(PyObject_GetIter(pyIn));
+    PyObject *(*iternext)(PyObject *) = *Py_TYPE(it)->tp_iternext;
+    for (;;) {
+        Shiboken::AutoDecRef pyItem(iternext(it));
+        if (pyItem.isNull()) {
+            if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_StopIteration))
+                PyErr_Clear();
+            break;
+        }
+        ::QString cppItem;
+        Shiboken::Conversions::pythonToCppCopy(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], pyItem, &(cppItem));
+        cppOutRef << cppItem;
+    }
+    // TEMPLATE - pyseq_to_cpplist_conversion - END
+
+}
+static PythonToCppFunc is__QList_QString__PythonToCpp__QList_QString__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], pyIn))
+        return _QList_QString__PythonToCpp__QList_QString_;
+    return {};
+}
+
+// C++ to Python conversion for type 'QMap<QString,QVariant >'.
+static PyObject *_QMap_QString_QVariant__CppToPython__QMap_QString_QVariant_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::QMap<QString,QVariant > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - cppmap_to_pymap_conversion - START
+    PyObject *pyOut = PyDict_New();
+    for (::QMap<QString,QVariant >::const_iterator it = cppInRef.begin(), end = cppInRef.end(); it != end; ++it) {
+        ::QString key = it.key();
+        ::QVariant value = it.value();
+        PyObject *pyKey = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &key);
+        PyObject *pyValue = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QVARIANT_IDX], &value);
+        PyDict_SetItem(pyOut, pyKey, pyValue);
+        Py_DECREF(pyKey);
+        Py_DECREF(pyValue);
+    }
+    return pyOut;
+    // TEMPLATE - cppmap_to_pymap_conversion - END
+
+}
+static void _QMap_QString_QVariant__PythonToCpp__QMap_QString_QVariant_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::QMap<QString,QVariant > *>(cppOut);
+    // TEMPLATE - pydict_to_cppmap_conversion - START
+    PyObject *key;
+    PyObject *value;
+    Py_ssize_t pos = 0;
+    while (PyDict_Next(pyIn, &pos, &key, &value)) {
+        ::QString cppKey;
+        Shiboken::Conversions::pythonToCppCopy(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], key, &(cppKey));
+        ::QVariant cppValue;
+        Shiboken::Conversions::pythonToCppCopy(SbkPySide2_QtCoreTypeConverters[SBK_QVARIANT_IDX], value, &(cppValue));
+        cppOutRef.insert(cppKey, cppValue);
+    }
+    // TEMPLATE - pydict_to_cppmap_conversion - END
+
+}
+static PythonToCppFunc is__QMap_QString_QVariant__PythonToCpp__QMap_QString_QVariant__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleDictTypes(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], false, SbkPySide2_QtCoreTypeConverters[SBK_QVARIANT_IDX], false, pyIn))
+        return _QMap_QString_QVariant__PythonToCpp__QMap_QString_QVariant_;
+    return {};
+}
+
+
+#ifdef IS_PY3K
+static struct PyModuleDef moduledef = {
+    /* m_base     */ PyModuleDef_HEAD_INIT,
+    /* m_name     */ "NatronEngine",
+    /* m_doc      */ nullptr,
+    /* m_size     */ -1,
+    /* m_methods  */ NatronEngine_methods,
+    /* m_reload   */ nullptr,
+    /* m_traverse */ nullptr,
+    /* m_clear    */ nullptr,
+    /* m_free     */ nullptr
+};
+
+#endif
+
+// The signatures string for the global functions.
+// Multiple signatures have their index "n:" in front.
+static const char *NatronEngine_SignatureStrings[] = {
+    nullptr}; // Sentinel
+
+SBK_MODULE_INIT_FUNCTION_BEGIN(NatronEngine)
+    {
+        Shiboken::AutoDecRef requiredModule(Shiboken::Module::import("PySide2.QtCore"));
+        if (requiredModule.isNull())
+            return SBK_MODULE_INIT_ERROR;
+        SbkPySide2_QtCoreTypes = Shiboken::Module::getTypes(requiredModule);
+        SbkPySide2_QtCoreTypeConverters = Shiboken::Module::getTypeConverters(requiredModule);
+    }
+
+    // Create an array of wrapper types for the current module.
+    static PyTypeObject *cppApi[SBK_NatronEngine_IDX_COUNT];
+    SbkNatronEngineTypes = cppApi;
+
+    // Create an array of primitive type converters for the current module.
+    static SbkConverter *sbkConverters[SBK_NatronEngine_CONVERTERS_IDX_COUNT];
+    SbkNatronEngineTypeConverters = sbkConverters;
+
+#ifdef IS_PY3K
+    PyObject *module = Shiboken::Module::create("NatronEngine", &moduledef);
+#else
+    PyObject *module = Shiboken::Module::create("NatronEngine", NatronEngine_methods);
+#endif
+
+    // Make module available from global scope
+    SbkNatronEngineModuleObject = module;
+
+    // Initialize classes in the type system
+    init_UserParamHolder(module);
+    init_Tracker(module);
+    init_Track(module);
+    init_Roto(module);
+    init_RectI(module);
+    init_RectD(module);
+    init_PyCoreApplication(module);
+    init_Param(module);
+    init_SeparatorParam(module);
+    init_ParametricParam(module);
+    init_PageParam(module);
+    init_NodeCreationProperty(module);
+    init_StringNodeCreationProperty(module);
+    init_NatronEngineNATRON_ENUM(module);
+    init_ItemBase(module);
+    init_Layer(module);
+    init_IntNodeCreationProperty(module);
+    init_Int3DTuple(module);
+    init_Int2DTuple(module);
+    init_ImageLayer(module);
+    init_GroupParam(module);
+    init_Group(module);
+    init_FloatNodeCreationProperty(module);
+    init_ExprUtils(module);
+    init_Effect(module);
+    init_Double3DTuple(module);
+    init_Double2DTuple(module);
+    init_ColorTuple(module);
+    init_ButtonParam(module);
+    init_BoolNodeCreationProperty(module);
+    init_BezierCurve(module);
+    init_AppSettings(module);
+    init_App(module);
+    init_AnimatedParam(module);
+    init_DoubleParam(module);
+    init_Double2DParam(module);
+    init_Double3DParam(module);
+    init_StringParamBase(module);
+    init_OutputFileParam(module);
+    init_StringParam(module);
+    init_PathParam(module);
+    init_FileParam(module);
+    init_IntParam(module);
+    init_Int2DParam(module);
+    init_Int3DParam(module);
+    init_ColorParam(module);
+    init_ChoiceParam(module);
+    init_BooleanParam(module);
+
+    // Register converter for type 'NatronEngine.std::size_t'.
+    SbkNatronEngineTypeConverters[SBK_STD_SIZE_T_IDX] = Shiboken::Conversions::createConverter(&PyLong_Type, std_size_t_CppToPython_std_size_t);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_STD_SIZE_T_IDX], "std::size_t");
+    // Add user defined implicit conversions to type converter.
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_STD_SIZE_T_IDX],
+        PyLong_PythonToCpp_std_size_t,
+        is_PyLong_PythonToCpp_std_size_t_Convertible);
+
+
+    // Register converter for type 'const std::map<QString,NodeCreationProperty*>&'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_MAP_QSTRING_NODECREATIONPROPERTYPTR_IDX] = Shiboken::Conversions::createConverter(&PyDict_Type, conststd_map_QString_NodeCreationPropertyPTR_REF_CppToPython_conststd_map_QString_NodeCreationPropertyPTR_REF);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_MAP_QSTRING_NODECREATIONPROPERTYPTR_IDX], "const std::map<QString,NodeCreationProperty*>&");
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_MAP_QSTRING_NODECREATIONPROPERTYPTR_IDX], "std::map<QString,NodeCreationProperty*>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_MAP_QSTRING_NODECREATIONPROPERTYPTR_IDX],
+        conststd_map_QString_NodeCreationPropertyPTR_REF_PythonToCpp_conststd_map_QString_NodeCreationPropertyPTR_REF,
+        is_conststd_map_QString_NodeCreationPropertyPTR_REF_PythonToCpp_conststd_map_QString_NodeCreationPropertyPTR_REF_Convertible);
+
+    // Register converter for type 'std::list<Effect*>'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_EFFECTPTR_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, std_list_EffectPTR__CppToPython_std_list_EffectPTR_);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_EFFECTPTR_IDX], "std::list<Effect*>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_EFFECTPTR_IDX],
+        std_list_EffectPTR__PythonToCpp_std_list_EffectPTR_,
+        is_std_list_EffectPTR__PythonToCpp_std_list_EffectPTR__Convertible);
+
+    // Register converter for type 'std::list<QString>'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_QSTRING_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, std_list_QString__CppToPython_std_list_QString_);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_QSTRING_IDX], "std::list<QString>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_QSTRING_IDX],
+        std_list_QString__PythonToCpp_std_list_QString_,
+        is_std_list_QString__PythonToCpp_std_list_QString__Convertible);
+
+    // Register converter for type 'const std::list<int>&'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_INT_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, conststd_list_int_REF_CppToPython_conststd_list_int_REF);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_INT_IDX], "const std::list<int>&");
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_INT_IDX], "std::list<int>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_INT_IDX],
+        conststd_list_int_REF_PythonToCpp_conststd_list_int_REF,
+        is_conststd_list_int_REF_PythonToCpp_conststd_list_int_REF_Convertible);
+
+    // Register converter for type 'std::list<Param*>'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_PARAMPTR_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, std_list_ParamPTR__CppToPython_std_list_ParamPTR_);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_PARAMPTR_IDX], "std::list<Param*>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_PARAMPTR_IDX],
+        std_list_ParamPTR__PythonToCpp_std_list_ParamPTR_,
+        is_std_list_ParamPTR__PythonToCpp_std_list_ParamPTR__Convertible);
+
+    // Register converter for type 'std::list<double>*'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_DOUBLE_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, std_list_double_PTR_CppToPython_std_list_double_PTR);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_DOUBLE_IDX], "std::list<double>*");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_DOUBLE_IDX],
+        std_list_double_PTR_PythonToCpp_std_list_double_PTR,
+        is_std_list_double_PTR_PythonToCpp_std_list_double_PTR_Convertible);
+
+    // Register converter for type 'const std::vector<bool>&'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_BOOL_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, conststd_vector_bool_REF_CppToPython_conststd_vector_bool_REF);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_BOOL_IDX], "const std::vector<bool>&");
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_BOOL_IDX], "std::vector<bool>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_BOOL_IDX],
+        conststd_vector_bool_REF_PythonToCpp_conststd_vector_bool_REF,
+        is_conststd_vector_bool_REF_PythonToCpp_conststd_vector_bool_REF_Convertible);
+
+    // Register converter for type 'std::pair<QString,QString>'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_PAIR_QSTRING_QSTRING_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, std_pair_QString_QString__CppToPython_std_pair_QString_QString_);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_PAIR_QSTRING_QSTRING_IDX], "std::pair<QString,QString>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_PAIR_QSTRING_QSTRING_IDX],
+        std_pair_QString_QString__PythonToCpp_std_pair_QString_QString_,
+        is_std_pair_QString_QString__PythonToCpp_std_pair_QString_QString__Convertible);
+
+    // Register converter for type 'const std::list<std::pair<QString,QString>>&'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_STD_PAIR_QSTRING_QSTRING_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, conststd_list_std_pair_QString_QString__REF_CppToPython_conststd_list_std_pair_QString_QString__REF);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_STD_PAIR_QSTRING_QSTRING_IDX], "const std::list<std::pair<QString,QString>>&");
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_STD_PAIR_QSTRING_QSTRING_IDX], "std::list<std::pair<QString,QString>>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_STD_PAIR_QSTRING_QSTRING_IDX],
+        conststd_list_std_pair_QString_QString__REF_PythonToCpp_conststd_list_std_pair_QString_QString__REF,
+        is_conststd_list_std_pair_QString_QString__REF_PythonToCpp_conststd_list_std_pair_QString_QString__REF_Convertible);
+
+    // Register converter for type 'std::list<ImageLayer>'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_IMAGELAYER_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, std_list_ImageLayer__CppToPython_std_list_ImageLayer_);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_IMAGELAYER_IDX], "std::list<ImageLayer>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_IMAGELAYER_IDX],
+        std_list_ImageLayer__PythonToCpp_std_list_ImageLayer_,
+        is_std_list_ImageLayer__PythonToCpp_std_list_ImageLayer__Convertible);
+
+    // Register converter for type 'const std::vector<double>&'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_DOUBLE_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, conststd_vector_double_REF_CppToPython_conststd_vector_double_REF);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_DOUBLE_IDX], "const std::vector<double>&");
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_DOUBLE_IDX], "std::vector<double>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_DOUBLE_IDX],
+        conststd_vector_double_REF_PythonToCpp_conststd_vector_double_REF,
+        is_conststd_vector_double_REF_PythonToCpp_conststd_vector_double_REF_Convertible);
+
+    // Register converter for type 'const std::vector<int>&'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_INT_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, conststd_vector_int_REF_CppToPython_conststd_vector_int_REF);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_INT_IDX], "const std::vector<int>&");
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_INT_IDX], "std::vector<int>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_INT_IDX],
+        conststd_vector_int_REF_PythonToCpp_conststd_vector_int_REF,
+        is_conststd_vector_int_REF_PythonToCpp_conststd_vector_int_REF_Convertible);
+
+    // Register converter for type 'std::list<ItemBase*>'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_ITEMBASEPTR_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, std_list_ItemBasePTR__CppToPython_std_list_ItemBasePTR_);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_ITEMBASEPTR_IDX], "std::list<ItemBase*>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_ITEMBASEPTR_IDX],
+        std_list_ItemBasePTR__PythonToCpp_std_list_ItemBasePTR_,
+        is_std_list_ItemBasePTR__PythonToCpp_std_list_ItemBasePTR__Convertible);
+
+    // Register converter for type 'std::vector<std::string>'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_STD_STRING_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, std_vector_std_string__CppToPython_std_vector_std_string_);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_STD_STRING_IDX], "std::vector<std::string>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_STD_STRING_IDX],
+        std_vector_std_string__PythonToCpp_std_vector_std_string_,
+        is_std_vector_std_string__PythonToCpp_std_vector_std_string__Convertible);
+
+    // Register converter for type 'std::list<std::vector<std::string>>*'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_STD_VECTOR_STD_STRING_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, std_list_std_vector_std_string__PTR_CppToPython_std_list_std_vector_std_string__PTR);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_STD_VECTOR_STD_STRING_IDX], "std::list<std::vector<std::string>>*");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_STD_VECTOR_STD_STRING_IDX],
+        std_list_std_vector_std_string__PTR_PythonToCpp_std_list_std_vector_std_string__PTR,
+        is_std_list_std_vector_std_string__PTR_PythonToCpp_std_list_std_vector_std_string__PTR_Convertible);
+
+    // Register converter for type 'std::vector<RectI>'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_RECTI_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, std_vector_RectI__CppToPython_std_vector_RectI_);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_RECTI_IDX], "std::vector<RectI>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_RECTI_IDX],
+        std_vector_RectI__PythonToCpp_std_vector_RectI_,
+        is_std_vector_RectI__PythonToCpp_std_vector_RectI__Convertible);
+
+    // Register converter for type 'std::list<Track*>*'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_TRACKPTR_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, std_list_TrackPTR_PTR_CppToPython_std_list_TrackPTR_PTR);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_TRACKPTR_IDX], "std::list<Track*>*");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_TRACKPTR_IDX],
+        std_list_TrackPTR_PTR_PythonToCpp_std_list_TrackPTR_PTR,
+        is_std_list_TrackPTR_PTR_PythonToCpp_std_list_TrackPTR_PTR_Convertible);
+
+    // Register converter for type 'QList<QVariant>'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_QLIST_QVARIANT_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, _QList_QVariant__CppToPython__QList_QVariant_);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_QLIST_QVARIANT_IDX], "QList<QVariant>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_QLIST_QVARIANT_IDX],
+        _QList_QVariant__PythonToCpp__QList_QVariant_,
+        is__QList_QVariant__PythonToCpp__QList_QVariant__Convertible);
+
+    // Register converter for type 'QList<QString>'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_QLIST_QSTRING_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, _QList_QString__CppToPython__QList_QString_);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_QLIST_QSTRING_IDX], "QList<QString>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_QLIST_QSTRING_IDX],
+        _QList_QString__PythonToCpp__QList_QString_,
+        is__QList_QString__PythonToCpp__QList_QString__Convertible);
+
+    // Register converter for type 'QMap<QString,QVariant>'.
+    SbkNatronEngineTypeConverters[SBK_NATRONENGINE_QMAP_QSTRING_QVARIANT_IDX] = Shiboken::Conversions::createConverter(&PyDict_Type, _QMap_QString_QVariant__CppToPython__QMap_QString_QVariant_);
+    Shiboken::Conversions::registerConverterName(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_QMAP_QSTRING_QVARIANT_IDX], "QMap<QString,QVariant>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_QMAP_QSTRING_QVARIANT_IDX],
+        _QMap_QString_QVariant__PythonToCpp__QMap_QString_QVariant_,
+        is__QMap_QString_QVariant__PythonToCpp__QMap_QString_QVariant__Convertible);
+
+    // Register primitive types converters.
+    Shiboken::Conversions::registerConverterName(Shiboken::Conversions::PrimitiveTypeConverter<unsigned short>(), "ushort");
+
+    Shiboken::Module::registerTypes(module, SbkNatronEngineTypes);
+    Shiboken::Module::registerTypeConverters(module, SbkNatronEngineTypeConverters);
+
+    if (PyErr_Occurred()) {
+        PyErr_Print();
+        Py_FatalError("can't initialize module NatronEngine");
+    }
+    PySide::registerCleanupFunction(cleanTypesAttributes);
+
+    FinishSignatureInitialization(module, NatronEngine_SignatureStrings);
+
+SBK_MODULE_INIT_FUNCTION_END

--- a/Engine/Qt5/NatronEngine/natronengine_python.h
+++ b/Engine/Qt5/NatronEngine/natronengine_python.h
@@ -1,0 +1,231 @@
+
+
+#ifndef SBK_NATRONENGINE_PYTHON_H
+#define SBK_NATRONENGINE_PYTHON_H
+
+#include <sbkpython.h>
+#include <sbkconverter.h>
+// Module Includes
+CLANG_DIAG_OFF(deprecated)
+CLANG_DIAG_OFF(uninitialized)
+CLANG_DIAG_OFF(keyword-macro)
+#include <pyside2_qtcore_python.h> // produces warnings
+CLANG_DIAG_ON(deprecated)
+CLANG_DIAG_ON(uninitialized)
+CLANG_DIAG_ON(keyword-macro)
+
+// Bound library includes
+#include <PyParameter.h>
+#include <RectD.h>
+#include <PyAppInstance.h>
+#include <PyNodeGroup.h>
+#include <PyTracker.h>
+#include <PyExprUtils.h>
+#include <PyRoto.h>
+#include <PyGlobalFunctions.h>
+#include <RectI.h>
+#include <Enums.h>
+#include <PyNode.h>
+// Conversion Includes - Primitive Types
+#include <qabstractitemmodel.h>
+#include <QString>
+#include <QStringList>
+#include <signalmanager.h>
+
+// Conversion Includes - Container Types
+#include <pysideqflags.h>
+#include <QLinkedList>
+#include <QList>
+#include <QMap>
+#include <QMultiMap>
+#include <QPair>
+#include <QQueue>
+#include <QSet>
+#include <QStack>
+#include <QVector>
+#include <list>
+#include <map>
+#include <map>
+#include <utility>
+#include <set>
+#include <vector>
+
+// Type indices
+enum : int {
+    SBK_ANIMATEDPARAM_IDX                                    = 0,
+    SBK_APP_IDX                                              = 1,
+    SBK_APPSETTINGS_IDX                                      = 2,
+    SBK_BEZIERCURVE_IDX                                      = 3,
+    SBK_BOOLNODECREATIONPROPERTY_IDX                         = 4,
+    SBK_BOOLEANPARAM_IDX                                     = 5,
+    SBK_BUTTONPARAM_IDX                                      = 6,
+    SBK_CHOICEPARAM_IDX                                      = 7,
+    SBK_COLORPARAM_IDX                                       = 8,
+    SBK_COLORTUPLE_IDX                                       = 9,
+    SBK_DOUBLE2DPARAM_IDX                                    = 10,
+    SBK_DOUBLE2DTUPLE_IDX                                    = 11,
+    SBK_DOUBLE3DPARAM_IDX                                    = 12,
+    SBK_DOUBLE3DTUPLE_IDX                                    = 13,
+    SBK_DOUBLEPARAM_IDX                                      = 14,
+    SBK_EFFECT_IDX                                           = 15,
+    SBK_EXPRUTILS_IDX                                        = 16,
+    SBK_FILEPARAM_IDX                                        = 17,
+    SBK_FLOATNODECREATIONPROPERTY_IDX                        = 18,
+    SBK_GROUP_IDX                                            = 19,
+    SBK_GROUPPARAM_IDX                                       = 20,
+    SBK_IMAGELAYER_IDX                                       = 21,
+    SBK_INT2DPARAM_IDX                                       = 22,
+    SBK_INT2DTUPLE_IDX                                       = 23,
+    SBK_INT3DPARAM_IDX                                       = 24,
+    SBK_INT3DTUPLE_IDX                                       = 25,
+    SBK_INTNODECREATIONPROPERTY_IDX                          = 26,
+    SBK_INTPARAM_IDX                                         = 27,
+    SBK_ITEMBASE_IDX                                         = 28,
+    SBK_LAYER_IDX                                            = 29,
+    SBK_NATRON_ENUM_STATUSENUM_IDX                           = 41,
+    SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX                   = 40,
+    SBK_QFLAGS_NATRON_ENUM_STANDARDBUTTONENUM_IDX            = 52,
+    SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX                     = 35,
+    SBK_NATRON_ENUM_PIXMAPENUM_IDX                           = 38,
+    SBK_NATRON_ENUM_VALUECHANGEDREASONENUM_IDX               = 42,
+    SBK_NATRON_ENUM_ANIMATIONLEVELENUM_IDX                   = 31,
+    SBK_NATRON_ENUM_IMAGEPREMULTIPLICATIONENUM_IDX           = 34,
+    SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX        = 44,
+    SBK_NATRON_ENUM_VIEWERCOLORSPACEENUM_IDX                 = 43,
+    SBK_NATRON_ENUM_IMAGEBITDEPTHENUM_IDX                    = 33,
+    SBK_NATRON_ENUM_ORIENTATIONENUM_IDX                      = 37,
+    SBK_NATRON_ENUM_PLAYBACKMODEENUM_IDX                     = 39,
+    SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX                  = 32,
+    SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX                  = 36,
+    SBK_NatronEngineNATRON_ENUM_IDX                          = 30,
+    SBK_NODECREATIONPROPERTY_IDX                             = 45,
+    SBK_OUTPUTFILEPARAM_IDX                                  = 46,
+    SBK_PAGEPARAM_IDX                                        = 47,
+    SBK_PARAM_IDX                                            = 48,
+    SBK_PARAMETRICPARAM_IDX                                  = 49,
+    SBK_PATHPARAM_IDX                                        = 50,
+    SBK_PYCOREAPPLICATION_IDX                                = 51,
+    SBK_RECTD_IDX                                            = 53,
+    SBK_RECTI_IDX                                            = 54,
+    SBK_ROTO_IDX                                             = 55,
+    SBK_SEPARATORPARAM_IDX                                   = 56,
+    SBK_STRINGNODECREATIONPROPERTY_IDX                       = 57,
+    SBK_STRINGPARAM_TYPEENUM_IDX                             = 59,
+    SBK_STRINGPARAM_IDX                                      = 58,
+    SBK_STRINGPARAMBASE_IDX                                  = 60,
+    SBK_TRACK_IDX                                            = 61,
+    SBK_TRACKER_IDX                                          = 62,
+    SBK_USERPARAMHOLDER_IDX                                  = 63,
+    SBK_NatronEngine_IDX_COUNT                               = 64
+};
+// This variable stores all Python types exported by this module.
+extern PyTypeObject **SbkNatronEngineTypes;
+
+// This variable stores the Python module object exported by this module.
+extern PyObject *SbkNatronEngineModuleObject;
+
+// This variable stores all type converters exported by this module.
+extern SbkConverter **SbkNatronEngineTypeConverters;
+
+// Converter indices
+enum : int {
+    SBK_STD_SIZE_T_IDX                                       = 0,
+    SBK_NATRONENGINE_STD_MAP_QSTRING_NODECREATIONPROPERTYPTR_IDX = 1, // const std::map<QString,NodeCreationProperty* > &
+    SBK_NATRONENGINE_STD_LIST_EFFECTPTR_IDX                  = 2, // std::list<Effect* >
+    SBK_NATRONENGINE_STD_LIST_QSTRING_IDX                    = 3, // std::list<QString >
+    SBK_NATRONENGINE_STD_LIST_INT_IDX                        = 4, // const std::list<int > &
+    SBK_NATRONENGINE_STD_LIST_PARAMPTR_IDX                   = 5, // std::list<Param* >
+    SBK_NATRONENGINE_STD_LIST_DOUBLE_IDX                     = 6, // std::list<double > *
+    SBK_NATRONENGINE_STD_VECTOR_BOOL_IDX                     = 7, // const std::vector<bool > &
+    SBK_NATRONENGINE_STD_PAIR_QSTRING_QSTRING_IDX            = 8, // std::pair<QString,QString >
+    SBK_NATRONENGINE_STD_LIST_STD_PAIR_QSTRING_QSTRING_IDX   = 9, // const std::list<std::pair< QString,QString > > &
+    SBK_NATRONENGINE_STD_LIST_IMAGELAYER_IDX                 = 10, // std::list<ImageLayer >
+    SBK_NATRONENGINE_STD_VECTOR_DOUBLE_IDX                   = 11, // const std::vector<double > &
+    SBK_NATRONENGINE_STD_VECTOR_INT_IDX                      = 12, // const std::vector<int > &
+    SBK_NATRONENGINE_STD_LIST_ITEMBASEPTR_IDX                = 13, // std::list<ItemBase* >
+    SBK_NATRONENGINE_STD_VECTOR_STD_STRING_IDX               = 14, // std::vector<std::string >
+    SBK_NATRONENGINE_STD_LIST_STD_VECTOR_STD_STRING_IDX      = 15, // std::list<std::vector< std::string > > *
+    SBK_NATRONENGINE_STD_VECTOR_RECTI_IDX                    = 16, // std::vector<RectI >
+    SBK_NATRONENGINE_STD_LIST_TRACKPTR_IDX                   = 17, // std::list<Track* > *
+    SBK_NATRONENGINE_QLIST_QVARIANT_IDX                      = 18, // QList<QVariant >
+    SBK_NATRONENGINE_QLIST_QSTRING_IDX                       = 19, // QList<QString >
+    SBK_NATRONENGINE_QMAP_QSTRING_QVARIANT_IDX               = 20, // QMap<QString,QVariant >
+    SBK_NatronEngine_CONVERTERS_IDX_COUNT                    = 21
+};
+// Macros for type check
+
+namespace Shiboken
+{
+
+// PyType functions, to get the PyObjectType for a type T
+QT_WARNING_PUSH
+QT_WARNING_DISABLE_DEPRECATED
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::AnimatedParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::App >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_APP_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::AppSettings >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_APPSETTINGS_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::BezierCurve >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::BoolNodeCreationProperty >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_BOOLNODECREATIONPROPERTY_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::BooleanParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_BOOLEANPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::ButtonParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_BUTTONPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::ChoiceParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::ColorParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_COLORPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::ColorTuple >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_COLORTUPLE_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Double2DParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_DOUBLE2DPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Double2DTuple >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_DOUBLE2DTUPLE_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Double3DParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_DOUBLE3DPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Double3DTuple >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_DOUBLE3DTUPLE_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::DoubleParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Effect >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::ExprUtils >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_EXPRUTILS_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::FileParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_FILEPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::FloatNodeCreationProperty >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_FLOATNODECREATIONPROPERTY_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Group >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_GROUP_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::GroupParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_GROUPPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::ImageLayer >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_IMAGELAYER_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Int2DParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_INT2DPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Int2DTuple >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_INT2DTUPLE_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Int3DParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_INT3DPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Int3DTuple >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_INT3DTUPLE_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::IntNodeCreationProperty >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_INTNODECREATIONPROPERTY_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::IntParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_INTPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::ItemBase >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_ITEMBASE_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Layer >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_LAYER_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_ENUM::StatusEnum >() { return SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX]; }
+template<> inline PyTypeObject *SbkType<NATRON_ENUM::StandardButtonEnum >() { return SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX]; }
+template<> inline PyTypeObject *SbkType< ::QFlags<::NATRON_ENUM::StandardButtonEnum> >() { return SbkNatronEngineTypes[SBK_QFLAGS_NATRON_ENUM_STANDARDBUTTONENUM_IDX]; }
+template<> inline PyTypeObject *SbkType<NATRON_ENUM::KeyframeTypeEnum >() { return SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX]; }
+template<> inline PyTypeObject *SbkType<NATRON_ENUM::PixmapEnum >() { return SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX]; }
+template<> inline PyTypeObject *SbkType<NATRON_ENUM::ValueChangedReasonEnum >() { return SbkNatronEngineTypes[SBK_NATRON_ENUM_VALUECHANGEDREASONENUM_IDX]; }
+template<> inline PyTypeObject *SbkType<NATRON_ENUM::AnimationLevelEnum >() { return SbkNatronEngineTypes[SBK_NATRON_ENUM_ANIMATIONLEVELENUM_IDX]; }
+template<> inline PyTypeObject *SbkType<NATRON_ENUM::ImagePremultiplicationEnum >() { return SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEPREMULTIPLICATIONENUM_IDX]; }
+template<> inline PyTypeObject *SbkType<NATRON_ENUM::ViewerCompositingOperatorEnum >() { return SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX]; }
+template<> inline PyTypeObject *SbkType<NATRON_ENUM::ViewerColorSpaceEnum >() { return SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOLORSPACEENUM_IDX]; }
+template<> inline PyTypeObject *SbkType<NATRON_ENUM::ImageBitDepthEnum >() { return SbkNatronEngineTypes[SBK_NATRON_ENUM_IMAGEBITDEPTHENUM_IDX]; }
+template<> inline PyTypeObject *SbkType<NATRON_ENUM::OrientationEnum >() { return SbkNatronEngineTypes[SBK_NATRON_ENUM_ORIENTATIONENUM_IDX]; }
+template<> inline PyTypeObject *SbkType<NATRON_ENUM::PlaybackModeEnum >() { return SbkNatronEngineTypes[SBK_NATRON_ENUM_PLAYBACKMODEENUM_IDX]; }
+template<> inline PyTypeObject *SbkType<NATRON_ENUM::DisplayChannelsEnum >() { return SbkNatronEngineTypes[SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX]; }
+template<> inline PyTypeObject *SbkType<NATRON_ENUM::MergingFunctionEnum >() { return SbkNatronEngineTypes[SBK_NATRON_ENUM_MERGINGFUNCTIONENUM_IDX]; }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::NodeCreationProperty >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_NODECREATIONPROPERTY_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::OutputFileParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_OUTPUTFILEPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::PageParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_PAGEPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Param >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_PARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::ParametricParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_PARAMETRICPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::PathParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_PATHPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::PyCoreApplication >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::RectD >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_RECTD_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::RectI >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_RECTI_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Roto >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_ROTO_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::SeparatorParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_SEPARATORPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::StringNodeCreationProperty >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_STRINGNODECREATIONPROPERTY_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::StringParam::TypeEnum >() { return SbkNatronEngineTypes[SBK_STRINGPARAM_TYPEENUM_IDX]; }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::StringParam >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_STRINGPARAM_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::StringParamBase >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Track >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_TRACK_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::Tracker >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_TRACKER_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::UserParamHolder >() { return reinterpret_cast<PyTypeObject *>(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX]); }
+QT_WARNING_POP
+
+} // namespace Shiboken
+
+#endif // SBK_NATRONENGINE_PYTHON_H
+

--- a/Engine/Qt5/NatronEngine/nodecreationproperty_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/nodecreationproperty_wrapper.cpp
@@ -1,0 +1,270 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "nodecreationproperty_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void NodeCreationPropertyWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void NodeCreationPropertyWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+NodeCreationPropertyWrapper::NodeCreationPropertyWrapper() : NodeCreationProperty()
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+NodeCreationPropertyWrapper::~NodeCreationPropertyWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_NodeCreationProperty_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::NodeCreationProperty >()))
+        return -1;
+
+    ::NodeCreationPropertyWrapper *cptr{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // NodeCreationProperty()
+            cptr = new ::NodeCreationPropertyWrapper();
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::NodeCreationProperty >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    Shiboken::Object::setHasCppWrapper(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+}
+
+
+static const char *Sbk_NodeCreationProperty_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_NodeCreationProperty_methods[] = {
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_NodeCreationProperty_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::NodeCreationProperty *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_NODECREATIONPROPERTY_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<NodeCreationPropertyWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_NodeCreationProperty_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_NodeCreationProperty_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_NodeCreationProperty_Type = nullptr;
+static SbkObjectType *Sbk_NodeCreationProperty_TypeF(void)
+{
+    return _Sbk_NodeCreationProperty_Type;
+}
+
+static PyType_Slot Sbk_NodeCreationProperty_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_NodeCreationProperty_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_NodeCreationProperty_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_NodeCreationProperty_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_NodeCreationProperty_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_NodeCreationProperty_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_NodeCreationProperty_spec = {
+    "1:NatronEngine.NodeCreationProperty",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_NodeCreationProperty_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void NodeCreationProperty_PythonToCpp_NodeCreationProperty_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_NodeCreationProperty_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_NodeCreationProperty_PythonToCpp_NodeCreationProperty_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_NodeCreationProperty_TypeF())))
+        return NodeCreationProperty_PythonToCpp_NodeCreationProperty_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *NodeCreationProperty_PTR_CppToPython_NodeCreationProperty(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::NodeCreationProperty *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_NodeCreationProperty_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *NodeCreationProperty_SignatureStrings[] = {
+    "NatronEngine.NodeCreationProperty(self)",
+    nullptr}; // Sentinel
+
+void init_NodeCreationProperty(PyObject *module)
+{
+    _Sbk_NodeCreationProperty_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "NodeCreationProperty",
+        "NodeCreationProperty*",
+        &Sbk_NodeCreationProperty_spec,
+        &Shiboken::callCppDestructor< ::NodeCreationProperty >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_NodeCreationProperty_Type);
+    InitSignatureStrings(pyType, NodeCreationProperty_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_NodeCreationProperty_Type), Sbk_NodeCreationProperty_PropertyStrings);
+    SbkNatronEngineTypes[SBK_NODECREATIONPROPERTY_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_NodeCreationProperty_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_NodeCreationProperty_TypeF(),
+        NodeCreationProperty_PythonToCpp_NodeCreationProperty_PTR,
+        is_NodeCreationProperty_PythonToCpp_NodeCreationProperty_PTR_Convertible,
+        NodeCreationProperty_PTR_CppToPython_NodeCreationProperty);
+
+    Shiboken::Conversions::registerConverterName(converter, "NodeCreationProperty");
+    Shiboken::Conversions::registerConverterName(converter, "NodeCreationProperty*");
+    Shiboken::Conversions::registerConverterName(converter, "NodeCreationProperty&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::NodeCreationProperty).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::NodeCreationPropertyWrapper).name());
+
+
+
+    NodeCreationPropertyWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/nodecreationproperty_wrapper.h
+++ b/Engine/Qt5/NatronEngine/nodecreationproperty_wrapper.h
@@ -1,0 +1,20 @@
+#ifndef SBK_NODECREATIONPROPERTYWRAPPER_H
+#define SBK_NODECREATIONPROPERTYWRAPPER_H
+
+#include <PyAppInstance.h>
+
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class NodeCreationPropertyWrapper : public NodeCreationProperty
+{
+public:
+    NodeCreationPropertyWrapper();
+    ~NodeCreationPropertyWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#endif // SBK_NODECREATIONPROPERTYWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/outputfileparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/outputfileparam_wrapper.cpp
@@ -1,0 +1,305 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "outputfileparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void OutputFileParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void OutputFileParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+OutputFileParamWrapper::~OutputFileParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_OutputFileParamFunc_openFile(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::OutputFileParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_OUTPUTFILEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // openFile()
+            cppSelf->openFile();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_OutputFileParamFunc_setSequenceEnabled(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::OutputFileParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_OUTPUTFILEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: OutputFileParam::setSequenceEnabled(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setSequenceEnabled(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_OutputFileParamFunc_setSequenceEnabled_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setSequenceEnabled(bool)
+            cppSelf->setSequenceEnabled(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_OutputFileParamFunc_setSequenceEnabled_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.OutputFileParam.setSequenceEnabled");
+        return {};
+}
+
+
+static const char *Sbk_OutputFileParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_OutputFileParam_methods[] = {
+    {"openFile", reinterpret_cast<PyCFunction>(Sbk_OutputFileParamFunc_openFile), METH_NOARGS},
+    {"setSequenceEnabled", reinterpret_cast<PyCFunction>(Sbk_OutputFileParamFunc_setSequenceEnabled), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_OutputFileParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::OutputFileParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_OUTPUTFILEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<OutputFileParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_OutputFileParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_OutputFileParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_OutputFileParam_Type = nullptr;
+static SbkObjectType *Sbk_OutputFileParam_TypeF(void)
+{
+    return _Sbk_OutputFileParam_Type;
+}
+
+static PyType_Slot Sbk_OutputFileParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_OutputFileParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_OutputFileParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_OutputFileParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_OutputFileParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_OutputFileParam_spec = {
+    "1:NatronEngine.OutputFileParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_OutputFileParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_OutputFileParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::OutputFileParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void OutputFileParam_PythonToCpp_OutputFileParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_OutputFileParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_OutputFileParam_PythonToCpp_OutputFileParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_OutputFileParam_TypeF())))
+        return OutputFileParam_PythonToCpp_OutputFileParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *OutputFileParam_PTR_CppToPython_OutputFileParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::OutputFileParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_OutputFileParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *OutputFileParam_SignatureStrings[] = {
+    "NatronEngine.OutputFileParam.openFile(self)",
+    "NatronEngine.OutputFileParam.setSequenceEnabled(self,enabled:bool)",
+    nullptr}; // Sentinel
+
+void init_OutputFileParam(PyObject *module)
+{
+    _Sbk_OutputFileParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "OutputFileParam",
+        "OutputFileParam*",
+        &Sbk_OutputFileParam_spec,
+        &Shiboken::callCppDestructor< ::OutputFileParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_OutputFileParam_Type);
+    InitSignatureStrings(pyType, OutputFileParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_OutputFileParam_Type), Sbk_OutputFileParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_OUTPUTFILEPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_OutputFileParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_OutputFileParam_TypeF(),
+        OutputFileParam_PythonToCpp_OutputFileParam_PTR,
+        is_OutputFileParam_PythonToCpp_OutputFileParam_PTR_Convertible,
+        OutputFileParam_PTR_CppToPython_OutputFileParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "OutputFileParam");
+    Shiboken::Conversions::registerConverterName(converter, "OutputFileParam*");
+    Shiboken::Conversions::registerConverterName(converter, "OutputFileParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::OutputFileParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::OutputFileParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_OutputFileParam_TypeF(), &Sbk_OutputFileParam_typeDiscovery);
+
+
+    OutputFileParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/outputfileparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/outputfileparam_wrapper.h
@@ -1,0 +1,78 @@
+#ifndef SBK_OUTPUTFILEPARAMWRAPPER_H
+#define SBK_OUTPUTFILEPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class OutputFileParamWrapper : public OutputFileParam
+{
+public:
+    ~OutputFileParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_STRINGPARAMBASEWRAPPER_H
+#  define SBK_STRINGPARAMBASEWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class StringParamBaseWrapper : public StringParamBase
+{
+public:
+    ~StringParamBaseWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_STRINGPARAMBASEWRAPPER_H
+
+#  ifndef SBK_ANIMATEDPARAMWRAPPER_H
+#  define SBK_ANIMATEDPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AnimatedParamWrapper : public AnimatedParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { AnimatedParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~AnimatedParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_ANIMATEDPARAMWRAPPER_H
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_OUTPUTFILEPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/pageparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/pageparam_wrapper.cpp
@@ -1,0 +1,283 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "pageparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void PageParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void PageParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+PageParamWrapper::~PageParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_PageParamFunc_addParam(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PageParamWrapper *>(reinterpret_cast< ::PageParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PAGEPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PageParam::addParam(const Param*)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), (pyArg)))) {
+        overloadId = 0; // addParam(const Param*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PageParamFunc_addParam_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::Param *cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // addParam(const Param*)
+            cppSelf->addParam(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PageParamFunc_addParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.PageParam.addParam");
+        return {};
+}
+
+
+static const char *Sbk_PageParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_PageParam_methods[] = {
+    {"addParam", reinterpret_cast<PyCFunction>(Sbk_PageParamFunc_addParam), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_PageParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::PageParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PAGEPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<PageParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_PageParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_PageParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_PageParam_Type = nullptr;
+static SbkObjectType *Sbk_PageParam_TypeF(void)
+{
+    return _Sbk_PageParam_Type;
+}
+
+static PyType_Slot Sbk_PageParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_PageParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_PageParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_PageParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_PageParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_PageParam_spec = {
+    "1:NatronEngine.PageParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_PageParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_PageParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::PageParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void PageParam_PythonToCpp_PageParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_PageParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_PageParam_PythonToCpp_PageParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_PageParam_TypeF())))
+        return PageParam_PythonToCpp_PageParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *PageParam_PTR_CppToPython_PageParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::PageParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_PageParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *PageParam_SignatureStrings[] = {
+    "NatronEngine.PageParam.addParam(self,param:NatronEngine.Param)",
+    nullptr}; // Sentinel
+
+void init_PageParam(PyObject *module)
+{
+    _Sbk_PageParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "PageParam",
+        "PageParam*",
+        &Sbk_PageParam_spec,
+        &Shiboken::callCppDestructor< ::PageParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_PageParam_Type);
+    InitSignatureStrings(pyType, PageParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_PageParam_Type), Sbk_PageParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_PAGEPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_PageParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_PageParam_TypeF(),
+        PageParam_PythonToCpp_PageParam_PTR,
+        is_PageParam_PythonToCpp_PageParam_PTR_Convertible,
+        PageParam_PTR_CppToPython_PageParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "PageParam");
+    Shiboken::Conversions::registerConverterName(converter, "PageParam*");
+    Shiboken::Conversions::registerConverterName(converter, "PageParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::PageParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::PageParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_PageParam_TypeF(), &Sbk_PageParam_typeDiscovery);
+
+
+    PageParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/pageparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/pageparam_wrapper.h
@@ -1,0 +1,42 @@
+#ifndef SBK_PAGEPARAMWRAPPER_H
+#define SBK_PAGEPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class PageParamWrapper : public PageParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { PageParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~PageParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_PAGEPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/param_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/param_wrapper.cpp
@@ -1,0 +1,1775 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "param_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void ParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void ParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+ParamWrapper::~ParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_ParamFunc__addAsDependencyOf(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "_addAsDependencyOf", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Param::_addAsDependencyOf(int,Param*,int)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+        overloadId = 0; // _addAsDependencyOf(int,Param*,int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc__addAsDependencyOf_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        if (!Shiboken::Object::isValid(pyArgs[1]))
+            return {};
+        ::Param *cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        int cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // _addAsDependencyOf(int,Param*,int)
+            static_cast<::ParamWrapper *>(cppSelf)->ParamWrapper::_addAsDependencyOf_protected(cppArg0, cppArg1, cppArg2);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ParamFunc__addAsDependencyOf_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Param._addAsDependencyOf");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_copy(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.copy(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.copy(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:copy", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Param::copy(Param*,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // copy(Param*,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // copy(Param*,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_copy_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.copy(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ParamFunc_copy_TypeError;
+                }
+            }
+        }
+        if (!Shiboken::Object::isValid(pyArgs[0]))
+            return {};
+        ::Param *cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = -1;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // copy(Param*,int)
+            bool cppResult = cppSelf->copy(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ParamFunc_copy_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Param.copy");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_curve(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.curve(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.curve(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:curve", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Param::curve(double,int)const
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // curve(double,int)const
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // curve(double,int)const
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_curve_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.curve(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ParamFunc_curve_TypeError;
+                }
+            }
+        }
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // curve(double,int)const
+            double cppResult = const_cast<const ::ParamWrapper *>(cppSelf)->curve(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ParamFunc_curve_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Param.curve");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_getAddNewLine(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getAddNewLine()
+            bool cppResult = cppSelf->getAddNewLine();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ParamFunc_getCanAnimate(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getCanAnimate()const
+            bool cppResult = const_cast<const ::ParamWrapper *>(cppSelf)->getCanAnimate();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ParamFunc_getEvaluateOnChange(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getEvaluateOnChange()const
+            bool cppResult = const_cast<const ::ParamWrapper *>(cppSelf)->getEvaluateOnChange();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ParamFunc_getHelp(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getHelp()const
+            QString cppResult = const_cast<const ::ParamWrapper *>(cppSelf)->getHelp();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ParamFunc_getIsAnimationEnabled(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getIsAnimationEnabled()const
+            bool cppResult = const_cast<const ::ParamWrapper *>(cppSelf)->getIsAnimationEnabled();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ParamFunc_getIsEnabled(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.getIsEnabled(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getIsEnabled", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Param::getIsEnabled(int)const
+    if (numArgs == 0) {
+        overloadId = 0; // getIsEnabled(int)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))) {
+        overloadId = 0; // getIsEnabled(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_getIsEnabled_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.getIsEnabled(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0]))))
+                        goto Sbk_ParamFunc_getIsEnabled_TypeError;
+                }
+            }
+        }
+        int cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getIsEnabled(int)const
+            bool cppResult = const_cast<const ::ParamWrapper *>(cppSelf)->getIsEnabled(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ParamFunc_getIsEnabled_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Param.getIsEnabled");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_getIsPersistent(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getIsPersistent()const
+            bool cppResult = const_cast<const ::ParamWrapper *>(cppSelf)->getIsPersistent();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ParamFunc_getIsVisible(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getIsVisible()const
+            bool cppResult = const_cast<const ::ParamWrapper *>(cppSelf)->getIsVisible();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ParamFunc_getLabel(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getLabel()const
+            QString cppResult = const_cast<const ::ParamWrapper *>(cppSelf)->getLabel();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ParamFunc_getNumDimensions(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getNumDimensions()const
+            int cppResult = const_cast<const ::ParamWrapper *>(cppSelf)->getNumDimensions();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ParamFunc_getParent(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getParent()const
+            Param * cppResult = const_cast<const ::ParamWrapper *>(cppSelf)->getParent();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ParamFunc_getScriptName(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getScriptName()const
+            QString cppResult = const_cast<const ::ParamWrapper *>(cppSelf)->getScriptName();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ParamFunc_getTypeName(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getTypeName()const
+            QString cppResult = const_cast<const ::ParamWrapper *>(cppSelf)->getTypeName();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_ParamFunc_random(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 4) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.random(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOOO:random", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Param::random(double,double)const
+    // 1: Param::random(double,double,double,uint)const
+    if (numArgs == 0) {
+        overloadId = 0; // random(double,double)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // random(double,double)const
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+            if (numArgs == 2) {
+                overloadId = 0; // random(double,double)const
+            } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+                if (numArgs == 3) {
+                    overloadId = 1; // random(double,double,double,uint)const
+                } else if ((pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<unsigned int>(), (pyArgs[3])))) {
+                    overloadId = 1; // random(double,double,double,uint)const
+                }
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_random_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // random(double min, double max) const
+        {
+            if (kwds) {
+                PyObject *keyName = nullptr;
+                PyObject *value = nullptr;
+                keyName = Py_BuildValue("s","min");
+                if (PyDict_Contains(kwds, keyName)) {
+                    value = PyDict_GetItem(kwds, keyName);
+                    if (value && pyArgs[0]) {
+                        PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.random(): got multiple values for keyword argument 'min'.");
+                        return {};
+                    }
+                    if (value) {
+                        pyArgs[0] = value;
+                        if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0]))))
+                            goto Sbk_ParamFunc_random_TypeError;
+                    }
+                }
+                keyName = Py_BuildValue("s","max");
+                if (PyDict_Contains(kwds, keyName)) {
+                    value = PyDict_GetItem(kwds, keyName);
+                    if (value && pyArgs[1]) {
+                        PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.random(): got multiple values for keyword argument 'max'.");
+                        return {};
+                    }
+                    if (value) {
+                        pyArgs[1] = value;
+                        if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1]))))
+                            goto Sbk_ParamFunc_random_TypeError;
+                    }
+                }
+            }
+            double cppArg0 = 0.;
+            if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1 = 1.;
+            if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+            if (!PyErr_Occurred()) {
+                // random(double,double)const
+                double cppResult = const_cast<const ::ParamWrapper *>(cppSelf)->random(cppArg0, cppArg1);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+            }
+            break;
+        }
+        case 1: // random(double min, double max, double time, unsigned int seed) const
+        {
+            if (kwds) {
+                PyObject *keyName = nullptr;
+                PyObject *value = nullptr;
+                keyName = Py_BuildValue("s","seed");
+                if (PyDict_Contains(kwds, keyName)) {
+                    value = PyDict_GetItem(kwds, keyName);
+                    if (value && pyArgs[3]) {
+                        PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.random(): got multiple values for keyword argument 'seed'.");
+                        return {};
+                    }
+                    if (value) {
+                        pyArgs[3] = value;
+                        if (!(pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<unsigned int>(), (pyArgs[3]))))
+                            goto Sbk_ParamFunc_random_TypeError;
+                    }
+                }
+            }
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            double cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            unsigned int cppArg3 = 0;
+            if (pythonToCpp[3]) pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // random(double,double,double,uint)const
+                double cppResult = const_cast<const ::ParamWrapper *>(cppSelf)->random(cppArg0, cppArg1, cppArg2, cppArg3);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ParamFunc_random_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Param.random");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_randomInt(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 4) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.randomInt(): too many arguments");
+        return {};
+    } else if (numArgs < 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.randomInt(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOOO:randomInt", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Param::randomInt(int,int)
+    // 1: Param::randomInt(int,int,double,uint)const
+    if (numArgs >= 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+        if (numArgs == 2) {
+            overloadId = 0; // randomInt(int,int)
+        } else if ((pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+            if (numArgs == 3) {
+                overloadId = 1; // randomInt(int,int,double,uint)const
+            } else if ((pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<unsigned int>(), (pyArgs[3])))) {
+                overloadId = 1; // randomInt(int,int,double,uint)const
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_randomInt_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // randomInt(int min, int max)
+        {
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            int cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+
+            if (!PyErr_Occurred()) {
+                // randomInt(int,int)
+                int cppResult = cppSelf->randomInt(cppArg0, cppArg1);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+            }
+            break;
+        }
+        case 1: // randomInt(int min, int max, double time, unsigned int seed) const
+        {
+            if (kwds) {
+                PyObject *keyName = nullptr;
+                PyObject *value = nullptr;
+                keyName = Py_BuildValue("s","seed");
+                if (PyDict_Contains(kwds, keyName)) {
+                    value = PyDict_GetItem(kwds, keyName);
+                    if (value && pyArgs[3]) {
+                        PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.randomInt(): got multiple values for keyword argument 'seed'.");
+                        return {};
+                    }
+                    if (value) {
+                        pyArgs[3] = value;
+                        if (!(pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<unsigned int>(), (pyArgs[3]))))
+                            goto Sbk_ParamFunc_randomInt_TypeError;
+                    }
+                }
+            }
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            int cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            double cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            unsigned int cppArg3 = 0;
+            if (pythonToCpp[3]) pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // randomInt(int,int,double,uint)const
+                int cppResult = const_cast<const ::ParamWrapper *>(cppSelf)->randomInt(cppArg0, cppArg1, cppArg2, cppArg3);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ParamFunc_randomInt_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Param.randomInt");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_setAddNewLine(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Param::setAddNewLine(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setAddNewLine(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_setAddNewLine_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setAddNewLine(bool)
+            cppSelf->setAddNewLine(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ParamFunc_setAddNewLine_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Param.setAddNewLine");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_setAnimationEnabled(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Param::setAnimationEnabled(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setAnimationEnabled(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_setAnimationEnabled_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setAnimationEnabled(bool)
+            cppSelf->setAnimationEnabled(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ParamFunc_setAnimationEnabled_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Param.setAnimationEnabled");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_setAsAlias(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Param::setAsAlias(Param*)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), (pyArg)))) {
+        overloadId = 0; // setAsAlias(Param*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_setAsAlias_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::Param *cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setAsAlias(Param*)
+            bool cppResult = cppSelf->setAsAlias(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ParamFunc_setAsAlias_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Param.setAsAlias");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_setEnabled(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.setEnabled(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.setEnabled(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setEnabled", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Param::setEnabled(bool,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setEnabled(bool,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setEnabled(bool,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_setEnabled_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","dimension");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.setEnabled(): got multiple values for keyword argument 'dimension'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_ParamFunc_setEnabled_TypeError;
+                }
+            }
+        }
+        bool cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setEnabled(bool,int)
+            cppSelf->setEnabled(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ParamFunc_setEnabled_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Param.setEnabled");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_setEnabledByDefault(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.setEnabledByDefault(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:setEnabledByDefault", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Param::setEnabledByDefault(bool)
+    if (numArgs == 0) {
+        overloadId = 0; // setEnabledByDefault(bool)
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[0])))) {
+        overloadId = 0; // setEnabledByDefault(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_setEnabledByDefault_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","enabled");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.Param.setEnabledByDefault(): got multiple values for keyword argument 'enabled'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[0]))))
+                        goto Sbk_ParamFunc_setEnabledByDefault_TypeError;
+                }
+            }
+        }
+        bool cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setEnabledByDefault(bool)
+            cppSelf->setEnabledByDefault(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ParamFunc_setEnabledByDefault_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Param.setEnabledByDefault");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_setEvaluateOnChange(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Param::setEvaluateOnChange(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setEvaluateOnChange(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_setEvaluateOnChange_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setEvaluateOnChange(bool)
+            cppSelf->setEvaluateOnChange(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ParamFunc_setEvaluateOnChange_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Param.setEvaluateOnChange");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_setHelp(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Param::setHelp(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setHelp(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_setHelp_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setHelp(QString)
+            cppSelf->setHelp(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ParamFunc_setHelp_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Param.setHelp");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_setIconFilePath(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Param::setIconFilePath(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setIconFilePath(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_setIconFilePath_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setIconFilePath(QString)
+            cppSelf->setIconFilePath(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ParamFunc_setIconFilePath_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Param.setIconFilePath");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_setPersistent(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Param::setPersistent(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setPersistent(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_setPersistent_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setPersistent(bool)
+            cppSelf->setPersistent(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ParamFunc_setPersistent_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Param.setPersistent");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_setVisible(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Param::setVisible(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setVisible(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_setVisible_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setVisible(bool)
+            cppSelf->setVisible(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ParamFunc_setVisible_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Param.setVisible");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_setVisibleByDefault(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Param::setVisibleByDefault(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setVisibleByDefault(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_setVisibleByDefault_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setVisibleByDefault(bool)
+            cppSelf->setVisibleByDefault(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ParamFunc_setVisibleByDefault_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Param.setVisibleByDefault");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_slaveTo(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "slaveTo", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Param::slaveTo(Param*,int,int)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+        overloadId = 0; // slaveTo(Param*,int,int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_slaveTo_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArgs[0]))
+            return {};
+        ::Param *cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        int cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // slaveTo(Param*,int,int)
+            bool cppResult = cppSelf->slaveTo(cppArg0, cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ParamFunc_slaveTo_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Param.slaveTo");
+        return {};
+}
+
+static PyObject *Sbk_ParamFunc_unslave(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParamWrapper *>(reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Param::unslave(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // unslave(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParamFunc_unslave_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // unslave(int)
+            cppSelf->unslave(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ParamFunc_unslave_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Param.unslave");
+        return {};
+}
+
+
+static const char *Sbk_Param_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_Param_methods[] = {
+    {"_addAsDependencyOf", reinterpret_cast<PyCFunction>(Sbk_ParamFunc__addAsDependencyOf), METH_VARARGS},
+    {"copy", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_copy), METH_VARARGS|METH_KEYWORDS},
+    {"curve", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_curve), METH_VARARGS|METH_KEYWORDS},
+    {"getAddNewLine", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_getAddNewLine), METH_NOARGS},
+    {"getCanAnimate", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_getCanAnimate), METH_NOARGS},
+    {"getEvaluateOnChange", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_getEvaluateOnChange), METH_NOARGS},
+    {"getHelp", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_getHelp), METH_NOARGS},
+    {"getIsAnimationEnabled", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_getIsAnimationEnabled), METH_NOARGS},
+    {"getIsEnabled", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_getIsEnabled), METH_VARARGS|METH_KEYWORDS},
+    {"getIsPersistent", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_getIsPersistent), METH_NOARGS},
+    {"getIsVisible", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_getIsVisible), METH_NOARGS},
+    {"getLabel", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_getLabel), METH_NOARGS},
+    {"getNumDimensions", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_getNumDimensions), METH_NOARGS},
+    {"getParent", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_getParent), METH_NOARGS},
+    {"getScriptName", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_getScriptName), METH_NOARGS},
+    {"getTypeName", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_getTypeName), METH_NOARGS},
+    {"random", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_random), METH_VARARGS|METH_KEYWORDS},
+    {"randomInt", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_randomInt), METH_VARARGS|METH_KEYWORDS},
+    {"setAddNewLine", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_setAddNewLine), METH_O},
+    {"setAnimationEnabled", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_setAnimationEnabled), METH_O},
+    {"setAsAlias", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_setAsAlias), METH_O},
+    {"setEnabled", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_setEnabled), METH_VARARGS|METH_KEYWORDS},
+    {"setEnabledByDefault", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_setEnabledByDefault), METH_VARARGS|METH_KEYWORDS},
+    {"setEvaluateOnChange", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_setEvaluateOnChange), METH_O},
+    {"setHelp", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_setHelp), METH_O},
+    {"setIconFilePath", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_setIconFilePath), METH_O},
+    {"setPersistent", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_setPersistent), METH_O},
+    {"setVisible", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_setVisible), METH_O},
+    {"setVisibleByDefault", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_setVisibleByDefault), METH_O},
+    {"slaveTo", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_slaveTo), METH_VARARGS},
+    {"unslave", reinterpret_cast<PyCFunction>(Sbk_ParamFunc_unslave), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_Param_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::Param *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<ParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_Param_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_Param_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_Param_Type = nullptr;
+static SbkObjectType *Sbk_Param_TypeF(void)
+{
+    return _Sbk_Param_Type;
+}
+
+static PyType_Slot Sbk_Param_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_Param_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_Param_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_Param_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_Param_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_Param_spec = {
+    "1:NatronEngine.Param",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_Param_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void Param_PythonToCpp_Param_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_Param_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_Param_PythonToCpp_Param_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_Param_TypeF())))
+        return Param_PythonToCpp_Param_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *Param_PTR_CppToPython_Param(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::Param *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_Param_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *Param_SignatureStrings[] = {
+    "NatronEngine.Param._addAsDependencyOf(self,fromExprDimension:int,param:NatronEngine.Param,thisDimension:int)",
+    "NatronEngine.Param.copy(self,other:NatronEngine.Param,dimension:int=-1)->bool",
+    "NatronEngine.Param.curve(self,time:double,dimension:int=0)->double",
+    "NatronEngine.Param.getAddNewLine(self)->bool",
+    "NatronEngine.Param.getCanAnimate(self)->bool",
+    "NatronEngine.Param.getEvaluateOnChange(self)->bool",
+    "NatronEngine.Param.getHelp(self)->QString",
+    "NatronEngine.Param.getIsAnimationEnabled(self)->bool",
+    "NatronEngine.Param.getIsEnabled(self,dimension:int=0)->bool",
+    "NatronEngine.Param.getIsPersistent(self)->bool",
+    "NatronEngine.Param.getIsVisible(self)->bool",
+    "NatronEngine.Param.getLabel(self)->QString",
+    "NatronEngine.Param.getNumDimensions(self)->int",
+    "NatronEngine.Param.getParent(self)->NatronEngine.Param",
+    "NatronEngine.Param.getScriptName(self)->QString",
+    "NatronEngine.Param.getTypeName(self)->QString",
+    "1:NatronEngine.Param.random(self,min:double=0.,max:double=1.)->double",
+    "0:NatronEngine.Param.random(self,min:double,max:double,time:double,seed:unsigned int=0)->double",
+    "1:NatronEngine.Param.randomInt(self,min:int,max:int)->int",
+    "0:NatronEngine.Param.randomInt(self,min:int,max:int,time:double,seed:unsigned int=0)->int",
+    "NatronEngine.Param.setAddNewLine(self,a:bool)",
+    "NatronEngine.Param.setAnimationEnabled(self,e:bool)",
+    "NatronEngine.Param.setAsAlias(self,other:NatronEngine.Param)->bool",
+    "NatronEngine.Param.setEnabled(self,enabled:bool,dimension:int=0)",
+    "NatronEngine.Param.setEnabledByDefault(self,enabled:bool=0)",
+    "NatronEngine.Param.setEvaluateOnChange(self,eval:bool)",
+    "NatronEngine.Param.setHelp(self,help:QString)",
+    "NatronEngine.Param.setIconFilePath(self,icon:QString)",
+    "NatronEngine.Param.setPersistent(self,persistent:bool)",
+    "NatronEngine.Param.setVisible(self,visible:bool)",
+    "NatronEngine.Param.setVisibleByDefault(self,visible:bool)",
+    "NatronEngine.Param.slaveTo(self,other:NatronEngine.Param,thisDimension:int,otherDimension:int)->bool",
+    "NatronEngine.Param.unslave(self,dimension:int)",
+    nullptr}; // Sentinel
+
+void init_Param(PyObject *module)
+{
+    _Sbk_Param_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "Param",
+        "Param*",
+        &Sbk_Param_spec,
+        &Shiboken::callCppDestructor< ::Param >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_Param_Type);
+    InitSignatureStrings(pyType, Param_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_Param_Type), Sbk_Param_PropertyStrings);
+    SbkNatronEngineTypes[SBK_PARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_Param_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_Param_TypeF(),
+        Param_PythonToCpp_Param_PTR,
+        is_Param_PythonToCpp_Param_PTR_Convertible,
+        Param_PTR_CppToPython_Param);
+
+    Shiboken::Conversions::registerConverterName(converter, "Param");
+    Shiboken::Conversions::registerConverterName(converter, "Param*");
+    Shiboken::Conversions::registerConverterName(converter, "Param&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Param).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::ParamWrapper).name());
+
+
+
+    ParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/param_wrapper.h
+++ b/Engine/Qt5/NatronEngine/param_wrapper.h
@@ -1,0 +1,23 @@
+#ifndef SBK_PARAMWRAPPER_H
+#define SBK_PARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#endif // SBK_PARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/parametricparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/parametricparam_wrapper.cpp
@@ -1,0 +1,932 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "parametricparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void ParametricParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void ParametricParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+ParametricParamWrapper::~ParametricParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_ParametricParamFunc_addControlPoint(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParametricParamWrapper *>(reinterpret_cast< ::ParametricParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAMETRICPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 6) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ParametricParam.addControlPoint(): too many arguments");
+        return {};
+    } else if (numArgs < 3) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.ParametricParam.addControlPoint(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OOOOOO:addControlPoint", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3]), &(pyArgs[4]), &(pyArgs[5])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ParametricParam::addControlPoint(int,double,double,NATRON_ENUM::KeyframeTypeEnum)
+    // 1: ParametricParam::addControlPoint(int,double,double,double,double,NATRON_ENUM::KeyframeTypeEnum)
+    if (numArgs >= 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+        if (numArgs == 3) {
+            overloadId = 0; // addControlPoint(int,double,double,NATRON_ENUM::KeyframeTypeEnum)
+        } else if ((pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX])->converter, (pyArgs[3])))) {
+            overloadId = 0; // addControlPoint(int,double,double,NATRON_ENUM::KeyframeTypeEnum)
+        } else if (numArgs >= 5
+            && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))
+            && (pythonToCpp[4] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[4])))) {
+            if (numArgs == 5) {
+                overloadId = 1; // addControlPoint(int,double,double,double,double,NATRON_ENUM::KeyframeTypeEnum)
+            } else if ((pythonToCpp[5] = Shiboken::Conversions::isPythonToCppConvertible(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX])->converter, (pyArgs[5])))) {
+                overloadId = 1; // addControlPoint(int,double,double,double,double,NATRON_ENUM::KeyframeTypeEnum)
+            }
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParametricParamFunc_addControlPoint_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // addControlPoint(int dimension, double key, double value, NATRON_ENUM::KeyframeTypeEnum interpolation)
+        {
+            if (kwds) {
+                PyObject *keyName = nullptr;
+                PyObject *value = nullptr;
+                keyName = Py_BuildValue("s","interpolation");
+                if (PyDict_Contains(kwds, keyName)) {
+                    value = PyDict_GetItem(kwds, keyName);
+                    if (value && pyArgs[3]) {
+                        PyErr_SetString(PyExc_TypeError, "NatronEngine.ParametricParam.addControlPoint(): got multiple values for keyword argument 'interpolation'.");
+                        return {};
+                    }
+                    if (value) {
+                        pyArgs[3] = value;
+                        if (!(pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX])->converter, (pyArgs[3]))))
+                            goto Sbk_ParametricParamFunc_addControlPoint_TypeError;
+                    }
+                }
+            }
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            double cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            ::NATRON_ENUM::KeyframeTypeEnum cppArg3 = NATRON_ENUM::eKeyframeTypeSmooth;
+            if (pythonToCpp[3]) pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // addControlPoint(int,double,double,NATRON_ENUM::KeyframeTypeEnum)
+                NATRON_ENUM::StatusEnum cppResult = NATRON_ENUM::StatusEnum(cppSelf->addControlPoint(cppArg0, cppArg1, cppArg2, cppArg3));
+                pyResult = Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX])->converter, &cppResult);
+            }
+            break;
+        }
+        case 1: // addControlPoint(int dimension, double key, double value, double leftDerivative, double rightDerivative, NATRON_ENUM::KeyframeTypeEnum interpolation)
+        {
+            if (kwds) {
+                PyObject *keyName = nullptr;
+                PyObject *value = nullptr;
+                keyName = Py_BuildValue("s","interpolation");
+                if (PyDict_Contains(kwds, keyName)) {
+                    value = PyDict_GetItem(kwds, keyName);
+                    if (value && pyArgs[5]) {
+                        PyErr_SetString(PyExc_TypeError, "NatronEngine.ParametricParam.addControlPoint(): got multiple values for keyword argument 'interpolation'.");
+                        return {};
+                    }
+                    if (value) {
+                        pyArgs[5] = value;
+                        if (!(pythonToCpp[5] = Shiboken::Conversions::isPythonToCppConvertible(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX])->converter, (pyArgs[5]))))
+                            goto Sbk_ParametricParamFunc_addControlPoint_TypeError;
+                    }
+                }
+            }
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            double cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            double cppArg3;
+            pythonToCpp[3](pyArgs[3], &cppArg3);
+            double cppArg4;
+            pythonToCpp[4](pyArgs[4], &cppArg4);
+            ::NATRON_ENUM::KeyframeTypeEnum cppArg5 = NATRON_ENUM::eKeyframeTypeSmooth;
+            if (pythonToCpp[5]) pythonToCpp[5](pyArgs[5], &cppArg5);
+
+            if (!PyErr_Occurred()) {
+                // addControlPoint(int,double,double,double,double,NATRON_ENUM::KeyframeTypeEnum)
+                NATRON_ENUM::StatusEnum cppResult = NATRON_ENUM::StatusEnum(cppSelf->addControlPoint(cppArg0, cppArg1, cppArg2, cppArg3, cppArg4, cppArg5));
+                pyResult = Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX])->converter, &cppResult);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ParametricParamFunc_addControlPoint_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ParametricParam.addControlPoint");
+        return {};
+}
+
+static PyObject *Sbk_ParametricParamFunc_deleteAllControlPoints(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParametricParamWrapper *>(reinterpret_cast< ::ParametricParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAMETRICPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: ParametricParam::deleteAllControlPoints(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // deleteAllControlPoints(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParametricParamFunc_deleteAllControlPoints_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // deleteAllControlPoints(int)
+            NATRON_ENUM::StatusEnum cppResult = NATRON_ENUM::StatusEnum(cppSelf->deleteAllControlPoints(cppArg0));
+            pyResult = Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX])->converter, &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ParametricParamFunc_deleteAllControlPoints_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ParametricParam.deleteAllControlPoints");
+        return {};
+}
+
+static PyObject *Sbk_ParametricParamFunc_deleteControlPoint(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParametricParamWrapper *>(reinterpret_cast< ::ParametricParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAMETRICPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "deleteControlPoint", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ParametricParam::deleteControlPoint(int,int)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+        overloadId = 0; // deleteControlPoint(int,int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParametricParamFunc_deleteControlPoint_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // deleteControlPoint(int,int)
+            NATRON_ENUM::StatusEnum cppResult = NATRON_ENUM::StatusEnum(cppSelf->deleteControlPoint(cppArg0, cppArg1));
+            pyResult = Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX])->converter, &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ParametricParamFunc_deleteControlPoint_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ParametricParam.deleteControlPoint");
+        return {};
+}
+
+static PyObject *Sbk_ParametricParamFunc_getCurveColor(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParametricParamWrapper *>(reinterpret_cast< ::ParametricParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAMETRICPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: ParametricParam::getCurveColor(int,ColorTuple&)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // getCurveColor(int,ColorTuple&)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParametricParamFunc_getCurveColor_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getCurveColor(int,ColorTuple&)const
+            // Begin code injection
+            ColorTuple t;
+            cppSelf->getCurveColor(cppArg0,t);
+            pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_COLORTUPLE_IDX]), &t);
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ParametricParamFunc_getCurveColor_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ParametricParam.getCurveColor");
+        return {};
+}
+
+static PyObject *Sbk_ParametricParamFunc_getNControlPoints(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParametricParamWrapper *>(reinterpret_cast< ::ParametricParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAMETRICPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: ParametricParam::getNControlPoints(int)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // getNControlPoints(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParametricParamFunc_getNControlPoints_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getNControlPoints(int)const
+            int cppResult = const_cast<const ::ParametricParamWrapper *>(cppSelf)->getNControlPoints(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ParametricParamFunc_getNControlPoints_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.ParametricParam.getNControlPoints");
+        return {};
+}
+
+static PyObject *Sbk_ParametricParamFunc_getNthControlPoint(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParametricParamWrapper *>(reinterpret_cast< ::ParametricParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAMETRICPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "getNthControlPoint", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ParametricParam::getNthControlPoint(int,int,double*,double*,double*,double*)const
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+        overloadId = 0; // getNthControlPoint(int,int,double*,double*,double*,double*)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParametricParamFunc_getNthControlPoint_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // getNthControlPoint(int,int,double*,double*,double*,double*)const
+            // Begin code injection
+            double key,value,left,right;
+            NATRON_ENUM::StatusEnum cppResult = cppSelf->getNthControlPoint(cppArg0, cppArg1,&key,&value, &left, &right);
+            pyResult = PyTuple_New(5);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX])->converter, &cppResult));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &key));
+            PyTuple_SET_ITEM(pyResult, 2, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &value));
+            PyTuple_SET_ITEM(pyResult, 3, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &left));
+            PyTuple_SET_ITEM(pyResult, 4, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &right));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ParametricParamFunc_getNthControlPoint_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ParametricParam.getNthControlPoint");
+        return {};
+}
+
+static PyObject *Sbk_ParametricParamFunc_getValue(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParametricParamWrapper *>(reinterpret_cast< ::ParametricParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAMETRICPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "getValue", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ParametricParam::getValue(int,double)const
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        overloadId = 0; // getValue(int,double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParametricParamFunc_getValue_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // getValue(int,double)const
+            double cppResult = const_cast<const ::ParametricParamWrapper *>(cppSelf)->getValue(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ParametricParamFunc_getValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ParametricParam.getValue");
+        return {};
+}
+
+static PyObject *Sbk_ParametricParamFunc_setCurveColor(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParametricParamWrapper *>(reinterpret_cast< ::ParametricParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAMETRICPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setCurveColor", 4, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ParametricParam::setCurveColor(int,double,double,double)
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+        overloadId = 0; // setCurveColor(int,double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParametricParamFunc_setCurveColor_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3;
+        pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // setCurveColor(int,double,double,double)
+            cppSelf->setCurveColor(cppArg0, cppArg1, cppArg2, cppArg3);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_ParametricParamFunc_setCurveColor_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ParametricParam.setCurveColor");
+        return {};
+}
+
+static PyObject *Sbk_ParametricParamFunc_setDefaultCurvesFromCurrentCurves(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParametricParamWrapper *>(reinterpret_cast< ::ParametricParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAMETRICPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // setDefaultCurvesFromCurrentCurves()
+            cppSelf->setDefaultCurvesFromCurrentCurves();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_ParametricParamFunc_setNthControlPoint(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParametricParamWrapper *>(reinterpret_cast< ::ParametricParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAMETRICPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setNthControlPoint", 6, 6, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3]), &(pyArgs[4]), &(pyArgs[5])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ParametricParam::setNthControlPoint(int,int,double,double,double,double)
+    if (numArgs == 6
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))
+        && (pythonToCpp[4] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[4])))
+        && (pythonToCpp[5] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[5])))) {
+        overloadId = 0; // setNthControlPoint(int,int,double,double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParametricParamFunc_setNthControlPoint_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3;
+        pythonToCpp[3](pyArgs[3], &cppArg3);
+        double cppArg4;
+        pythonToCpp[4](pyArgs[4], &cppArg4);
+        double cppArg5;
+        pythonToCpp[5](pyArgs[5], &cppArg5);
+
+        if (!PyErr_Occurred()) {
+            // setNthControlPoint(int,int,double,double,double,double)
+            NATRON_ENUM::StatusEnum cppResult = NATRON_ENUM::StatusEnum(cppSelf->setNthControlPoint(cppArg0, cppArg1, cppArg2, cppArg3, cppArg4, cppArg5));
+            pyResult = Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX])->converter, &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ParametricParamFunc_setNthControlPoint_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ParametricParam.setNthControlPoint");
+        return {};
+}
+
+static PyObject *Sbk_ParametricParamFunc_setNthControlPointInterpolation(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<ParametricParamWrapper *>(reinterpret_cast< ::ParametricParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAMETRICPARAM_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setNthControlPointInterpolation", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: ParametricParam::setNthControlPointInterpolation(int,int,NATRON_ENUM::KeyframeTypeEnum)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_KEYFRAMETYPEENUM_IDX])->converter, (pyArgs[2])))) {
+        overloadId = 0; // setNthControlPointInterpolation(int,int,NATRON_ENUM::KeyframeTypeEnum)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_ParametricParamFunc_setNthControlPointInterpolation_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        ::NATRON_ENUM::KeyframeTypeEnum cppArg2{NATRON_ENUM::eKeyframeTypeConstant};
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // setNthControlPointInterpolation(int,int,NATRON_ENUM::KeyframeTypeEnum)
+            NATRON_ENUM::StatusEnum cppResult = NATRON_ENUM::StatusEnum(cppSelf->setNthControlPointInterpolation(cppArg0, cppArg1, cppArg2));
+            pyResult = Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_STATUSENUM_IDX])->converter, &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_ParametricParamFunc_setNthControlPointInterpolation_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.ParametricParam.setNthControlPointInterpolation");
+        return {};
+}
+
+
+static const char *Sbk_ParametricParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_ParametricParam_methods[] = {
+    {"addControlPoint", reinterpret_cast<PyCFunction>(Sbk_ParametricParamFunc_addControlPoint), METH_VARARGS|METH_KEYWORDS},
+    {"deleteAllControlPoints", reinterpret_cast<PyCFunction>(Sbk_ParametricParamFunc_deleteAllControlPoints), METH_O},
+    {"deleteControlPoint", reinterpret_cast<PyCFunction>(Sbk_ParametricParamFunc_deleteControlPoint), METH_VARARGS},
+    {"getCurveColor", reinterpret_cast<PyCFunction>(Sbk_ParametricParamFunc_getCurveColor), METH_O},
+    {"getNControlPoints", reinterpret_cast<PyCFunction>(Sbk_ParametricParamFunc_getNControlPoints), METH_O},
+    {"getNthControlPoint", reinterpret_cast<PyCFunction>(Sbk_ParametricParamFunc_getNthControlPoint), METH_VARARGS},
+    {"getValue", reinterpret_cast<PyCFunction>(Sbk_ParametricParamFunc_getValue), METH_VARARGS},
+    {"setCurveColor", reinterpret_cast<PyCFunction>(Sbk_ParametricParamFunc_setCurveColor), METH_VARARGS},
+    {"setDefaultCurvesFromCurrentCurves", reinterpret_cast<PyCFunction>(Sbk_ParametricParamFunc_setDefaultCurvesFromCurrentCurves), METH_NOARGS},
+    {"setNthControlPoint", reinterpret_cast<PyCFunction>(Sbk_ParametricParamFunc_setNthControlPoint), METH_VARARGS},
+    {"setNthControlPointInterpolation", reinterpret_cast<PyCFunction>(Sbk_ParametricParamFunc_setNthControlPointInterpolation), METH_VARARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_ParametricParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::ParametricParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PARAMETRICPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<ParametricParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_ParametricParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_ParametricParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_ParametricParam_Type = nullptr;
+static SbkObjectType *Sbk_ParametricParam_TypeF(void)
+{
+    return _Sbk_ParametricParam_Type;
+}
+
+static PyType_Slot Sbk_ParametricParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_ParametricParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_ParametricParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_ParametricParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_ParametricParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_ParametricParam_spec = {
+    "1:NatronEngine.ParametricParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_ParametricParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_ParametricParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::ParametricParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void ParametricParam_PythonToCpp_ParametricParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_ParametricParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_ParametricParam_PythonToCpp_ParametricParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_ParametricParam_TypeF())))
+        return ParametricParam_PythonToCpp_ParametricParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *ParametricParam_PTR_CppToPython_ParametricParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::ParametricParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_ParametricParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *ParametricParam_SignatureStrings[] = {
+    "1:NatronEngine.ParametricParam.addControlPoint(self,dimension:int,key:double,value:double,interpolation:NatronEngine.NATRON_ENUM.KeyframeTypeEnum=NATRON_ENUM.eKeyframeTypeSmooth)->NatronEngine.NATRON_ENUM.StatusEnum",
+    "0:NatronEngine.ParametricParam.addControlPoint(self,dimension:int,key:double,value:double,leftDerivative:double,rightDerivative:double,interpolation:NatronEngine.NATRON_ENUM.KeyframeTypeEnum=NATRON_ENUM.eKeyframeTypeSmooth)->NatronEngine.NATRON_ENUM.StatusEnum",
+    "NatronEngine.ParametricParam.deleteAllControlPoints(self,dimension:int)->NatronEngine.NATRON_ENUM.StatusEnum",
+    "NatronEngine.ParametricParam.deleteControlPoint(self,dimension:int,nthCtl:int)->NatronEngine.NATRON_ENUM.StatusEnum",
+    "NatronEngine.ParametricParam.getCurveColor(self,dimension:int,ret:NatronEngine.ColorTuple)",
+    "NatronEngine.ParametricParam.getNControlPoints(self,dimension:int)->int",
+    "NatronEngine.ParametricParam.getNthControlPoint(self,dimension:int,nthCtl:int,key:double*,value:double*,leftDerivative:double*,rightDerivative:double*)->NatronEngine.NATRON_ENUM.StatusEnum",
+    "NatronEngine.ParametricParam.getValue(self,dimension:int,parametricPosition:double)->double",
+    "NatronEngine.ParametricParam.setCurveColor(self,dimension:int,r:double,g:double,b:double)",
+    "NatronEngine.ParametricParam.setDefaultCurvesFromCurrentCurves(self)",
+    "NatronEngine.ParametricParam.setNthControlPoint(self,dimension:int,nthCtl:int,key:double,value:double,leftDerivative:double,rightDerivative:double)->NatronEngine.NATRON_ENUM.StatusEnum",
+    "NatronEngine.ParametricParam.setNthControlPointInterpolation(self,dimension:int,nThCtl:int,interpolation:NatronEngine.NATRON_ENUM.KeyframeTypeEnum)->NatronEngine.NATRON_ENUM.StatusEnum",
+    nullptr}; // Sentinel
+
+void init_ParametricParam(PyObject *module)
+{
+    _Sbk_ParametricParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "ParametricParam",
+        "ParametricParam*",
+        &Sbk_ParametricParam_spec,
+        &Shiboken::callCppDestructor< ::ParametricParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_ParametricParam_Type);
+    InitSignatureStrings(pyType, ParametricParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_ParametricParam_Type), Sbk_ParametricParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_PARAMETRICPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_ParametricParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_ParametricParam_TypeF(),
+        ParametricParam_PythonToCpp_ParametricParam_PTR,
+        is_ParametricParam_PythonToCpp_ParametricParam_PTR_Convertible,
+        ParametricParam_PTR_CppToPython_ParametricParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "ParametricParam");
+    Shiboken::Conversions::registerConverterName(converter, "ParametricParam*");
+    Shiboken::Conversions::registerConverterName(converter, "ParametricParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::ParametricParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::ParametricParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_ParametricParam_TypeF(), &Sbk_ParametricParam_typeDiscovery);
+
+
+    ParametricParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/parametricparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/parametricparam_wrapper.h
@@ -1,0 +1,42 @@
+#ifndef SBK_PARAMETRICPARAMWRAPPER_H
+#define SBK_PARAMETRICPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParametricParamWrapper : public ParametricParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { ParametricParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParametricParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_PARAMETRICPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/pathparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/pathparam_wrapper.cpp
@@ -1,0 +1,404 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "pathparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void PathParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void PathParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+PathParamWrapper::~PathParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_PathParamFunc_getTable(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PathParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PATHPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getTable(std::list<std::vector<std::string> >*)const
+            // Begin code injection
+            std::list<std::vector<std::string> > table;
+            cppSelf->getTable(&table);
+
+            std::size_t outListSize = table.size();
+            PyObject* outList = PyList_New((int) outListSize);
+
+            std::size_t i = 0;
+            for (std::list<std::vector<std::string> >::iterator it = table.begin(); it != table.end(); ++it, ++i) {
+            std::size_t subListSize = it->size();
+            PyObject* subList = PyList_New((int) subListSize);
+            for (std::size_t j = 0; j < subListSize; ++j) {
+            std::string cppItem = (*it)[j];
+            PyList_SET_ITEM(subList, j, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<std::string>(), &cppItem));
+            }
+            PyList_SET_ITEM(outList, i, subList);
+            }
+
+            return outList;
+
+            // End of code injection
+
+            pyResult = Py_None;
+            Py_INCREF(Py_None);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PathParamFunc_setAsMultiPathTable(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PathParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PATHPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // setAsMultiPathTable()
+            cppSelf->setAsMultiPathTable();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_PathParamFunc_setTable(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PathParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PATHPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PathParam::setTable(std::list<std::vector<std::string> >)
+    if (Shiboken::String::checkIterable(pyArg)) {
+        overloadId = 0; // setTable(std::list<std::vector<std::string> >)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PathParamFunc_setTable_TypeError;
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // setTable(std::list<std::vector<std::string> >)
+            // Begin code injection
+
+
+            if (!PyList_Check(pyArg)) {
+                PyErr_SetString(PyExc_TypeError, "table must be a list of list objects.");
+                return 0;
+            }
+
+            std::list<std::vector<std::string> > table;
+
+            int size = (int)PyList_GET_SIZE(pyArg);
+            for (int i = 0; i < size; ++i) {
+
+
+                PyObject* subList = PyList_GET_ITEM(pyArg,i);
+                if (!subList || !PyList_Check(subList)) {
+                    PyErr_SetString(PyExc_TypeError, "table must be a list of list objects.");
+                    return 0;
+                }
+                int subSize = (int)PyList_GET_SIZE(subList);
+                std::vector<std::string> rowVec(subSize);
+
+                for (int j = 0; j < subSize; ++j) {
+                    PyObject* pyString = PyList_GET_ITEM(subList,j);
+#if PY_MAJOR_VERSION < 3
+                    if ( PyString_Check(pyString) ) {
+                        char* buf = PyString_AsString(pyString);
+                        if (buf) {
+                            std::string ret;
+                            ret.append(buf);
+                            rowVec[j] = ret;
+                            }
+                    } else if (PyUnicode_Check(pyString) ) {
+#else
+                    if (PyUnicode_Check(pyString) ) {
+#endif
+                        PyObject* utf8pyobj = PyUnicode_AsUTF8String(pyString); // newRef
+                        if (utf8pyobj) {
+                            char* cstr = PyBytes_AS_STRING(utf8pyobj); // Borrowed pointer
+                            std::string ret;
+                            ret.append(cstr);
+                            Py_DECREF(utf8pyobj);
+                            rowVec[j] = ret;
+                        }
+                    }
+                }
+                table.push_back(rowVec);
+            }
+
+            cppSelf->setTable(table);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PathParamFunc_setTable_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.PathParam.setTable");
+        return {};
+}
+
+
+static const char *Sbk_PathParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_PathParam_methods[] = {
+    {"getTable", reinterpret_cast<PyCFunction>(Sbk_PathParamFunc_getTable), METH_NOARGS},
+    {"setAsMultiPathTable", reinterpret_cast<PyCFunction>(Sbk_PathParamFunc_setAsMultiPathTable), METH_NOARGS},
+    {"setTable", reinterpret_cast<PyCFunction>(Sbk_PathParamFunc_setTable), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_PathParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::PathParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PATHPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<PathParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_PathParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_PathParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_PathParam_Type = nullptr;
+static SbkObjectType *Sbk_PathParam_TypeF(void)
+{
+    return _Sbk_PathParam_Type;
+}
+
+static PyType_Slot Sbk_PathParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_PathParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_PathParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_PathParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_PathParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_PathParam_spec = {
+    "1:NatronEngine.PathParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_PathParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_PathParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::PathParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void PathParam_PythonToCpp_PathParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_PathParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_PathParam_PythonToCpp_PathParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_PathParam_TypeF())))
+        return PathParam_PythonToCpp_PathParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *PathParam_PTR_CppToPython_PathParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::PathParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_PathParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *PathParam_SignatureStrings[] = {
+    "NatronEngine.PathParam.getTable(self,table:std.list[std.vector[std.string]])",
+    "NatronEngine.PathParam.setAsMultiPathTable(self)",
+    "NatronEngine.PathParam.setTable(self,table:std.list[std.vector[std.string]])",
+    nullptr}; // Sentinel
+
+void init_PathParam(PyObject *module)
+{
+    _Sbk_PathParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "PathParam",
+        "PathParam*",
+        &Sbk_PathParam_spec,
+        &Shiboken::callCppDestructor< ::PathParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_PathParam_Type);
+    InitSignatureStrings(pyType, PathParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_PathParam_Type), Sbk_PathParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_PATHPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_PathParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_PathParam_TypeF(),
+        PathParam_PythonToCpp_PathParam_PTR,
+        is_PathParam_PythonToCpp_PathParam_PTR_Convertible,
+        PathParam_PTR_CppToPython_PathParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "PathParam");
+    Shiboken::Conversions::registerConverterName(converter, "PathParam*");
+    Shiboken::Conversions::registerConverterName(converter, "PathParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::PathParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::PathParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_PathParam_TypeF(), &Sbk_PathParam_typeDiscovery);
+
+
+    PathParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/pathparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/pathparam_wrapper.h
@@ -1,0 +1,80 @@
+#ifndef SBK_PATHPARAMWRAPPER_H
+#define SBK_PATHPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <list>
+#include <vector>
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class PathParamWrapper : public PathParam
+{
+public:
+    ~PathParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_STRINGPARAMBASEWRAPPER_H
+#  define SBK_STRINGPARAMBASEWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class StringParamBaseWrapper : public StringParamBase
+{
+public:
+    ~StringParamBaseWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_STRINGPARAMBASEWRAPPER_H
+
+#  ifndef SBK_ANIMATEDPARAMWRAPPER_H
+#  define SBK_ANIMATEDPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AnimatedParamWrapper : public AnimatedParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { AnimatedParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~AnimatedParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_ANIMATEDPARAMWRAPPER_H
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_PATHPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/pycoreapplication_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/pycoreapplication_wrapper.cpp
@@ -1,0 +1,1010 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "pycoreapplication_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void PyCoreApplicationWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void PyCoreApplicationWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+PyCoreApplicationWrapper::PyCoreApplicationWrapper() : PyCoreApplication()
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+PyCoreApplicationWrapper::~PyCoreApplicationWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_PyCoreApplication_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::PyCoreApplication >()))
+        return -1;
+
+    ::PyCoreApplicationWrapper *cptr{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // PyCoreApplication()
+            cptr = new ::PyCoreApplicationWrapper();
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::PyCoreApplication >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    Shiboken::Object::setHasCppWrapper(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_appendToNatronPath(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyCoreApplication::appendToNatronPath(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // appendToNatronPath(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyCoreApplicationFunc_appendToNatronPath_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // appendToNatronPath(QString)
+            cppSelf->appendToNatronPath(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyCoreApplicationFunc_appendToNatronPath_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.PyCoreApplication.appendToNatronPath");
+        return {};
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_getActiveInstance(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getActiveInstance()const
+            App * cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->getActiveInstance();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_APP_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_getBuildNumber(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getBuildNumber()const
+            int cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->getBuildNumber();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_getInstance(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyCoreApplication::getInstance(int)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // getInstance(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyCoreApplicationFunc_getInstance_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getInstance(int)const
+            App * cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->getInstance(cppArg0);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_APP_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_PyCoreApplicationFunc_getInstance_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.PyCoreApplication.getInstance");
+        return {};
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_getNatronDevelopmentStatus(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getNatronDevelopmentStatus()const
+            QString cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->getNatronDevelopmentStatus();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_getNatronPath(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getNatronPath()const
+            QStringList cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->getNatronPath();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRINGLIST_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_getNatronVersionEncoded(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getNatronVersionEncoded()const
+            int cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->getNatronVersionEncoded();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_getNatronVersionMajor(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getNatronVersionMajor()const
+            int cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->getNatronVersionMajor();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_getNatronVersionMinor(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getNatronVersionMinor()const
+            int cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->getNatronVersionMinor();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_getNatronVersionRevision(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getNatronVersionRevision()const
+            int cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->getNatronVersionRevision();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_getNatronVersionString(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getNatronVersionString()const
+            QString cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->getNatronVersionString();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_getNumCpus(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getNumCpus()const
+            int cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->getNumCpus();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_getNumInstances(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getNumInstances()const
+            int cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->getNumInstances();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_getPluginIDs(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "getPluginIDs", 0, 1, &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: PyCoreApplication::getPluginIDs()const
+    // 1: PyCoreApplication::getPluginIDs(QString)const
+    if (numArgs == 0) {
+        overloadId = 0; // getPluginIDs()const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))) {
+        overloadId = 1; // getPluginIDs(QString)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyCoreApplicationFunc_getPluginIDs_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // getPluginIDs() const
+        {
+
+            if (!PyErr_Occurred()) {
+                // getPluginIDs()const
+                QStringList cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->getPluginIDs();
+                pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRINGLIST_IDX], &cppResult);
+            }
+            break;
+        }
+        case 1: // getPluginIDs(const QString & filter) const
+        {
+            ::QString cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // getPluginIDs(QString)const
+                QStringList cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->getPluginIDs(cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRINGLIST_IDX], &cppResult);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_PyCoreApplicationFunc_getPluginIDs_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.PyCoreApplication.getPluginIDs");
+        return {};
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_getSettings(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getSettings()const
+            AppSettings * cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->getSettings();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_APPSETTINGS_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_is64Bit(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // is64Bit()const
+            bool cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->is64Bit();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_isBackground(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // isBackground()const
+            bool cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->isBackground();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_isLinux(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // isLinux()const
+            bool cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->isLinux();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_isMacOSX(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // isMacOSX()const
+            bool cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->isMacOSX();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_isUnix(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // isUnix()const
+            bool cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->isUnix();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_isWindows(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // isWindows()const
+            bool cppResult = const_cast<const ::PyCoreApplication *>(cppSelf)->isWindows();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_setOnProjectCreatedCallback(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyCoreApplication::setOnProjectCreatedCallback(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setOnProjectCreatedCallback(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyCoreApplicationFunc_setOnProjectCreatedCallback_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setOnProjectCreatedCallback(QString)
+            cppSelf->setOnProjectCreatedCallback(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyCoreApplicationFunc_setOnProjectCreatedCallback_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.PyCoreApplication.setOnProjectCreatedCallback");
+        return {};
+}
+
+static PyObject *Sbk_PyCoreApplicationFunc_setOnProjectLoadedCallback(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyCoreApplication::setOnProjectLoadedCallback(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setOnProjectLoadedCallback(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyCoreApplicationFunc_setOnProjectLoadedCallback_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setOnProjectLoadedCallback(QString)
+            cppSelf->setOnProjectLoadedCallback(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyCoreApplicationFunc_setOnProjectLoadedCallback_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.PyCoreApplication.setOnProjectLoadedCallback");
+        return {};
+}
+
+
+static const char *Sbk_PyCoreApplication_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_PyCoreApplication_methods[] = {
+    {"appendToNatronPath", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_appendToNatronPath), METH_O},
+    {"getActiveInstance", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_getActiveInstance), METH_NOARGS},
+    {"getBuildNumber", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_getBuildNumber), METH_NOARGS},
+    {"getInstance", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_getInstance), METH_O},
+    {"getNatronDevelopmentStatus", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_getNatronDevelopmentStatus), METH_NOARGS},
+    {"getNatronPath", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_getNatronPath), METH_NOARGS},
+    {"getNatronVersionEncoded", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_getNatronVersionEncoded), METH_NOARGS},
+    {"getNatronVersionMajor", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_getNatronVersionMajor), METH_NOARGS},
+    {"getNatronVersionMinor", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_getNatronVersionMinor), METH_NOARGS},
+    {"getNatronVersionRevision", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_getNatronVersionRevision), METH_NOARGS},
+    {"getNatronVersionString", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_getNatronVersionString), METH_NOARGS},
+    {"getNumCpus", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_getNumCpus), METH_NOARGS},
+    {"getNumInstances", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_getNumInstances), METH_NOARGS},
+    {"getPluginIDs", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_getPluginIDs), METH_VARARGS},
+    {"getSettings", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_getSettings), METH_NOARGS},
+    {"is64Bit", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_is64Bit), METH_NOARGS},
+    {"isBackground", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_isBackground), METH_NOARGS},
+    {"isLinux", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_isLinux), METH_NOARGS},
+    {"isMacOSX", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_isMacOSX), METH_NOARGS},
+    {"isUnix", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_isUnix), METH_NOARGS},
+    {"isWindows", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_isWindows), METH_NOARGS},
+    {"setOnProjectCreatedCallback", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_setOnProjectCreatedCallback), METH_O},
+    {"setOnProjectLoadedCallback", reinterpret_cast<PyCFunction>(Sbk_PyCoreApplicationFunc_setOnProjectLoadedCallback), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_PyCoreApplication_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::PyCoreApplication *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<PyCoreApplicationWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_PyCoreApplication_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_PyCoreApplication_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_PyCoreApplication_Type = nullptr;
+static SbkObjectType *Sbk_PyCoreApplication_TypeF(void)
+{
+    return _Sbk_PyCoreApplication_Type;
+}
+
+static PyType_Slot Sbk_PyCoreApplication_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_PyCoreApplication_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_PyCoreApplication_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_PyCoreApplication_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_PyCoreApplication_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_PyCoreApplication_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_PyCoreApplication_spec = {
+    "1:NatronEngine.PyCoreApplication",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_PyCoreApplication_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void PyCoreApplication_PythonToCpp_PyCoreApplication_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_PyCoreApplication_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_PyCoreApplication_PythonToCpp_PyCoreApplication_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_PyCoreApplication_TypeF())))
+        return PyCoreApplication_PythonToCpp_PyCoreApplication_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *PyCoreApplication_PTR_CppToPython_PyCoreApplication(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::PyCoreApplication *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_PyCoreApplication_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *PyCoreApplication_SignatureStrings[] = {
+    "NatronEngine.PyCoreApplication(self)",
+    "NatronEngine.PyCoreApplication.appendToNatronPath(self,path:QString)",
+    "NatronEngine.PyCoreApplication.getActiveInstance(self)->NatronEngine.App",
+    "NatronEngine.PyCoreApplication.getBuildNumber(self)->int",
+    "NatronEngine.PyCoreApplication.getInstance(self,idx:int)->NatronEngine.App",
+    "NatronEngine.PyCoreApplication.getNatronDevelopmentStatus(self)->QString",
+    "NatronEngine.PyCoreApplication.getNatronPath(self)->QStringList",
+    "NatronEngine.PyCoreApplication.getNatronVersionEncoded(self)->int",
+    "NatronEngine.PyCoreApplication.getNatronVersionMajor(self)->int",
+    "NatronEngine.PyCoreApplication.getNatronVersionMinor(self)->int",
+    "NatronEngine.PyCoreApplication.getNatronVersionRevision(self)->int",
+    "NatronEngine.PyCoreApplication.getNatronVersionString(self)->QString",
+    "NatronEngine.PyCoreApplication.getNumCpus(self)->int",
+    "NatronEngine.PyCoreApplication.getNumInstances(self)->int",
+    "1:NatronEngine.PyCoreApplication.getPluginIDs(self)->QStringList",
+    "0:NatronEngine.PyCoreApplication.getPluginIDs(self,filter:QString)->QStringList",
+    "NatronEngine.PyCoreApplication.getSettings(self)->NatronEngine.AppSettings",
+    "NatronEngine.PyCoreApplication.is64Bit(self)->bool",
+    "NatronEngine.PyCoreApplication.isBackground(self)->bool",
+    "NatronEngine.PyCoreApplication.isLinux(self)->bool",
+    "NatronEngine.PyCoreApplication.isMacOSX(self)->bool",
+    "NatronEngine.PyCoreApplication.isUnix(self)->bool",
+    "NatronEngine.PyCoreApplication.isWindows(self)->bool",
+    "NatronEngine.PyCoreApplication.setOnProjectCreatedCallback(self,pythonFunctionName:QString)",
+    "NatronEngine.PyCoreApplication.setOnProjectLoadedCallback(self,pythonFunctionName:QString)",
+    nullptr}; // Sentinel
+
+void init_PyCoreApplication(PyObject *module)
+{
+    _Sbk_PyCoreApplication_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "PyCoreApplication",
+        "PyCoreApplication*",
+        &Sbk_PyCoreApplication_spec,
+        &Shiboken::callCppDestructor< ::PyCoreApplication >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_PyCoreApplication_Type);
+    InitSignatureStrings(pyType, PyCoreApplication_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_PyCoreApplication_Type), Sbk_PyCoreApplication_PropertyStrings);
+    SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_PyCoreApplication_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_PyCoreApplication_TypeF(),
+        PyCoreApplication_PythonToCpp_PyCoreApplication_PTR,
+        is_PyCoreApplication_PythonToCpp_PyCoreApplication_PTR_Convertible,
+        PyCoreApplication_PTR_CppToPython_PyCoreApplication);
+
+    Shiboken::Conversions::registerConverterName(converter, "PyCoreApplication");
+    Shiboken::Conversions::registerConverterName(converter, "PyCoreApplication*");
+    Shiboken::Conversions::registerConverterName(converter, "PyCoreApplication&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::PyCoreApplication).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::PyCoreApplicationWrapper).name());
+
+
+
+    PyCoreApplicationWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/pycoreapplication_wrapper.h
+++ b/Engine/Qt5/NatronEngine/pycoreapplication_wrapper.h
@@ -1,0 +1,23 @@
+#ifndef SBK_PYCOREAPPLICATIONWRAPPER_H
+#define SBK_PYCOREAPPLICATIONWRAPPER_H
+
+#include <PyGlobalFunctions.h>
+
+
+// Extra includes
+#include <PyAppInstance.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class PyCoreApplicationWrapper : public PyCoreApplication
+{
+public:
+    PyCoreApplicationWrapper();
+    ~PyCoreApplicationWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#endif // SBK_PYCOREAPPLICATIONWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/rectd_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/rectd_wrapper.cpp
@@ -1,0 +1,1517 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "rectd_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void RectDWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void RectDWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+RectDWrapper::RectDWrapper() : RectD()
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+RectDWrapper::RectDWrapper(double l, double b, double r, double t) : RectD(l, b, r, t)
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+RectDWrapper::~RectDWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_RectD_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::RectD >()))
+        return -1;
+
+    ::RectDWrapper *cptr{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs == 2 || numArgs == 3)
+        goto Sbk_RectD_Init_TypeError;
+
+    if (!PyArg_UnpackTuple(args, "RectD", 0, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return -1;
+
+
+    // Overloaded function decisor
+    // 0: RectD::RectD()
+    // 1: RectD::RectD(RectD)
+    // 2: RectD::RectD(double,double,double,double)
+    if (numArgs == 0) {
+        overloadId = 0; // RectD()
+    } else if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+        overloadId = 2; // RectD(double,double,double,double)
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTD_IDX]), (pyArgs[0])))) {
+        overloadId = 1; // RectD(RectD)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectD_Init_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // RectD()
+        {
+
+            if (!PyErr_Occurred()) {
+                // RectD()
+                cptr = new ::RectDWrapper();
+            }
+            break;
+        }
+        case 1: // RectD(const RectD & b)
+        {
+            if (!Shiboken::Object::isValid(pyArgs[0]))
+                return -1;
+            ::RectD *cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // RectD(RectD)
+                cptr = new ::RectDWrapper(*cppArg0);
+            }
+            break;
+        }
+        case 2: // RectD(double l, double b, double r, double t)
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            double cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            double cppArg3;
+            pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // RectD(double,double,double,double)
+                cptr = new ::RectDWrapper(cppArg0, cppArg1, cppArg2, cppArg3);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::RectD >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    if (!cptr) goto Sbk_RectD_Init_TypeError;
+
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    Shiboken::Object::setHasCppWrapper(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+
+    Sbk_RectD_Init_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.RectD");
+        return -1;
+}
+
+static PyObject *Sbk_RectDFunc_area(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // area()const
+            double cppResult = const_cast<const ::RectD *>(cppSelf)->area();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RectDFunc_bottom(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // bottom()const
+            double cppResult = const_cast<const ::RectD *>(cppSelf)->bottom();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RectDFunc_clear(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // clear()
+            cppSelf->clear();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_RectDFunc_contains(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "contains", 1, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: RectD::contains(RectD)const
+    // 1: RectD::contains(double,double)const
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        overloadId = 1; // contains(double,double)const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTD_IDX]), (pyArgs[0])))) {
+        overloadId = 0; // contains(RectD)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectDFunc_contains_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // contains(const RectD & other) const
+        {
+            if (!Shiboken::Object::isValid(pyArgs[0]))
+                return {};
+            ::RectD *cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // contains(RectD)const
+                bool cppResult = const_cast<const ::RectD *>(cppSelf)->contains(*cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            }
+            break;
+        }
+        case 1: // contains(double x, double y) const
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+
+            if (!PyErr_Occurred()) {
+                // contains(double,double)const
+                bool cppResult = const_cast<const ::RectD *>(cppSelf)->contains(cppArg0, cppArg1);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_RectDFunc_contains_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.RectD.contains");
+        return {};
+}
+
+static PyObject *Sbk_RectDFunc_height(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // height()const
+            double cppResult = const_cast<const ::RectD *>(cppSelf)->height();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RectDFunc_intersect(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs == 2 || numArgs == 3)
+        goto Sbk_RectDFunc_intersect_TypeError;
+
+    if (!PyArg_UnpackTuple(args, "intersect", 1, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: RectD::intersect(RectD,RectD*)const
+    // 1: RectD::intersect(double,double,double,double,RectD*)const
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+        overloadId = 1; // intersect(double,double,double,double,RectD*)const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTD_IDX]), (pyArgs[0])))) {
+        overloadId = 0; // intersect(RectD,RectD*)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectDFunc_intersect_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // intersect(const RectD & r, RectD * intersection) const
+        {
+            if (!Shiboken::Object::isValid(pyArgs[0]))
+                return {};
+            ::RectD *cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // intersect(RectD,RectD*)const
+                // Begin code injection
+                RectD t;
+                cppSelf->intersect(*cppArg0,&t);
+                pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTD_IDX]), &t);
+                return pyResult;
+
+                // End of code injection
+
+            }
+            break;
+        }
+        case 1: // intersect(double l, double b, double r, double t, RectD * intersection) const
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            double cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            double cppArg3;
+            pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // intersect(double,double,double,double,RectD*)const
+                // Begin code injection
+                RectD t;
+                cppSelf->intersect(cppArg0,cppArg1,cppArg2,cppArg3,&t);
+                pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTD_IDX]), &t);
+                return pyResult;
+
+                // End of code injection
+
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_RectDFunc_intersect_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.RectD.intersect");
+        return {};
+}
+
+static PyObject *Sbk_RectDFunc_intersects(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs == 2 || numArgs == 3)
+        goto Sbk_RectDFunc_intersects_TypeError;
+
+    if (!PyArg_UnpackTuple(args, "intersects", 1, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: RectD::intersects(RectD)const
+    // 1: RectD::intersects(double,double,double,double)const
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+        overloadId = 1; // intersects(double,double,double,double)const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTD_IDX]), (pyArgs[0])))) {
+        overloadId = 0; // intersects(RectD)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectDFunc_intersects_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // intersects(const RectD & r) const
+        {
+            if (!Shiboken::Object::isValid(pyArgs[0]))
+                return {};
+            ::RectD *cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // intersects(RectD)const
+                bool cppResult = const_cast<const ::RectD *>(cppSelf)->intersects(*cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            }
+            break;
+        }
+        case 1: // intersects(double l, double b, double r, double t) const
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            double cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            double cppArg3;
+            pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // intersects(double,double,double,double)const
+                bool cppResult = const_cast<const ::RectD *>(cppSelf)->intersects(cppArg0, cppArg1, cppArg2, cppArg3);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_RectDFunc_intersects_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.RectD.intersects");
+        return {};
+}
+
+static PyObject *Sbk_RectDFunc_isInfinite(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // isInfinite()const
+            bool cppResult = const_cast<const ::RectD *>(cppSelf)->isInfinite();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RectDFunc_isNull(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // isNull()const
+            bool cppResult = const_cast<const ::RectD *>(cppSelf)->isNull();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RectDFunc_left(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // left()const
+            double cppResult = const_cast<const ::RectD *>(cppSelf)->left();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RectDFunc_merge(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs == 2 || numArgs == 3)
+        goto Sbk_RectDFunc_merge_TypeError;
+
+    if (!PyArg_UnpackTuple(args, "merge", 1, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: RectD::merge(RectD)
+    // 1: RectD::merge(double,double,double,double)
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+        overloadId = 1; // merge(double,double,double,double)
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTD_IDX]), (pyArgs[0])))) {
+        overloadId = 0; // merge(RectD)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectDFunc_merge_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // merge(const RectD & box)
+        {
+            if (!Shiboken::Object::isValid(pyArgs[0]))
+                return {};
+            ::RectD *cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // merge(RectD)
+                cppSelf->merge(*cppArg0);
+            }
+            break;
+        }
+        case 1: // merge(double l, double b, double r, double t)
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            double cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            double cppArg3;
+            pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // merge(double,double,double,double)
+                cppSelf->merge(cppArg0, cppArg1, cppArg2, cppArg3);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_RectDFunc_merge_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.RectD.merge");
+        return {};
+}
+
+static PyObject *Sbk_RectDFunc_right(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // right()const
+            double cppResult = const_cast<const ::RectD *>(cppSelf)->right();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RectDFunc_set(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs == 2 || numArgs == 3)
+        goto Sbk_RectDFunc_set_TypeError;
+
+    if (!PyArg_UnpackTuple(args, "set", 1, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: RectD::set(RectD)
+    // 1: RectD::set(double,double,double,double)
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+        overloadId = 1; // set(double,double,double,double)
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTD_IDX]), (pyArgs[0])))) {
+        overloadId = 0; // set(RectD)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectDFunc_set_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // set(const RectD & b)
+        {
+            if (!Shiboken::Object::isValid(pyArgs[0]))
+                return {};
+            ::RectD *cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // set(RectD)
+                cppSelf->set(*cppArg0);
+            }
+            break;
+        }
+        case 1: // set(double l, double b, double r, double t)
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            double cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            double cppArg3;
+            pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // set(double,double,double,double)
+                cppSelf->set(cppArg0, cppArg1, cppArg2, cppArg3);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_RectDFunc_set_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.RectD.set");
+        return {};
+}
+
+static PyObject *Sbk_RectDFunc_set_bottom(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: RectD::set_bottom(double)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArg)))) {
+        overloadId = 0; // set_bottom(double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectDFunc_set_bottom_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // set_bottom(double)
+            cppSelf->set_bottom(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_RectDFunc_set_bottom_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.RectD.set_bottom");
+        return {};
+}
+
+static PyObject *Sbk_RectDFunc_set_left(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: RectD::set_left(double)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArg)))) {
+        overloadId = 0; // set_left(double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectDFunc_set_left_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // set_left(double)
+            cppSelf->set_left(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_RectDFunc_set_left_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.RectD.set_left");
+        return {};
+}
+
+static PyObject *Sbk_RectDFunc_set_right(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: RectD::set_right(double)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArg)))) {
+        overloadId = 0; // set_right(double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectDFunc_set_right_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // set_right(double)
+            cppSelf->set_right(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_RectDFunc_set_right_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.RectD.set_right");
+        return {};
+}
+
+static PyObject *Sbk_RectDFunc_set_top(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: RectD::set_top(double)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArg)))) {
+        overloadId = 0; // set_top(double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectDFunc_set_top_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // set_top(double)
+            cppSelf->set_top(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_RectDFunc_set_top_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.RectD.set_top");
+        return {};
+}
+
+static PyObject *Sbk_RectDFunc_setupInfinity(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // setupInfinity()
+            cppSelf->setupInfinity();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_RectDFunc_top(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // top()const
+            double cppResult = const_cast<const ::RectD *>(cppSelf)->top();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RectDFunc_translate(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "translate", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: RectD::translate(int,int)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+        overloadId = 0; // translate(int,int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectDFunc_translate_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // translate(int,int)
+            cppSelf->translate(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_RectDFunc_translate_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.RectD.translate");
+        return {};
+}
+
+static PyObject *Sbk_RectDFunc_width(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // width()const
+            double cppResult = const_cast<const ::RectD *>(cppSelf)->width();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+
+static const char *Sbk_RectD_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_RectD_methods[] = {
+    {"area", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_area), METH_NOARGS},
+    {"bottom", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_bottom), METH_NOARGS},
+    {"clear", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_clear), METH_NOARGS},
+    {"contains", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_contains), METH_VARARGS},
+    {"height", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_height), METH_NOARGS},
+    {"intersect", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_intersect), METH_VARARGS},
+    {"intersects", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_intersects), METH_VARARGS},
+    {"isInfinite", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_isInfinite), METH_NOARGS},
+    {"isNull", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_isNull), METH_NOARGS},
+    {"left", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_left), METH_NOARGS},
+    {"merge", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_merge), METH_VARARGS},
+    {"right", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_right), METH_NOARGS},
+    {"set", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_set), METH_VARARGS},
+    {"set_bottom", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_set_bottom), METH_O},
+    {"set_left", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_set_left), METH_O},
+    {"set_right", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_set_right), METH_O},
+    {"set_top", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_set_top), METH_O},
+    {"setupInfinity", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_setupInfinity), METH_NOARGS},
+    {"top", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_top), METH_NOARGS},
+    {"translate", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_translate), METH_VARARGS},
+    {"width", reinterpret_cast<PyCFunction>(Sbk_RectDFunc_width), METH_NOARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_RectD_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<RectDWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+static int Sbk_RectD___nb_bool(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return -1;
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    return !cppSelf->isNull();
+}
+
+// Rich comparison
+static PyObject * Sbk_RectD_richcompare(PyObject *self, PyObject *pyArg, int op)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto &cppSelf = *reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    PythonToCppFunc pythonToCpp;
+    SBK_UNUSED(pythonToCpp)
+
+    switch (op) {
+        case Py_NE:
+            if ((pythonToCpp = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTD_IDX]), (pyArg)))) {
+                // operator!=(const RectD & b2)
+                if (!Shiboken::Object::isValid(pyArg))
+                    return {};
+                ::RectD *cppArg0;
+                pythonToCpp(pyArg, &cppArg0);
+                bool cppResult = cppSelf !=(*cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            } else {
+                pyResult = Py_True;
+                Py_INCREF(pyResult);
+            }
+
+            break;
+        case Py_EQ:
+            if ((pythonToCpp = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTD_IDX]), (pyArg)))) {
+                // operator==(const RectD & b2)
+                if (!Shiboken::Object::isValid(pyArg))
+                    return {};
+                ::RectD *cppArg0;
+                pythonToCpp(pyArg, &cppArg0);
+                bool cppResult = cppSelf ==(*cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            } else {
+                pyResult = Py_False;
+                Py_INCREF(pyResult);
+            }
+
+            break;
+        default:
+            // PYSIDE-74: By default, we redirect to object's tp_richcompare (which is `==`, `!=`).
+            return FallbackRichCompare(self, pyArg, op);
+            goto Sbk_RectD_RichComparison_TypeError;
+    }
+
+    if (pyResult && !PyErr_Occurred())
+        return pyResult;
+    Sbk_RectD_RichComparison_TypeError:
+    PyErr_SetString(PyExc_NotImplementedError, "operator not implemented.");
+    return {};
+
+}
+
+static PyObject *Sbk_RectD_get_x1(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppSelf->x1);
+    return pyOut;
+}
+static int Sbk_RectD_set_x1(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'x1' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'x1', 'double' or convertible type expected");
+        return -1;
+    }
+
+    double& cppOut_ptr = cppSelf->x1;
+    pythonToCpp(pyIn, &cppOut_ptr);
+
+    return 0;
+}
+
+static PyObject *Sbk_RectD_get_y1(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppSelf->y1);
+    return pyOut;
+}
+static int Sbk_RectD_set_y1(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'y1' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'y1', 'double' or convertible type expected");
+        return -1;
+    }
+
+    double& cppOut_ptr = cppSelf->y1;
+    pythonToCpp(pyIn, &cppOut_ptr);
+
+    return 0;
+}
+
+static PyObject *Sbk_RectD_get_x2(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppSelf->x2);
+    return pyOut;
+}
+static int Sbk_RectD_set_x2(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'x2' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'x2', 'double' or convertible type expected");
+        return -1;
+    }
+
+    double& cppOut_ptr = cppSelf->x2;
+    pythonToCpp(pyIn, &cppOut_ptr);
+
+    return 0;
+}
+
+static PyObject *Sbk_RectD_get_y2(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<double>(), &cppSelf->y2);
+    return pyOut;
+}
+static int Sbk_RectD_set_y2(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::RectD *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTD_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'y2' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'y2', 'double' or convertible type expected");
+        return -1;
+    }
+
+    double& cppOut_ptr = cppSelf->y2;
+    pythonToCpp(pyIn, &cppOut_ptr);
+
+    return 0;
+}
+
+// Getters and Setters for RectD
+static PyGetSetDef Sbk_RectD_getsetlist[] = {
+    {const_cast<char *>("x1"), Sbk_RectD_get_x1, Sbk_RectD_set_x1},
+    {const_cast<char *>("y1"), Sbk_RectD_get_y1, Sbk_RectD_set_y1},
+    {const_cast<char *>("x2"), Sbk_RectD_get_x2, Sbk_RectD_set_x2},
+    {const_cast<char *>("y2"), Sbk_RectD_get_y2, Sbk_RectD_set_y2},
+    {nullptr} // Sentinel
+};
+
+} // extern "C"
+
+static int Sbk_RectD_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_RectD_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_RectD_Type = nullptr;
+static SbkObjectType *Sbk_RectD_TypeF(void)
+{
+    return _Sbk_RectD_Type;
+}
+
+static PyType_Slot Sbk_RectD_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_RectD_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_RectD_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_RectD_clear)},
+    {Py_tp_richcompare, reinterpret_cast<void *>(Sbk_RectD_richcompare)},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_RectD_methods)},
+    {Py_tp_getset,      reinterpret_cast<void *>(Sbk_RectD_getsetlist)},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_RectD_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    // type supports number protocol
+#ifdef IS_PY3K
+    {Py_nb_bool, (void *)Sbk_RectD___nb_bool},
+#else
+    {Py_nb_nonzero, (void *)Sbk_RectD___nb_bool},
+#endif
+    {0, nullptr}
+};
+static PyType_Spec Sbk_RectD_spec = {
+    "1:NatronEngine.RectD",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_RectD_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void RectD_PythonToCpp_RectD_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_RectD_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_RectD_PythonToCpp_RectD_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_RectD_TypeF())))
+        return RectD_PythonToCpp_RectD_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *RectD_PTR_CppToPython_RectD(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::RectD *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_RectD_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *RectD_SignatureStrings[] = {
+    "2:NatronEngine.RectD(self)",
+    "1:NatronEngine.RectD(self,b:NatronEngine.RectD)",
+    "0:NatronEngine.RectD(self,l:double,b:double,r:double,t:double)",
+    "NatronEngine.RectD.area(self)->double",
+    "NatronEngine.RectD.bottom(self)->double",
+    "NatronEngine.RectD.clear(self)",
+    "1:NatronEngine.RectD.contains(self,other:NatronEngine.RectD)->bool",
+    "0:NatronEngine.RectD.contains(self,x:double,y:double)->bool",
+    "NatronEngine.RectD.height(self)->double",
+    "1:NatronEngine.RectD.intersect(self,r:NatronEngine.RectD,intersection:NatronEngine.RectD)->bool",
+    "0:NatronEngine.RectD.intersect(self,l:double,b:double,r:double,t:double,intersection:NatronEngine.RectD)->bool",
+    "1:NatronEngine.RectD.intersects(self,r:NatronEngine.RectD)->bool",
+    "0:NatronEngine.RectD.intersects(self,l:double,b:double,r:double,t:double)->bool",
+    "NatronEngine.RectD.isInfinite(self)->bool",
+    "NatronEngine.RectD.isNull(self)->bool",
+    "NatronEngine.RectD.left(self)->double",
+    "1:NatronEngine.RectD.merge(self,box:NatronEngine.RectD)",
+    "0:NatronEngine.RectD.merge(self,l:double,b:double,r:double,t:double)",
+    "NatronEngine.RectD.right(self)->double",
+    "1:NatronEngine.RectD.set(self,b:NatronEngine.RectD)",
+    "0:NatronEngine.RectD.set(self,l:double,b:double,r:double,t:double)",
+    "NatronEngine.RectD.set_bottom(self,v:double)",
+    "NatronEngine.RectD.set_left(self,v:double)",
+    "NatronEngine.RectD.set_right(self,v:double)",
+    "NatronEngine.RectD.set_top(self,v:double)",
+    "NatronEngine.RectD.setupInfinity(self)",
+    "NatronEngine.RectD.top(self)->double",
+    "NatronEngine.RectD.translate(self,dx:int,dy:int)",
+    "NatronEngine.RectD.width(self)->double",
+    nullptr}; // Sentinel
+
+void init_RectD(PyObject *module)
+{
+    _Sbk_RectD_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "RectD",
+        "RectD*",
+        &Sbk_RectD_spec,
+        &Shiboken::callCppDestructor< ::RectD >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_RectD_Type);
+    InitSignatureStrings(pyType, RectD_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_RectD_Type), Sbk_RectD_PropertyStrings);
+    SbkNatronEngineTypes[SBK_RECTD_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_RectD_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_RectD_TypeF(),
+        RectD_PythonToCpp_RectD_PTR,
+        is_RectD_PythonToCpp_RectD_PTR_Convertible,
+        RectD_PTR_CppToPython_RectD);
+
+    Shiboken::Conversions::registerConverterName(converter, "RectD");
+    Shiboken::Conversions::registerConverterName(converter, "RectD*");
+    Shiboken::Conversions::registerConverterName(converter, "RectD&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::RectD).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::RectDWrapper).name());
+
+
+
+    RectDWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/rectd_wrapper.h
+++ b/Engine/Qt5/NatronEngine/rectd_wrapper.h
@@ -1,0 +1,28 @@
+#ifndef SBK_RECTDWRAPPER_H
+#define SBK_RECTDWRAPPER_H
+
+#include <RectD.h>
+
+
+// Extra includes
+#include <RectD.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class RectDWrapper : public RectD
+{
+public:
+    RectDWrapper();
+    RectDWrapper(const RectD& self) : RectD(self)
+    {
+    }
+
+    RectDWrapper(double l, double b, double r, double t);
+    ~RectDWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#endif // SBK_RECTDWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/recti_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/recti_wrapper.cpp
@@ -1,0 +1,1494 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "recti_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void RectIWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void RectIWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+RectIWrapper::RectIWrapper() : RectI()
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+RectIWrapper::RectIWrapper(int x1_, int y1_, int x2_, int y2_) : RectI(x1_, y1_, x2_, y2_)
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+RectIWrapper::~RectIWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_RectI_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::RectI >()))
+        return -1;
+
+    ::RectIWrapper *cptr{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs == 2 || numArgs == 3)
+        goto Sbk_RectI_Init_TypeError;
+
+    if (!PyArg_UnpackTuple(args, "RectI", 0, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return -1;
+
+
+    // Overloaded function decisor
+    // 0: RectI::RectI()
+    // 1: RectI::RectI(RectI)
+    // 2: RectI::RectI(int,int,int,int)
+    if (numArgs == 0) {
+        overloadId = 0; // RectI()
+    } else if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[3])))) {
+        overloadId = 2; // RectI(int,int,int,int)
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTI_IDX]), (pyArgs[0])))) {
+        overloadId = 1; // RectI(RectI)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectI_Init_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // RectI()
+        {
+
+            if (!PyErr_Occurred()) {
+                // RectI()
+                cptr = new ::RectIWrapper();
+            }
+            break;
+        }
+        case 1: // RectI(const RectI & b)
+        {
+            if (!Shiboken::Object::isValid(pyArgs[0]))
+                return -1;
+            ::RectI *cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // RectI(RectI)
+                cptr = new ::RectIWrapper(*cppArg0);
+            }
+            break;
+        }
+        case 2: // RectI(int x1_, int y1_, int x2_, int y2_)
+        {
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            int cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            int cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            int cppArg3;
+            pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // RectI(int,int,int,int)
+                cptr = new ::RectIWrapper(cppArg0, cppArg1, cppArg2, cppArg3);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::RectI >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    if (!cptr) goto Sbk_RectI_Init_TypeError;
+
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    Shiboken::Object::setHasCppWrapper(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+
+    Sbk_RectI_Init_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.RectI");
+        return -1;
+}
+
+static PyObject *Sbk_RectIFunc_bottom(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // bottom()const
+            int cppResult = const_cast<const ::RectI *>(cppSelf)->bottom();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RectIFunc_clear(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // clear()
+            cppSelf->clear();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_RectIFunc_contains(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "contains", 1, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: RectI::contains(RectI)const
+    // 1: RectI::contains(double,double)const
+    // 2: RectI::contains(int,int)const
+    if (numArgs == 2
+        && PyFloat_Check(pyArgs[0]) && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        overloadId = 1; // contains(double,double)const
+    } else if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+        overloadId = 2; // contains(int,int)const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTI_IDX]), (pyArgs[0])))) {
+        overloadId = 0; // contains(RectI)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectIFunc_contains_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // contains(const RectI & other) const
+        {
+            if (!Shiboken::Object::isValid(pyArgs[0]))
+                return {};
+            ::RectI *cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // contains(RectI)const
+                bool cppResult = const_cast<const ::RectI *>(cppSelf)->contains(*cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            }
+            break;
+        }
+        case 1: // contains(double x, double y) const
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+
+            if (!PyErr_Occurred()) {
+                // contains(double,double)const
+                bool cppResult = const_cast<const ::RectI *>(cppSelf)->contains(cppArg0, cppArg1);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            }
+            break;
+        }
+        case 2: // contains(int x, int y) const
+        {
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            int cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+
+            if (!PyErr_Occurred()) {
+                // contains(int,int)const
+                bool cppResult = const_cast<const ::RectI *>(cppSelf)->contains(cppArg0, cppArg1);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_RectIFunc_contains_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.RectI.contains");
+        return {};
+}
+
+static PyObject *Sbk_RectIFunc_height(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // height()const
+            int cppResult = const_cast<const ::RectI *>(cppSelf)->height();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RectIFunc_intersect(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs == 2 || numArgs == 3)
+        goto Sbk_RectIFunc_intersect_TypeError;
+
+    if (!PyArg_UnpackTuple(args, "intersect", 1, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: RectI::intersect(RectI,RectI*)const
+    // 1: RectI::intersect(int,int,int,int,RectI*)const
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[3])))) {
+        overloadId = 1; // intersect(int,int,int,int,RectI*)const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTI_IDX]), (pyArgs[0])))) {
+        overloadId = 0; // intersect(RectI,RectI*)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectIFunc_intersect_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // intersect(const RectI & r, RectI * intersection) const
+        {
+            if (!Shiboken::Object::isValid(pyArgs[0]))
+                return {};
+            ::RectI *cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // intersect(RectI,RectI*)const
+                // Begin code injection
+                RectI t;
+                cppSelf->intersect(*cppArg0,&t);
+                pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTI_IDX]), &t);
+                return pyResult;
+
+                // End of code injection
+
+            }
+            break;
+        }
+        case 1: // intersect(int x1_, int y1_, int x2_, int y2_, RectI * intersection) const
+        {
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            int cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            int cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            int cppArg3;
+            pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // intersect(int,int,int,int,RectI*)const
+                // Begin code injection
+                RectI t;
+                cppSelf->intersect(cppArg0,cppArg1,cppArg2,cppArg3,&t);
+                pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTI_IDX]), &t);
+                return pyResult;
+
+                // End of code injection
+
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_RectIFunc_intersect_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.RectI.intersect");
+        return {};
+}
+
+static PyObject *Sbk_RectIFunc_intersects(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs == 2 || numArgs == 3)
+        goto Sbk_RectIFunc_intersects_TypeError;
+
+    if (!PyArg_UnpackTuple(args, "intersects", 1, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: RectI::intersects(RectI)const
+    // 1: RectI::intersects(int,int,int,int)const
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[3])))) {
+        overloadId = 1; // intersects(int,int,int,int)const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTI_IDX]), (pyArgs[0])))) {
+        overloadId = 0; // intersects(RectI)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectIFunc_intersects_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // intersects(const RectI & r) const
+        {
+            if (!Shiboken::Object::isValid(pyArgs[0]))
+                return {};
+            ::RectI *cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // intersects(RectI)const
+                bool cppResult = const_cast<const ::RectI *>(cppSelf)->intersects(*cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            }
+            break;
+        }
+        case 1: // intersects(int x1_, int y1_, int x2_, int y2_) const
+        {
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            int cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            int cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            int cppArg3;
+            pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // intersects(int,int,int,int)const
+                bool cppResult = const_cast<const ::RectI *>(cppSelf)->intersects(cppArg0, cppArg1, cppArg2, cppArg3);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_RectIFunc_intersects_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.RectI.intersects");
+        return {};
+}
+
+static PyObject *Sbk_RectIFunc_isInfinite(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // isInfinite()const
+            bool cppResult = const_cast<const ::RectI *>(cppSelf)->isInfinite();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RectIFunc_isNull(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // isNull()const
+            bool cppResult = const_cast<const ::RectI *>(cppSelf)->isNull();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RectIFunc_left(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // left()const
+            int cppResult = const_cast<const ::RectI *>(cppSelf)->left();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RectIFunc_merge(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs == 2 || numArgs == 3)
+        goto Sbk_RectIFunc_merge_TypeError;
+
+    if (!PyArg_UnpackTuple(args, "merge", 1, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: RectI::merge(RectI)
+    // 1: RectI::merge(int,int,int,int)
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[3])))) {
+        overloadId = 1; // merge(int,int,int,int)
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTI_IDX]), (pyArgs[0])))) {
+        overloadId = 0; // merge(RectI)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectIFunc_merge_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // merge(const RectI & box)
+        {
+            if (!Shiboken::Object::isValid(pyArgs[0]))
+                return {};
+            ::RectI *cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // merge(RectI)
+                cppSelf->merge(*cppArg0);
+            }
+            break;
+        }
+        case 1: // merge(int x1_, int y1_, int x2_, int y2_)
+        {
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            int cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            int cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            int cppArg3;
+            pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // merge(int,int,int,int)
+                cppSelf->merge(cppArg0, cppArg1, cppArg2, cppArg3);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_RectIFunc_merge_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.RectI.merge");
+        return {};
+}
+
+static PyObject *Sbk_RectIFunc_right(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // right()const
+            int cppResult = const_cast<const ::RectI *>(cppSelf)->right();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RectIFunc_set(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs == 2 || numArgs == 3)
+        goto Sbk_RectIFunc_set_TypeError;
+
+    if (!PyArg_UnpackTuple(args, "set", 1, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: RectI::set(RectI)
+    // 1: RectI::set(int,int,int,int)
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[3])))) {
+        overloadId = 1; // set(int,int,int,int)
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTI_IDX]), (pyArgs[0])))) {
+        overloadId = 0; // set(RectI)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectIFunc_set_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // set(const RectI & b)
+        {
+            if (!Shiboken::Object::isValid(pyArgs[0]))
+                return {};
+            ::RectI *cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // set(RectI)
+                cppSelf->set(*cppArg0);
+            }
+            break;
+        }
+        case 1: // set(int x1_, int y1_, int x2_, int y2_)
+        {
+            int cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            int cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            int cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            int cppArg3;
+            pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // set(int,int,int,int)
+                cppSelf->set(cppArg0, cppArg1, cppArg2, cppArg3);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_RectIFunc_set_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.RectI.set");
+        return {};
+}
+
+static PyObject *Sbk_RectIFunc_set_bottom(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: RectI::set_bottom(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // set_bottom(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectIFunc_set_bottom_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // set_bottom(int)
+            cppSelf->set_bottom(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_RectIFunc_set_bottom_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.RectI.set_bottom");
+        return {};
+}
+
+static PyObject *Sbk_RectIFunc_set_left(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: RectI::set_left(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // set_left(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectIFunc_set_left_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // set_left(int)
+            cppSelf->set_left(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_RectIFunc_set_left_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.RectI.set_left");
+        return {};
+}
+
+static PyObject *Sbk_RectIFunc_set_right(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: RectI::set_right(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // set_right(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectIFunc_set_right_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // set_right(int)
+            cppSelf->set_right(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_RectIFunc_set_right_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.RectI.set_right");
+        return {};
+}
+
+static PyObject *Sbk_RectIFunc_set_top(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: RectI::set_top(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // set_top(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectIFunc_set_top_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // set_top(int)
+            cppSelf->set_top(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_RectIFunc_set_top_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.RectI.set_top");
+        return {};
+}
+
+static PyObject *Sbk_RectIFunc_top(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // top()const
+            int cppResult = const_cast<const ::RectI *>(cppSelf)->top();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RectIFunc_translate(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "translate", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: RectI::translate(int,int)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+        overloadId = 0; // translate(int,int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RectIFunc_translate_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // translate(int,int)
+            cppSelf->translate(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_RectIFunc_translate_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.RectI.translate");
+        return {};
+}
+
+static PyObject *Sbk_RectIFunc_width(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // width()const
+            int cppResult = const_cast<const ::RectI *>(cppSelf)->width();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+
+static const char *Sbk_RectI_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_RectI_methods[] = {
+    {"bottom", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_bottom), METH_NOARGS},
+    {"clear", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_clear), METH_NOARGS},
+    {"contains", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_contains), METH_VARARGS},
+    {"height", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_height), METH_NOARGS},
+    {"intersect", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_intersect), METH_VARARGS},
+    {"intersects", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_intersects), METH_VARARGS},
+    {"isInfinite", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_isInfinite), METH_NOARGS},
+    {"isNull", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_isNull), METH_NOARGS},
+    {"left", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_left), METH_NOARGS},
+    {"merge", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_merge), METH_VARARGS},
+    {"right", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_right), METH_NOARGS},
+    {"set", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_set), METH_VARARGS},
+    {"set_bottom", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_set_bottom), METH_O},
+    {"set_left", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_set_left), METH_O},
+    {"set_right", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_set_right), METH_O},
+    {"set_top", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_set_top), METH_O},
+    {"top", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_top), METH_NOARGS},
+    {"translate", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_translate), METH_VARARGS},
+    {"width", reinterpret_cast<PyCFunction>(Sbk_RectIFunc_width), METH_NOARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_RectI_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<RectIWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+static int Sbk_RectI___nb_bool(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return -1;
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    return !cppSelf->isNull();
+}
+
+// Rich comparison
+static PyObject * Sbk_RectI_richcompare(PyObject *self, PyObject *pyArg, int op)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto &cppSelf = *reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    PythonToCppFunc pythonToCpp;
+    SBK_UNUSED(pythonToCpp)
+
+    switch (op) {
+        case Py_NE:
+            if ((pythonToCpp = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTI_IDX]), (pyArg)))) {
+                // operator!=(const RectI & b2)
+                if (!Shiboken::Object::isValid(pyArg))
+                    return {};
+                ::RectI *cppArg0;
+                pythonToCpp(pyArg, &cppArg0);
+                bool cppResult = cppSelf !=(*cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            } else {
+                pyResult = Py_True;
+                Py_INCREF(pyResult);
+            }
+
+            break;
+        case Py_EQ:
+            if ((pythonToCpp = Shiboken::Conversions::isPythonToCppReferenceConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_RECTI_IDX]), (pyArg)))) {
+                // operator==(const RectI & b2)
+                if (!Shiboken::Object::isValid(pyArg))
+                    return {};
+                ::RectI *cppArg0;
+                pythonToCpp(pyArg, &cppArg0);
+                bool cppResult = cppSelf ==(*cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+            } else {
+                pyResult = Py_False;
+                Py_INCREF(pyResult);
+            }
+
+            break;
+        default:
+            // PYSIDE-74: By default, we redirect to object's tp_richcompare (which is `==`, `!=`).
+            return FallbackRichCompare(self, pyArg, op);
+            goto Sbk_RectI_RichComparison_TypeError;
+    }
+
+    if (pyResult && !PyErr_Occurred())
+        return pyResult;
+    Sbk_RectI_RichComparison_TypeError:
+    PyErr_SetString(PyExc_NotImplementedError, "operator not implemented.");
+    return {};
+
+}
+
+static PyObject *Sbk_RectI_get_x1(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int cppOut_local = cppSelf->x1;
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppOut_local);
+    return pyOut;
+}
+static int Sbk_RectI_set_x1(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'x1' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'x1', 'int' or convertible type expected");
+        return -1;
+    }
+
+    int cppOut_local = cppSelf->x1;
+    pythonToCpp(pyIn, &cppOut_local);
+    cppSelf->x1 = cppOut_local;
+
+    return 0;
+}
+
+static PyObject *Sbk_RectI_get_y1(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int cppOut_local = cppSelf->y1;
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppOut_local);
+    return pyOut;
+}
+static int Sbk_RectI_set_y1(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'y1' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'y1', 'int' or convertible type expected");
+        return -1;
+    }
+
+    int cppOut_local = cppSelf->y1;
+    pythonToCpp(pyIn, &cppOut_local);
+    cppSelf->y1 = cppOut_local;
+
+    return 0;
+}
+
+static PyObject *Sbk_RectI_get_x2(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int cppOut_local = cppSelf->x2;
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppOut_local);
+    return pyOut;
+}
+static int Sbk_RectI_set_x2(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'x2' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'x2', 'int' or convertible type expected");
+        return -1;
+    }
+
+    int cppOut_local = cppSelf->x2;
+    pythonToCpp(pyIn, &cppOut_local);
+    cppSelf->x2 = cppOut_local;
+
+    return 0;
+}
+
+static PyObject *Sbk_RectI_get_y2(PyObject *self, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return nullptr;
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int cppOut_local = cppSelf->y2;
+    PyObject *pyOut = {};
+    pyOut = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppOut_local);
+    return pyOut;
+}
+static int Sbk_RectI_set_y2(PyObject *self, PyObject *pyIn, void *)
+{
+    if (!Shiboken::Object::isValid(self))
+        return 0;
+    auto cppSelf = reinterpret_cast< ::RectI *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_RECTI_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    if (pyIn == nullptr) {
+        PyErr_SetString(PyExc_TypeError, "'y2' may not be deleted");
+        return -1;
+    }
+    PythonToCppFunc pythonToCpp{nullptr};
+    if (!(pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyIn)))) {
+        PyErr_SetString(PyExc_TypeError, "wrong type attributed to 'y2', 'int' or convertible type expected");
+        return -1;
+    }
+
+    int cppOut_local = cppSelf->y2;
+    pythonToCpp(pyIn, &cppOut_local);
+    cppSelf->y2 = cppOut_local;
+
+    return 0;
+}
+
+// Getters and Setters for RectI
+static PyGetSetDef Sbk_RectI_getsetlist[] = {
+    {const_cast<char *>("x1"), Sbk_RectI_get_x1, Sbk_RectI_set_x1},
+    {const_cast<char *>("y1"), Sbk_RectI_get_y1, Sbk_RectI_set_y1},
+    {const_cast<char *>("x2"), Sbk_RectI_get_x2, Sbk_RectI_set_x2},
+    {const_cast<char *>("y2"), Sbk_RectI_get_y2, Sbk_RectI_set_y2},
+    {nullptr} // Sentinel
+};
+
+} // extern "C"
+
+static int Sbk_RectI_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_RectI_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_RectI_Type = nullptr;
+static SbkObjectType *Sbk_RectI_TypeF(void)
+{
+    return _Sbk_RectI_Type;
+}
+
+static PyType_Slot Sbk_RectI_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_RectI_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_RectI_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_RectI_clear)},
+    {Py_tp_richcompare, reinterpret_cast<void *>(Sbk_RectI_richcompare)},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_RectI_methods)},
+    {Py_tp_getset,      reinterpret_cast<void *>(Sbk_RectI_getsetlist)},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_RectI_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    // type supports number protocol
+#ifdef IS_PY3K
+    {Py_nb_bool, (void *)Sbk_RectI___nb_bool},
+#else
+    {Py_nb_nonzero, (void *)Sbk_RectI___nb_bool},
+#endif
+    {0, nullptr}
+};
+static PyType_Spec Sbk_RectI_spec = {
+    "1:NatronEngine.RectI",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_RectI_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void RectI_PythonToCpp_RectI_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_RectI_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_RectI_PythonToCpp_RectI_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_RectI_TypeF())))
+        return RectI_PythonToCpp_RectI_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *RectI_PTR_CppToPython_RectI(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::RectI *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_RectI_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *RectI_SignatureStrings[] = {
+    "2:NatronEngine.RectI(self)",
+    "1:NatronEngine.RectI(self,b:NatronEngine.RectI)",
+    "0:NatronEngine.RectI(self,x1_:int,y1_:int,x2_:int,y2_:int)",
+    "NatronEngine.RectI.bottom(self)->int",
+    "NatronEngine.RectI.clear(self)",
+    "2:NatronEngine.RectI.contains(self,other:NatronEngine.RectI)->bool",
+    "1:NatronEngine.RectI.contains(self,x:double,y:double)->bool",
+    "0:NatronEngine.RectI.contains(self,x:int,y:int)->bool",
+    "NatronEngine.RectI.height(self)->int",
+    "1:NatronEngine.RectI.intersect(self,r:NatronEngine.RectI,intersection:NatronEngine.RectI)->bool",
+    "0:NatronEngine.RectI.intersect(self,x1_:int,y1_:int,x2_:int,y2_:int,intersection:NatronEngine.RectI)->bool",
+    "1:NatronEngine.RectI.intersects(self,r:NatronEngine.RectI)->bool",
+    "0:NatronEngine.RectI.intersects(self,x1_:int,y1_:int,x2_:int,y2_:int)->bool",
+    "NatronEngine.RectI.isInfinite(self)->bool",
+    "NatronEngine.RectI.isNull(self)->bool",
+    "NatronEngine.RectI.left(self)->int",
+    "1:NatronEngine.RectI.merge(self,box:NatronEngine.RectI)",
+    "0:NatronEngine.RectI.merge(self,x1_:int,y1_:int,x2_:int,y2_:int)",
+    "NatronEngine.RectI.right(self)->int",
+    "1:NatronEngine.RectI.set(self,b:NatronEngine.RectI)",
+    "0:NatronEngine.RectI.set(self,x1_:int,y1_:int,x2_:int,y2_:int)",
+    "NatronEngine.RectI.set_bottom(self,v:int)",
+    "NatronEngine.RectI.set_left(self,v:int)",
+    "NatronEngine.RectI.set_right(self,v:int)",
+    "NatronEngine.RectI.set_top(self,v:int)",
+    "NatronEngine.RectI.top(self)->int",
+    "NatronEngine.RectI.translate(self,dx:int,dy:int)",
+    "NatronEngine.RectI.width(self)->int",
+    nullptr}; // Sentinel
+
+void init_RectI(PyObject *module)
+{
+    _Sbk_RectI_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "RectI",
+        "RectI*",
+        &Sbk_RectI_spec,
+        &Shiboken::callCppDestructor< ::RectI >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_RectI_Type);
+    InitSignatureStrings(pyType, RectI_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_RectI_Type), Sbk_RectI_PropertyStrings);
+    SbkNatronEngineTypes[SBK_RECTI_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_RectI_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_RectI_TypeF(),
+        RectI_PythonToCpp_RectI_PTR,
+        is_RectI_PythonToCpp_RectI_PTR_Convertible,
+        RectI_PTR_CppToPython_RectI);
+
+    Shiboken::Conversions::registerConverterName(converter, "RectI");
+    Shiboken::Conversions::registerConverterName(converter, "RectI*");
+    Shiboken::Conversions::registerConverterName(converter, "RectI&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::RectI).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::RectIWrapper).name());
+
+
+
+    RectIWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/recti_wrapper.h
+++ b/Engine/Qt5/NatronEngine/recti_wrapper.h
@@ -1,0 +1,28 @@
+#ifndef SBK_RECTIWRAPPER_H
+#define SBK_RECTIWRAPPER_H
+
+#include <RectI.h>
+
+
+// Extra includes
+#include <RectI.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class RectIWrapper : public RectI
+{
+public:
+    RectIWrapper();
+    RectIWrapper(const RectI& self) : RectI(self)
+    {
+    }
+
+    RectIWrapper(int x1_, int y1_, int x2_, int y2_);
+    ~RectIWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#endif // SBK_RECTIWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/roto_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/roto_wrapper.cpp
@@ -1,0 +1,532 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "roto_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+// Extra includes
+#include <PyRoto.h>
+
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_RotoFunc_createBezier(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Roto *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ROTO_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createBezier", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Roto::createBezier(double,double,double)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))) {
+        overloadId = 0; // createBezier(double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RotoFunc_createBezier_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // createBezier(double,double,double)
+            // Begin code injection
+            BezierCurve * cppResult = cppSelf->createBezier(cppArg0,cppArg1,cppArg2);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX]), cppResult);
+
+            // End of code injection
+
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_RotoFunc_createBezier_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Roto.createBezier");
+        return {};
+}
+
+static PyObject *Sbk_RotoFunc_createEllipse(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Roto *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ROTO_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createEllipse", 5, 5, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3]), &(pyArgs[4])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Roto::createEllipse(double,double,double,bool,double)
+    if (numArgs == 5
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[3])))
+        && (pythonToCpp[4] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[4])))) {
+        overloadId = 0; // createEllipse(double,double,double,bool,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RotoFunc_createEllipse_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+        bool cppArg3;
+        pythonToCpp[3](pyArgs[3], &cppArg3);
+        double cppArg4;
+        pythonToCpp[4](pyArgs[4], &cppArg4);
+
+        if (!PyErr_Occurred()) {
+            // createEllipse(double,double,double,bool,double)
+            // Begin code injection
+            BezierCurve * cppResult = cppSelf->createEllipse(cppArg0,cppArg1,cppArg2,cppArg3,cppArg4);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX]), cppResult);
+
+            // End of code injection
+
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_RotoFunc_createEllipse_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Roto.createEllipse");
+        return {};
+}
+
+static PyObject *Sbk_RotoFunc_createLayer(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Roto *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ROTO_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // createLayer()
+            // Begin code injection
+            Layer * cppResult = cppSelf->createLayer();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_LAYER_IDX]), cppResult);
+
+            // End of code injection
+
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RotoFunc_createRectangle(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Roto *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ROTO_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createRectangle", 4, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Roto::createRectangle(double,double,double,double)
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[3])))) {
+        overloadId = 0; // createRectangle(double,double,double,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RotoFunc_createRectangle_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        double cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+        double cppArg3;
+        pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // createRectangle(double,double,double,double)
+            // Begin code injection
+            BezierCurve * cppResult = cppSelf->createRectangle(cppArg0,cppArg1,cppArg2,cppArg3);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_BEZIERCURVE_IDX]), cppResult);
+
+            // End of code injection
+
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_RotoFunc_createRectangle_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Roto.createRectangle");
+        return {};
+}
+
+static PyObject *Sbk_RotoFunc_getBaseLayer(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Roto *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ROTO_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getBaseLayer()const
+            Layer * cppResult = const_cast<const ::Roto *>(cppSelf)->getBaseLayer();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_LAYER_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_RotoFunc_getItemByName(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Roto *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_ROTO_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Roto::getItemByName(QString)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // getItemByName(QString)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_RotoFunc_getItemByName_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getItemByName(QString)const
+            ItemBase * cppResult = const_cast<const ::Roto *>(cppSelf)->getItemByName(cppArg0);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_ITEMBASE_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_RotoFunc_getItemByName_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Roto.getItemByName");
+        return {};
+}
+
+
+static const char *Sbk_Roto_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_Roto_methods[] = {
+    {"createBezier", reinterpret_cast<PyCFunction>(Sbk_RotoFunc_createBezier), METH_VARARGS},
+    {"createEllipse", reinterpret_cast<PyCFunction>(Sbk_RotoFunc_createEllipse), METH_VARARGS},
+    {"createLayer", reinterpret_cast<PyCFunction>(Sbk_RotoFunc_createLayer), METH_NOARGS},
+    {"createRectangle", reinterpret_cast<PyCFunction>(Sbk_RotoFunc_createRectangle), METH_VARARGS},
+    {"getBaseLayer", reinterpret_cast<PyCFunction>(Sbk_RotoFunc_getBaseLayer), METH_NOARGS},
+    {"getItemByName", reinterpret_cast<PyCFunction>(Sbk_RotoFunc_getItemByName), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+} // extern "C"
+
+static int Sbk_Roto_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_Roto_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_Roto_Type = nullptr;
+static SbkObjectType *Sbk_Roto_TypeF(void)
+{
+    return _Sbk_Roto_Type;
+}
+
+static PyType_Slot Sbk_Roto_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    nullptr},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_Roto_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_Roto_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_Roto_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_Roto_spec = {
+    "1:NatronEngine.Roto",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_Roto_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void Roto_PythonToCpp_Roto_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_Roto_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_Roto_PythonToCpp_Roto_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_Roto_TypeF())))
+        return Roto_PythonToCpp_Roto_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *Roto_PTR_CppToPython_Roto(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::Roto *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_Roto_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *Roto_SignatureStrings[] = {
+    "NatronEngine.Roto.createBezier(self,x:double,y:double,time:double)->NatronEngine.BezierCurve",
+    "NatronEngine.Roto.createEllipse(self,x:double,y:double,diameter:double,fromCenter:bool,time:double)->NatronEngine.BezierCurve",
+    "NatronEngine.Roto.createLayer(self)->NatronEngine.Layer",
+    "NatronEngine.Roto.createRectangle(self,x:double,y:double,size:double,time:double)->NatronEngine.BezierCurve",
+    "NatronEngine.Roto.getBaseLayer(self)->NatronEngine.Layer",
+    "NatronEngine.Roto.getItemByName(self,name:QString)->NatronEngine.ItemBase",
+    nullptr}; // Sentinel
+
+void init_Roto(PyObject *module)
+{
+    _Sbk_Roto_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "Roto",
+        "Roto*",
+        &Sbk_Roto_spec,
+        &Shiboken::callCppDestructor< ::Roto >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_Roto_Type);
+    InitSignatureStrings(pyType, Roto_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_Roto_Type), Sbk_Roto_PropertyStrings);
+    SbkNatronEngineTypes[SBK_ROTO_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_Roto_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_Roto_TypeF(),
+        Roto_PythonToCpp_Roto_PTR,
+        is_Roto_PythonToCpp_Roto_PTR_Convertible,
+        Roto_PTR_CppToPython_Roto);
+
+    Shiboken::Conversions::registerConverterName(converter, "Roto");
+    Shiboken::Conversions::registerConverterName(converter, "Roto*");
+    Shiboken::Conversions::registerConverterName(converter, "Roto&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Roto).name());
+
+
+
+}

--- a/Engine/Qt5/NatronEngine/roto_wrapper.h
+++ b/Engine/Qt5/NatronEngine/roto_wrapper.h
@@ -1,0 +1,7 @@
+#ifndef SBK_ROTO_H
+#define SBK_ROTO_H
+
+#include <PyRoto.h>
+
+#endif // SBK_ROTO_H
+

--- a/Engine/Qt5/NatronEngine/separatorparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/separatorparam_wrapper.cpp
@@ -1,0 +1,239 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "separatorparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void SeparatorParamWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void SeparatorParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+SeparatorParamWrapper::~SeparatorParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+
+static const char *Sbk_SeparatorParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_SeparatorParam_methods[] = {
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_SeparatorParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::SeparatorParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_SEPARATORPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<SeparatorParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_SeparatorParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_SeparatorParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_SeparatorParam_Type = nullptr;
+static SbkObjectType *Sbk_SeparatorParam_TypeF(void)
+{
+    return _Sbk_SeparatorParam_Type;
+}
+
+static PyType_Slot Sbk_SeparatorParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_SeparatorParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_SeparatorParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_SeparatorParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_SeparatorParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_SeparatorParam_spec = {
+    "1:NatronEngine.SeparatorParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_SeparatorParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_SeparatorParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::SeparatorParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void SeparatorParam_PythonToCpp_SeparatorParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_SeparatorParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_SeparatorParam_PythonToCpp_SeparatorParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_SeparatorParam_TypeF())))
+        return SeparatorParam_PythonToCpp_SeparatorParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *SeparatorParam_PTR_CppToPython_SeparatorParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::SeparatorParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_SeparatorParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *SeparatorParam_SignatureStrings[] = {
+    nullptr}; // Sentinel
+
+void init_SeparatorParam(PyObject *module)
+{
+    _Sbk_SeparatorParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "SeparatorParam",
+        "SeparatorParam*",
+        &Sbk_SeparatorParam_spec,
+        &Shiboken::callCppDestructor< ::SeparatorParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_SeparatorParam_Type);
+    InitSignatureStrings(pyType, SeparatorParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_SeparatorParam_Type), Sbk_SeparatorParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_SEPARATORPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_SeparatorParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_SeparatorParam_TypeF(),
+        SeparatorParam_PythonToCpp_SeparatorParam_PTR,
+        is_SeparatorParam_PythonToCpp_SeparatorParam_PTR_Convertible,
+        SeparatorParam_PTR_CppToPython_SeparatorParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "SeparatorParam");
+    Shiboken::Conversions::registerConverterName(converter, "SeparatorParam*");
+    Shiboken::Conversions::registerConverterName(converter, "SeparatorParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::SeparatorParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::SeparatorParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_SeparatorParam_TypeF(), &Sbk_SeparatorParam_typeDiscovery);
+
+
+    SeparatorParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/separatorparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/separatorparam_wrapper.h
@@ -1,0 +1,42 @@
+#ifndef SBK_SEPARATORPARAMWRAPPER_H
+#define SBK_SEPARATORPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class SeparatorParamWrapper : public SeparatorParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { SeparatorParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~SeparatorParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_SEPARATORPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/stringnodecreationproperty_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/stringnodecreationproperty_wrapper.cpp
@@ -1,0 +1,467 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "stringnodecreationproperty_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void StringNodeCreationPropertyWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void StringNodeCreationPropertyWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+StringNodeCreationPropertyWrapper::StringNodeCreationPropertyWrapper(const std::string & value) : StringNodeCreationProperty(value)
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+StringNodeCreationPropertyWrapper::StringNodeCreationPropertyWrapper(const std::vector<std::string > & values) : StringNodeCreationProperty(values)
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+StringNodeCreationPropertyWrapper::~StringNodeCreationPropertyWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_StringNodeCreationProperty_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::StringNodeCreationProperty >()))
+        return -1;
+
+    ::StringNodeCreationPropertyWrapper *cptr{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.StringNodeCreationProperty(): too many arguments");
+        return -1;
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:StringNodeCreationProperty", &(pyArgs[0])))
+        return -1;
+
+
+    // Overloaded function decisor
+    // 0: StringNodeCreationProperty::StringNodeCreationProperty(std::string)
+    // 1: StringNodeCreationProperty::StringNodeCreationProperty(std::vector<std::string>)
+    if (numArgs == 0) {
+        overloadId = 1; // StringNodeCreationProperty(std::vector<std::string>)
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<std::string>(), (pyArgs[0])))) {
+        overloadId = 0; // StringNodeCreationProperty(std::string)
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_STD_STRING_IDX], (pyArgs[0])))) {
+        overloadId = 1; // StringNodeCreationProperty(std::vector<std::string>)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_StringNodeCreationProperty_Init_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // StringNodeCreationProperty(const std::string & value)
+        {
+            ::std::string cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // StringNodeCreationProperty(std::string)
+                cptr = new ::StringNodeCreationPropertyWrapper(cppArg0);
+            }
+            break;
+        }
+        case 1: // StringNodeCreationProperty(const std::vector<std::string > & values)
+        {
+            if (kwds) {
+                PyObject *keyName = nullptr;
+                PyObject *value = nullptr;
+                keyName = Py_BuildValue("s","values");
+                if (PyDict_Contains(kwds, keyName)) {
+                    value = PyDict_GetItem(kwds, keyName);
+                    if (value && pyArgs[0]) {
+                        PyErr_SetString(PyExc_TypeError, "NatronEngine.StringNodeCreationProperty(): got multiple values for keyword argument 'values'.");
+                        return -1;
+                    }
+                    if (value) {
+                        pyArgs[0] = value;
+                        if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_STD_STRING_IDX], (pyArgs[0]))))
+                            goto Sbk_StringNodeCreationProperty_Init_TypeError;
+                    }
+                }
+            }
+            ::std::vector<std::string > cppArg0;
+            if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // StringNodeCreationProperty(std::vector<std::string>)
+                cptr = new ::StringNodeCreationPropertyWrapper(cppArg0);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::StringNodeCreationProperty >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    if (!cptr) goto Sbk_StringNodeCreationProperty_Init_TypeError;
+
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    Shiboken::Object::setHasCppWrapper(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+
+    Sbk_StringNodeCreationProperty_Init_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.StringNodeCreationProperty");
+        return -1;
+}
+
+static PyObject *Sbk_StringNodeCreationPropertyFunc_getValues(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::StringNodeCreationProperty *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_STRINGNODECREATIONPROPERTY_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getValues()const
+            const std::vector<std::string > & cppResult = const_cast<const ::StringNodeCreationProperty *>(cppSelf)->getValues();
+            pyResult = Shiboken::Conversions::copyToPython(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_VECTOR_STD_STRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_StringNodeCreationPropertyFunc_setValue(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::StringNodeCreationProperty *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_STRINGNODECREATIONPROPERTY_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.StringNodeCreationProperty.setValue(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronEngine.StringNodeCreationProperty.setValue(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:setValue", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: StringNodeCreationProperty::setValue(std::string,int)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<std::string>(), (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // setValue(std::string,int)
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+            overloadId = 0; // setValue(std::string,int)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_StringNodeCreationPropertyFunc_setValue_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","index");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronEngine.StringNodeCreationProperty.setValue(): got multiple values for keyword argument 'index'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1]))))
+                        goto Sbk_StringNodeCreationPropertyFunc_setValue_TypeError;
+                }
+            }
+        }
+        ::std::string cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1 = 0;
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setValue(std::string,int)
+            cppSelf->setValue(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_StringNodeCreationPropertyFunc_setValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.StringNodeCreationProperty.setValue");
+        return {};
+}
+
+
+static const char *Sbk_StringNodeCreationProperty_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_StringNodeCreationProperty_methods[] = {
+    {"getValues", reinterpret_cast<PyCFunction>(Sbk_StringNodeCreationPropertyFunc_getValues), METH_NOARGS},
+    {"setValue", reinterpret_cast<PyCFunction>(Sbk_StringNodeCreationPropertyFunc_setValue), METH_VARARGS|METH_KEYWORDS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_StringNodeCreationProperty_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::StringNodeCreationProperty *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_STRINGNODECREATIONPROPERTY_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<StringNodeCreationPropertyWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_StringNodeCreationProperty_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_StringNodeCreationProperty_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_StringNodeCreationProperty_Type = nullptr;
+static SbkObjectType *Sbk_StringNodeCreationProperty_TypeF(void)
+{
+    return _Sbk_StringNodeCreationProperty_Type;
+}
+
+static PyType_Slot Sbk_StringNodeCreationProperty_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_StringNodeCreationProperty_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_StringNodeCreationProperty_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_StringNodeCreationProperty_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_StringNodeCreationProperty_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_StringNodeCreationProperty_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_StringNodeCreationProperty_spec = {
+    "1:NatronEngine.StringNodeCreationProperty",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_StringNodeCreationProperty_slots
+};
+
+} //extern "C"
+
+static void *Sbk_StringNodeCreationProperty_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::NodeCreationProperty >()))
+        return dynamic_cast< ::StringNodeCreationProperty *>(reinterpret_cast< ::NodeCreationProperty *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void StringNodeCreationProperty_PythonToCpp_StringNodeCreationProperty_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_StringNodeCreationProperty_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_StringNodeCreationProperty_PythonToCpp_StringNodeCreationProperty_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_StringNodeCreationProperty_TypeF())))
+        return StringNodeCreationProperty_PythonToCpp_StringNodeCreationProperty_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *StringNodeCreationProperty_PTR_CppToPython_StringNodeCreationProperty(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::StringNodeCreationProperty *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_StringNodeCreationProperty_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *StringNodeCreationProperty_SignatureStrings[] = {
+    "1:NatronEngine.StringNodeCreationProperty(self,value:std.string)",
+    "0:NatronEngine.StringNodeCreationProperty(self,values:std.vector[std.string]=std.vector< std.string >())",
+    "NatronEngine.StringNodeCreationProperty.getValues(self)->std.vector[std.string]",
+    "NatronEngine.StringNodeCreationProperty.setValue(self,value:std.string,index:int=0)",
+    nullptr}; // Sentinel
+
+void init_StringNodeCreationProperty(PyObject *module)
+{
+    _Sbk_StringNodeCreationProperty_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "StringNodeCreationProperty",
+        "StringNodeCreationProperty*",
+        &Sbk_StringNodeCreationProperty_spec,
+        &Shiboken::callCppDestructor< ::StringNodeCreationProperty >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_NODECREATIONPROPERTY_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_StringNodeCreationProperty_Type);
+    InitSignatureStrings(pyType, StringNodeCreationProperty_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_StringNodeCreationProperty_Type), Sbk_StringNodeCreationProperty_PropertyStrings);
+    SbkNatronEngineTypes[SBK_STRINGNODECREATIONPROPERTY_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_StringNodeCreationProperty_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_StringNodeCreationProperty_TypeF(),
+        StringNodeCreationProperty_PythonToCpp_StringNodeCreationProperty_PTR,
+        is_StringNodeCreationProperty_PythonToCpp_StringNodeCreationProperty_PTR_Convertible,
+        StringNodeCreationProperty_PTR_CppToPython_StringNodeCreationProperty);
+
+    Shiboken::Conversions::registerConverterName(converter, "StringNodeCreationProperty");
+    Shiboken::Conversions::registerConverterName(converter, "StringNodeCreationProperty*");
+    Shiboken::Conversions::registerConverterName(converter, "StringNodeCreationProperty&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::StringNodeCreationProperty).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::StringNodeCreationPropertyWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_StringNodeCreationProperty_TypeF(), &Sbk_StringNodeCreationProperty_typeDiscovery);
+
+
+    StringNodeCreationPropertyWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/stringnodecreationproperty_wrapper.h
+++ b/Engine/Qt5/NatronEngine/stringnodecreationproperty_wrapper.h
@@ -1,0 +1,43 @@
+#ifndef SBK_STRINGNODECREATIONPROPERTYWRAPPER_H
+#define SBK_STRINGNODECREATIONPROPERTYWRAPPER_H
+
+#include <PyAppInstance.h>
+
+
+// Extra includes
+#include <vector>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class StringNodeCreationPropertyWrapper : public StringNodeCreationProperty
+{
+public:
+    StringNodeCreationPropertyWrapper(const std::string & value);
+    StringNodeCreationPropertyWrapper(const std::vector<std::string > & values = std::vector< std::string >());
+    ~StringNodeCreationPropertyWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_NODECREATIONPROPERTYWRAPPER_H
+#  define SBK_NODECREATIONPROPERTYWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class NodeCreationPropertyWrapper : public NodeCreationProperty
+{
+public:
+    NodeCreationPropertyWrapper();
+    ~NodeCreationPropertyWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_NODECREATIONPROPERTYWRAPPER_H
+
+#endif // SBK_STRINGNODECREATIONPROPERTYWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/stringparam_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/stringparam_wrapper.cpp
@@ -1,0 +1,337 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "stringparam_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void StringParamWrapper::pysideInitQtMetaTypes()
+{
+    qRegisterMetaType< ::StringParam::TypeEnum >("StringParam::TypeEnum");
+}
+
+void StringParamWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+StringParamWrapper::~StringParamWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_StringParamFunc_setType(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::StringParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_STRINGPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: StringParam::setType(StringParam::TypeEnum)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(*PepType_SGTP(SbkNatronEngineTypes[SBK_STRINGPARAM_TYPEENUM_IDX])->converter, (pyArg)))) {
+        overloadId = 0; // setType(StringParam::TypeEnum)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_StringParamFunc_setType_TypeError;
+
+    // Call function/method
+    {
+        ::StringParam::TypeEnum cppArg0{StringParam::eStringTypeLabel};
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setType(StringParam::TypeEnum)
+            cppSelf->setType(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_StringParamFunc_setType_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.StringParam.setType");
+        return {};
+}
+
+
+static const char *Sbk_StringParam_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_StringParam_methods[] = {
+    {"setType", reinterpret_cast<PyCFunction>(Sbk_StringParamFunc_setType), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_StringParam_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::StringParam *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_STRINGPARAM_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<StringParamWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_StringParam_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_StringParam_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_StringParam_Type = nullptr;
+static SbkObjectType *Sbk_StringParam_TypeF(void)
+{
+    return _Sbk_StringParam_Type;
+}
+
+static PyType_Slot Sbk_StringParam_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_StringParam_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_StringParam_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_StringParam_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_StringParam_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_StringParam_spec = {
+    "1:NatronEngine.StringParam",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_StringParam_slots
+};
+
+} //extern "C"
+
+static void *Sbk_StringParam_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::StringParam *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ enum conversion.
+static void StringParam_TypeEnum_PythonToCpp_StringParam_TypeEnum(PyObject *pyIn, void *cppOut) {
+    *reinterpret_cast<::StringParam::TypeEnum *>(cppOut) =
+        static_cast<::StringParam::TypeEnum>(Shiboken::Enum::getValue(pyIn));
+
+}
+static PythonToCppFunc is_StringParam_TypeEnum_PythonToCpp_StringParam_TypeEnum_Convertible(PyObject *pyIn) {
+    if (PyObject_TypeCheck(pyIn, SbkNatronEngineTypes[SBK_STRINGPARAM_TYPEENUM_IDX]))
+        return StringParam_TypeEnum_PythonToCpp_StringParam_TypeEnum;
+    return {};
+}
+static PyObject *StringParam_TypeEnum_CppToPython_StringParam_TypeEnum(const void *cppIn) {
+    const int castCppIn = int(*reinterpret_cast<const ::StringParam::TypeEnum *>(cppIn));
+    return Shiboken::Enum::newItem(SbkNatronEngineTypes[SBK_STRINGPARAM_TYPEENUM_IDX], castCppIn);
+
+}
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void StringParam_PythonToCpp_StringParam_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_StringParam_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_StringParam_PythonToCpp_StringParam_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_StringParam_TypeF())))
+        return StringParam_PythonToCpp_StringParam_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *StringParam_PTR_CppToPython_StringParam(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::StringParam *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_StringParam_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *StringParam_SignatureStrings[] = {
+    "NatronEngine.StringParam.setType(self,type:NatronEngine.StringParam.TypeEnum)",
+    nullptr}; // Sentinel
+
+void init_StringParam(PyObject *module)
+{
+    _Sbk_StringParam_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "StringParam",
+        "StringParam*",
+        &Sbk_StringParam_spec,
+        &Shiboken::callCppDestructor< ::StringParam >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_StringParam_Type);
+    InitSignatureStrings(pyType, StringParam_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_StringParam_Type), Sbk_StringParam_PropertyStrings);
+    SbkNatronEngineTypes[SBK_STRINGPARAM_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_StringParam_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_StringParam_TypeF(),
+        StringParam_PythonToCpp_StringParam_PTR,
+        is_StringParam_PythonToCpp_StringParam_PTR_Convertible,
+        StringParam_PTR_CppToPython_StringParam);
+
+    Shiboken::Conversions::registerConverterName(converter, "StringParam");
+    Shiboken::Conversions::registerConverterName(converter, "StringParam*");
+    Shiboken::Conversions::registerConverterName(converter, "StringParam&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::StringParam).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::StringParamWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_StringParam_TypeF(), &Sbk_StringParam_typeDiscovery);
+
+    // Initialization of enums.
+
+    // Initialization of enum 'TypeEnum'.
+    SbkNatronEngineTypes[SBK_STRINGPARAM_TYPEENUM_IDX] = Shiboken::Enum::createScopedEnum(Sbk_StringParam_TypeF(),
+        "TypeEnum",
+        "1:NatronEngine.StringParam.TypeEnum",
+        "StringParam::TypeEnum");
+    if (!SbkNatronEngineTypes[SBK_STRINGPARAM_TYPEENUM_IDX])
+        return;
+
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_STRINGPARAM_TYPEENUM_IDX],
+        Sbk_StringParam_TypeF(), "eStringTypeLabel", (long) StringParam::TypeEnum::eStringTypeLabel))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_STRINGPARAM_TYPEENUM_IDX],
+        Sbk_StringParam_TypeF(), "eStringTypeMultiLine", (long) StringParam::TypeEnum::eStringTypeMultiLine))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_STRINGPARAM_TYPEENUM_IDX],
+        Sbk_StringParam_TypeF(), "eStringTypeRichTextMultiLine", (long) StringParam::TypeEnum::eStringTypeRichTextMultiLine))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_STRINGPARAM_TYPEENUM_IDX],
+        Sbk_StringParam_TypeF(), "eStringTypeCustom", (long) StringParam::TypeEnum::eStringTypeCustom))
+        return;
+    if (!Shiboken::Enum::createScopedEnumItem(SbkNatronEngineTypes[SBK_STRINGPARAM_TYPEENUM_IDX],
+        Sbk_StringParam_TypeF(), "eStringTypeDefault", (long) StringParam::TypeEnum::eStringTypeDefault))
+        return;
+    // Register converter for enum 'StringParam::TypeEnum'.
+    {
+        SbkConverter *converter = Shiboken::Conversions::createConverter(SbkNatronEngineTypes[SBK_STRINGPARAM_TYPEENUM_IDX],
+            StringParam_TypeEnum_CppToPython_StringParam_TypeEnum);
+        Shiboken::Conversions::addPythonToCppValueConversion(converter,
+            StringParam_TypeEnum_PythonToCpp_StringParam_TypeEnum,
+            is_StringParam_TypeEnum_PythonToCpp_StringParam_TypeEnum_Convertible);
+        Shiboken::Enum::setTypeConverter(SbkNatronEngineTypes[SBK_STRINGPARAM_TYPEENUM_IDX], converter);
+        Shiboken::Conversions::registerConverterName(converter, "StringParam::TypeEnum");
+        Shiboken::Conversions::registerConverterName(converter, "TypeEnum");
+    }
+    // End of 'TypeEnum' enum.
+
+
+    StringParamWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/stringparam_wrapper.h
+++ b/Engine/Qt5/NatronEngine/stringparam_wrapper.h
@@ -1,0 +1,78 @@
+#ifndef SBK_STRINGPARAMWRAPPER_H
+#define SBK_STRINGPARAMWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class StringParamWrapper : public StringParam
+{
+public:
+    ~StringParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_STRINGPARAMBASEWRAPPER_H
+#  define SBK_STRINGPARAMBASEWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class StringParamBaseWrapper : public StringParamBase
+{
+public:
+    ~StringParamBaseWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_STRINGPARAMBASEWRAPPER_H
+
+#  ifndef SBK_ANIMATEDPARAMWRAPPER_H
+#  define SBK_ANIMATEDPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AnimatedParamWrapper : public AnimatedParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { AnimatedParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~AnimatedParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_ANIMATEDPARAMWRAPPER_H
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_STRINGPARAMWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/stringparambase_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/stringparambase_wrapper.cpp
@@ -1,0 +1,716 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "stringparambase_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void StringParamBaseWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void StringParamBaseWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+StringParamBaseWrapper::~StringParamBaseWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_StringParamBaseFunc_addAsDependencyOf(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::StringParamBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "addAsDependencyOf", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: StringParamBase::addAsDependencyOf(int,Param*,int)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+        overloadId = 0; // addAsDependencyOf(int,Param*,int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_StringParamBaseFunc_addAsDependencyOf_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        if (!Shiboken::Object::isValid(pyArgs[1]))
+            return {};
+        ::Param *cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        int cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // addAsDependencyOf(int,Param*,int)
+            QString cppResult = cppSelf->addAsDependencyOf(cppArg0, cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_StringParamBaseFunc_addAsDependencyOf_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.StringParamBase.addAsDependencyOf");
+        return {};
+}
+
+static PyObject *Sbk_StringParamBaseFunc_get(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::StringParamBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "get", 0, 1, &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: StringParamBase::get()const
+    // 1: StringParamBase::get(double)const
+    if (numArgs == 0) {
+        overloadId = 0; // get()const
+    } else if (numArgs == 1
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[0])))) {
+        overloadId = 1; // get(double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_StringParamBaseFunc_get_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // get() const
+        {
+
+            if (!PyErr_Occurred()) {
+                // get()const
+                QString cppResult = const_cast<const ::StringParamBase *>(cppSelf)->get();
+                pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+            }
+            break;
+        }
+        case 1: // get(double frame) const
+        {
+            double cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // get(double)const
+                QString cppResult = const_cast<const ::StringParamBase *>(cppSelf)->get(cppArg0);
+                pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_StringParamBaseFunc_get_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.StringParamBase.get");
+        return {};
+}
+
+static PyObject *Sbk_StringParamBaseFunc_getDefaultValue(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::StringParamBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getDefaultValue()const
+            QString cppResult = const_cast<const ::StringParamBase *>(cppSelf)->getDefaultValue();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_StringParamBaseFunc_getValue(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::StringParamBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getValue()const
+            QString cppResult = const_cast<const ::StringParamBase *>(cppSelf)->getValue();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_StringParamBaseFunc_getValueAtTime(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::StringParamBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: StringParamBase::getValueAtTime(double)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArg)))) {
+        overloadId = 0; // getValueAtTime(double)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_StringParamBaseFunc_getValueAtTime_TypeError;
+
+    // Call function/method
+    {
+        double cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getValueAtTime(double)const
+            QString cppResult = const_cast<const ::StringParamBase *>(cppSelf)->getValueAtTime(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_StringParamBaseFunc_getValueAtTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.StringParamBase.getValueAtTime");
+        return {};
+}
+
+static PyObject *Sbk_StringParamBaseFunc_restoreDefaultValue(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::StringParamBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // restoreDefaultValue()
+            cppSelf->restoreDefaultValue();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_StringParamBaseFunc_set(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::StringParamBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "set", 1, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: StringParamBase::set(QString)
+    // 1: StringParamBase::set(QString,double)
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // set(QString)
+        } else if (numArgs == 2
+            && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+            overloadId = 1; // set(QString,double)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_StringParamBaseFunc_set_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // set(const QString & x)
+        {
+            ::QString cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // set(QString)
+                cppSelf->set(cppArg0);
+            }
+            break;
+        }
+        case 1: // set(const QString & x, double frame)
+        {
+            ::QString cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            double cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+
+            if (!PyErr_Occurred()) {
+                // set(QString,double)
+                cppSelf->set(cppArg0, cppArg1);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_StringParamBaseFunc_set_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.StringParamBase.set");
+        return {};
+}
+
+static PyObject *Sbk_StringParamBaseFunc_setDefaultValue(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::StringParamBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: StringParamBase::setDefaultValue(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setDefaultValue(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_StringParamBaseFunc_setDefaultValue_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setDefaultValue(QString)
+            cppSelf->setDefaultValue(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_StringParamBaseFunc_setDefaultValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.StringParamBase.setDefaultValue");
+        return {};
+}
+
+static PyObject *Sbk_StringParamBaseFunc_setValue(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::StringParamBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: StringParamBase::setValue(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setValue(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_StringParamBaseFunc_setValue_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setValue(QString)
+            cppSelf->setValue(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_StringParamBaseFunc_setValue_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.StringParamBase.setValue");
+        return {};
+}
+
+static PyObject *Sbk_StringParamBaseFunc_setValueAtTime(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::StringParamBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setValueAtTime", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: StringParamBase::setValueAtTime(QString,double)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<double>(), (pyArgs[1])))) {
+        overloadId = 0; // setValueAtTime(QString,double)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_StringParamBaseFunc_setValueAtTime_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        double cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setValueAtTime(QString,double)
+            cppSelf->setValueAtTime(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_StringParamBaseFunc_setValueAtTime_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.StringParamBase.setValueAtTime");
+        return {};
+}
+
+
+static const char *Sbk_StringParamBase_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_StringParamBase_methods[] = {
+    {"addAsDependencyOf", reinterpret_cast<PyCFunction>(Sbk_StringParamBaseFunc_addAsDependencyOf), METH_VARARGS},
+    {"get", reinterpret_cast<PyCFunction>(Sbk_StringParamBaseFunc_get), METH_VARARGS},
+    {"getDefaultValue", reinterpret_cast<PyCFunction>(Sbk_StringParamBaseFunc_getDefaultValue), METH_NOARGS},
+    {"getValue", reinterpret_cast<PyCFunction>(Sbk_StringParamBaseFunc_getValue), METH_NOARGS},
+    {"getValueAtTime", reinterpret_cast<PyCFunction>(Sbk_StringParamBaseFunc_getValueAtTime), METH_O},
+    {"restoreDefaultValue", reinterpret_cast<PyCFunction>(Sbk_StringParamBaseFunc_restoreDefaultValue), METH_NOARGS},
+    {"set", reinterpret_cast<PyCFunction>(Sbk_StringParamBaseFunc_set), METH_VARARGS},
+    {"setDefaultValue", reinterpret_cast<PyCFunction>(Sbk_StringParamBaseFunc_setDefaultValue), METH_O},
+    {"setValue", reinterpret_cast<PyCFunction>(Sbk_StringParamBaseFunc_setValue), METH_O},
+    {"setValueAtTime", reinterpret_cast<PyCFunction>(Sbk_StringParamBaseFunc_setValueAtTime), METH_VARARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_StringParamBase_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::StringParamBase *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<StringParamBaseWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_StringParamBase_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_StringParamBase_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_StringParamBase_Type = nullptr;
+static SbkObjectType *Sbk_StringParamBase_TypeF(void)
+{
+    return _Sbk_StringParamBase_Type;
+}
+
+static PyType_Slot Sbk_StringParamBase_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_StringParamBase_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_StringParamBase_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_StringParamBase_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_StringParamBase_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_StringParamBase_spec = {
+    "1:NatronEngine.StringParamBase",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_StringParamBase_slots
+};
+
+} //extern "C"
+
+static void *Sbk_StringParamBase_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Param >()))
+        return dynamic_cast< ::StringParamBase *>(reinterpret_cast< ::Param *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void StringParamBase_PythonToCpp_StringParamBase_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_StringParamBase_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_StringParamBase_PythonToCpp_StringParamBase_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_StringParamBase_TypeF())))
+        return StringParamBase_PythonToCpp_StringParamBase_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *StringParamBase_PTR_CppToPython_StringParamBase(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::StringParamBase *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_StringParamBase_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *StringParamBase_SignatureStrings[] = {
+    "NatronEngine.StringParamBase.addAsDependencyOf(self,fromExprDimension:int,param:NatronEngine.Param,thisDimension:int)->QString",
+    "1:NatronEngine.StringParamBase.get(self)->QString",
+    "0:NatronEngine.StringParamBase.get(self,frame:double)->QString",
+    "NatronEngine.StringParamBase.getDefaultValue(self)->QString",
+    "NatronEngine.StringParamBase.getValue(self)->QString",
+    "NatronEngine.StringParamBase.getValueAtTime(self,time:double)->QString",
+    "NatronEngine.StringParamBase.restoreDefaultValue(self)",
+    "1:NatronEngine.StringParamBase.set(self,x:QString)",
+    "0:NatronEngine.StringParamBase.set(self,x:QString,frame:double)",
+    "NatronEngine.StringParamBase.setDefaultValue(self,value:QString)",
+    "NatronEngine.StringParamBase.setValue(self,value:QString)",
+    "NatronEngine.StringParamBase.setValueAtTime(self,value:QString,time:double)",
+    nullptr}; // Sentinel
+
+void init_StringParamBase(PyObject *module)
+{
+    _Sbk_StringParamBase_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "StringParamBase",
+        "StringParamBase*",
+        &Sbk_StringParamBase_spec,
+        &Shiboken::callCppDestructor< ::StringParamBase >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_ANIMATEDPARAM_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_StringParamBase_Type);
+    InitSignatureStrings(pyType, StringParamBase_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_StringParamBase_Type), Sbk_StringParamBase_PropertyStrings);
+    SbkNatronEngineTypes[SBK_STRINGPARAMBASE_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_StringParamBase_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_StringParamBase_TypeF(),
+        StringParamBase_PythonToCpp_StringParamBase_PTR,
+        is_StringParamBase_PythonToCpp_StringParamBase_PTR_Convertible,
+        StringParamBase_PTR_CppToPython_StringParamBase);
+
+    Shiboken::Conversions::registerConverterName(converter, "StringParamBase");
+    Shiboken::Conversions::registerConverterName(converter, "StringParamBase*");
+    Shiboken::Conversions::registerConverterName(converter, "StringParamBase&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::StringParamBase).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::StringParamBaseWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_StringParamBase_TypeF(), &Sbk_StringParamBase_typeDiscovery);
+
+
+    StringParamBaseWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/stringparambase_wrapper.h
+++ b/Engine/Qt5/NatronEngine/stringparambase_wrapper.h
@@ -1,0 +1,60 @@
+#ifndef SBK_STRINGPARAMBASEWRAPPER_H
+#define SBK_STRINGPARAMBASEWRAPPER_H
+
+#include <PyParameter.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class StringParamBaseWrapper : public StringParamBase
+{
+public:
+    ~StringParamBaseWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_ANIMATEDPARAMWRAPPER_H
+#  define SBK_ANIMATEDPARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AnimatedParamWrapper : public AnimatedParam
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { AnimatedParam::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~AnimatedParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_ANIMATEDPARAMWRAPPER_H
+
+#  ifndef SBK_PARAMWRAPPER_H
+#  define SBK_PARAMWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class ParamWrapper : public Param
+{
+public:
+    inline void _addAsDependencyOf_protected(int fromExprDimension, Param * param, int thisDimension) { Param::_addAsDependencyOf(fromExprDimension, param, thisDimension); }
+    ~ParamWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PARAMWRAPPER_H
+
+#endif // SBK_STRINGPARAMBASEWRAPPER_H
+

--- a/Engine/Qt5/NatronEngine/track_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/track_wrapper.cpp
@@ -1,0 +1,385 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "track_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+// Extra includes
+#include <PyParameter.h>
+#include <list>
+
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_TrackFunc_getParam(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Track *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_TRACK_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Track::getParam(QString)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // getParam(QString)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_TrackFunc_getParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getParam(QString)const
+            Param * cppResult = const_cast<const ::Track *>(cppSelf)->getParam(cppArg0);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_TrackFunc_getParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Track.getParam");
+        return {};
+}
+
+static PyObject *Sbk_TrackFunc_getParams(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Track *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_TRACK_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getParams()const
+            // Begin code injection
+            std::list<Param*> params = cppSelf->getParams();
+            PyObject* ret = PyList_New((int) params.size());
+            int idx = 0;
+            for (std::list<Param*>::iterator it = params.begin(); it!=params.end(); ++it,++idx) {
+            PyObject* item = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), *it);
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(item);
+            PyList_SET_ITEM(ret, idx, item);
+            }
+            return ret;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_TrackFunc_getScriptName(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Track *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_TRACK_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getScriptName()const
+            QString cppResult = const_cast<const ::Track *>(cppSelf)->getScriptName();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_TrackFunc_reset(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Track *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_TRACK_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // reset()
+            cppSelf->reset();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_TrackFunc_setScriptName(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Track *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_TRACK_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Track::setScriptName(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setScriptName(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_TrackFunc_setScriptName_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setScriptName(QString)
+            cppSelf->setScriptName(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_TrackFunc_setScriptName_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Track.setScriptName");
+        return {};
+}
+
+
+static const char *Sbk_Track_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_Track_methods[] = {
+    {"getParam", reinterpret_cast<PyCFunction>(Sbk_TrackFunc_getParam), METH_O},
+    {"getParams", reinterpret_cast<PyCFunction>(Sbk_TrackFunc_getParams), METH_NOARGS},
+    {"getScriptName", reinterpret_cast<PyCFunction>(Sbk_TrackFunc_getScriptName), METH_NOARGS},
+    {"reset", reinterpret_cast<PyCFunction>(Sbk_TrackFunc_reset), METH_NOARGS},
+    {"setScriptName", reinterpret_cast<PyCFunction>(Sbk_TrackFunc_setScriptName), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+} // extern "C"
+
+static int Sbk_Track_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_Track_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_Track_Type = nullptr;
+static SbkObjectType *Sbk_Track_TypeF(void)
+{
+    return _Sbk_Track_Type;
+}
+
+static PyType_Slot Sbk_Track_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    nullptr},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_Track_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_Track_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_Track_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_Track_spec = {
+    "1:NatronEngine.Track",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_Track_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void Track_PythonToCpp_Track_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_Track_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_Track_PythonToCpp_Track_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_Track_TypeF())))
+        return Track_PythonToCpp_Track_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *Track_PTR_CppToPython_Track(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::Track *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_Track_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *Track_SignatureStrings[] = {
+    "NatronEngine.Track.getParam(self,scriptName:QString)->NatronEngine.Param",
+    "NatronEngine.Track.getParams(self)->std.list[NatronEngine.Param]",
+    "NatronEngine.Track.getScriptName(self)->QString",
+    "NatronEngine.Track.reset(self)",
+    "NatronEngine.Track.setScriptName(self,scriptName:QString)",
+    nullptr}; // Sentinel
+
+void init_Track(PyObject *module)
+{
+    _Sbk_Track_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "Track",
+        "Track*",
+        &Sbk_Track_spec,
+        &Shiboken::callCppDestructor< ::Track >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_Track_Type);
+    InitSignatureStrings(pyType, Track_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_Track_Type), Sbk_Track_PropertyStrings);
+    SbkNatronEngineTypes[SBK_TRACK_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_Track_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_Track_TypeF(),
+        Track_PythonToCpp_Track_PTR,
+        is_Track_PythonToCpp_Track_PTR_Convertible,
+        Track_PTR_CppToPython_Track);
+
+    Shiboken::Conversions::registerConverterName(converter, "Track");
+    Shiboken::Conversions::registerConverterName(converter, "Track*");
+    Shiboken::Conversions::registerConverterName(converter, "Track&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Track).name());
+
+
+
+}

--- a/Engine/Qt5/NatronEngine/track_wrapper.h
+++ b/Engine/Qt5/NatronEngine/track_wrapper.h
@@ -1,0 +1,7 @@
+#ifndef SBK_TRACK_H
+#define SBK_TRACK_H
+
+#include <PyTracker.h>
+
+#endif // SBK_TRACK_H
+

--- a/Engine/Qt5/NatronEngine/tracker_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/tracker_wrapper.cpp
@@ -1,0 +1,453 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "tracker_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+// Extra includes
+#include <PyTracker.h>
+#include <list>
+
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_TrackerFunc_createTrack(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Tracker *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_TRACKER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // createTrack()
+            Track * cppResult = cppSelf->createTrack();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_TRACK_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_TrackerFunc_getAllTracks(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Tracker *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_TRACKER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getAllTracks(std::list<Track*>*)const
+            // Begin code injection
+            std::list<Track*> tracks;
+            cppSelf->getAllTracks(&tracks);
+            PyObject* ret = PyList_New((int) tracks.size());
+            int idx = 0;
+            for (std::list<Track*>::iterator it = tracks.begin(); it!=tracks.end(); ++it,++idx) {
+            PyObject* item = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_TRACK_IDX]), *it);
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(item);
+            PyList_SET_ITEM(ret, idx, item);
+            }
+            return ret;
+
+            // End of code injection
+
+            pyResult = Py_None;
+            Py_INCREF(Py_None);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_TrackerFunc_getSelectedTracks(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Tracker *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_TRACKER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getSelectedTracks(std::list<Track*>*)const
+            // Begin code injection
+            std::list<Track*> tracks;
+            cppSelf->getSelectedTracks(&tracks);
+            PyObject* ret = PyList_New((int) tracks.size());
+            int idx = 0;
+            for (std::list<Track*>::iterator it = tracks.begin(); it!=tracks.end(); ++it,++idx) {
+            PyObject* item = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_TRACK_IDX]), *it);
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(item);
+            PyList_SET_ITEM(ret, idx, item);
+            }
+            return ret;
+
+            // End of code injection
+
+            pyResult = Py_None;
+            Py_INCREF(Py_None);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_TrackerFunc_getTrackByName(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Tracker *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_TRACKER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: Tracker::getTrackByName(QString)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // getTrackByName(QString)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_TrackerFunc_getTrackByName_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getTrackByName(QString)const
+            Track * cppResult = const_cast<const ::Tracker *>(cppSelf)->getTrackByName(cppArg0);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_TRACK_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_TrackerFunc_getTrackByName_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.Tracker.getTrackByName");
+        return {};
+}
+
+static PyObject *Sbk_TrackerFunc_startTracking(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Tracker *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_TRACKER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "startTracking", 4, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: Tracker::startTracking(std::list<Track*>,int,int,bool)
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronEngineTypeConverters[SBK_NATRONENGINE_STD_LIST_TRACKPTR_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[3])))) {
+        overloadId = 0; // startTracking(std::list<Track*>,int,int,bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_TrackerFunc_startTracking_TypeError;
+
+    // Call function/method
+    {
+        ::std::list<Track* > cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        int cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+        bool cppArg3;
+        pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // startTracking(std::list<Track*>,int,int,bool)
+            cppSelf->startTracking(cppArg0, cppArg1, cppArg2, cppArg3);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_TrackerFunc_startTracking_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.Tracker.startTracking");
+        return {};
+}
+
+static PyObject *Sbk_TrackerFunc_stopTracking(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::Tracker *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_TRACKER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // stopTracking()
+            cppSelf->stopTracking();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+
+static const char *Sbk_Tracker_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_Tracker_methods[] = {
+    {"createTrack", reinterpret_cast<PyCFunction>(Sbk_TrackerFunc_createTrack), METH_NOARGS},
+    {"getAllTracks", reinterpret_cast<PyCFunction>(Sbk_TrackerFunc_getAllTracks), METH_NOARGS},
+    {"getSelectedTracks", reinterpret_cast<PyCFunction>(Sbk_TrackerFunc_getSelectedTracks), METH_NOARGS},
+    {"getTrackByName", reinterpret_cast<PyCFunction>(Sbk_TrackerFunc_getTrackByName), METH_O},
+    {"startTracking", reinterpret_cast<PyCFunction>(Sbk_TrackerFunc_startTracking), METH_VARARGS},
+    {"stopTracking", reinterpret_cast<PyCFunction>(Sbk_TrackerFunc_stopTracking), METH_NOARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+} // extern "C"
+
+static int Sbk_Tracker_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_Tracker_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_Tracker_Type = nullptr;
+static SbkObjectType *Sbk_Tracker_TypeF(void)
+{
+    return _Sbk_Tracker_Type;
+}
+
+static PyType_Slot Sbk_Tracker_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    nullptr},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_Tracker_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_Tracker_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_Tracker_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_Tracker_spec = {
+    "1:NatronEngine.Tracker",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_Tracker_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void Tracker_PythonToCpp_Tracker_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_Tracker_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_Tracker_PythonToCpp_Tracker_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_Tracker_TypeF())))
+        return Tracker_PythonToCpp_Tracker_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *Tracker_PTR_CppToPython_Tracker(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::Tracker *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_Tracker_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *Tracker_SignatureStrings[] = {
+    "NatronEngine.Tracker.createTrack(self)->NatronEngine.Track",
+    "NatronEngine.Tracker.getAllTracks(self,markers:std.list[NatronEngine.Track])",
+    "NatronEngine.Tracker.getSelectedTracks(self,markers:std.list[NatronEngine.Track])",
+    "NatronEngine.Tracker.getTrackByName(self,name:QString)->NatronEngine.Track",
+    "NatronEngine.Tracker.startTracking(self,marks:std.list[NatronEngine.Track],start:int,end:int,forward:bool)",
+    "NatronEngine.Tracker.stopTracking(self)",
+    nullptr}; // Sentinel
+
+void init_Tracker(PyObject *module)
+{
+    _Sbk_Tracker_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "Tracker",
+        "Tracker*",
+        &Sbk_Tracker_spec,
+        &Shiboken::callCppDestructor< ::Tracker >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_Tracker_Type);
+    InitSignatureStrings(pyType, Tracker_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_Tracker_Type), Sbk_Tracker_PropertyStrings);
+    SbkNatronEngineTypes[SBK_TRACKER_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_Tracker_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_Tracker_TypeF(),
+        Tracker_PythonToCpp_Tracker_PTR,
+        is_Tracker_PythonToCpp_Tracker_PTR_Convertible,
+        Tracker_PTR_CppToPython_Tracker);
+
+    Shiboken::Conversions::registerConverterName(converter, "Tracker");
+    Shiboken::Conversions::registerConverterName(converter, "Tracker*");
+    Shiboken::Conversions::registerConverterName(converter, "Tracker&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::Tracker).name());
+
+
+
+}

--- a/Engine/Qt5/NatronEngine/tracker_wrapper.h
+++ b/Engine/Qt5/NatronEngine/tracker_wrapper.h
@@ -1,0 +1,7 @@
+#ifndef SBK_TRACKER_H
+#define SBK_TRACKER_H
+
+#include <PyTracker.h>
+
+#endif // SBK_TRACKER_H
+

--- a/Engine/Qt5/NatronEngine/userparamholder_wrapper.cpp
+++ b/Engine/Qt5/NatronEngine/userparamholder_wrapper.cpp
@@ -1,0 +1,1467 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natronengine_python.h"
+
+// main header
+#include "userparamholder_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void UserParamHolderWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void UserParamHolderWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+UserParamHolderWrapper::UserParamHolderWrapper() : UserParamHolder()
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+UserParamHolderWrapper::~UserParamHolderWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_UserParamHolder_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::UserParamHolder >()))
+        return -1;
+
+    ::UserParamHolderWrapper *cptr{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // UserParamHolder()
+            cptr = new ::UserParamHolderWrapper();
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::UserParamHolder >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    Shiboken::Object::setHasCppWrapper(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createBooleanParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createBooleanParam", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createBooleanParam(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // createBooleanParam(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createBooleanParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // createBooleanParam(QString,QString)
+            BooleanParam * cppResult = cppSelf->createBooleanParam(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_BOOLEANPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createBooleanParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createBooleanParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createButtonParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createButtonParam", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createButtonParam(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // createButtonParam(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createButtonParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // createButtonParam(QString,QString)
+            ButtonParam * cppResult = cppSelf->createButtonParam(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_BUTTONPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createButtonParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createButtonParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createChoiceParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createChoiceParam", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createChoiceParam(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // createChoiceParam(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createChoiceParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // createChoiceParam(QString,QString)
+            ChoiceParam * cppResult = cppSelf->createChoiceParam(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_CHOICEPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createChoiceParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createChoiceParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createColorParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createColorParam", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createColorParam(QString,QString,bool)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[2])))) {
+        overloadId = 0; // createColorParam(QString,QString,bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createColorParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        bool cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // createColorParam(QString,QString,bool)
+            ColorParam * cppResult = cppSelf->createColorParam(cppArg0, cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_COLORPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createColorParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createColorParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createDouble2DParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createDouble2DParam", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createDouble2DParam(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // createDouble2DParam(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createDouble2DParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // createDouble2DParam(QString,QString)
+            Double2DParam * cppResult = cppSelf->createDouble2DParam(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_DOUBLE2DPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createDouble2DParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createDouble2DParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createDouble3DParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createDouble3DParam", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createDouble3DParam(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // createDouble3DParam(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createDouble3DParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // createDouble3DParam(QString,QString)
+            Double3DParam * cppResult = cppSelf->createDouble3DParam(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_DOUBLE3DPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createDouble3DParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createDouble3DParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createDoubleParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createDoubleParam", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createDoubleParam(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // createDoubleParam(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createDoubleParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // createDoubleParam(QString,QString)
+            DoubleParam * cppResult = cppSelf->createDoubleParam(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_DOUBLEPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createDoubleParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createDoubleParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createFileParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createFileParam", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createFileParam(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // createFileParam(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createFileParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // createFileParam(QString,QString)
+            FileParam * cppResult = cppSelf->createFileParam(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_FILEPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createFileParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createFileParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createGroupParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createGroupParam", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createGroupParam(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // createGroupParam(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createGroupParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // createGroupParam(QString,QString)
+            GroupParam * cppResult = cppSelf->createGroupParam(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUPPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createGroupParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createGroupParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createInt2DParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createInt2DParam", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createInt2DParam(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // createInt2DParam(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createInt2DParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // createInt2DParam(QString,QString)
+            Int2DParam * cppResult = cppSelf->createInt2DParam(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_INT2DPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createInt2DParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createInt2DParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createInt3DParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createInt3DParam", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createInt3DParam(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // createInt3DParam(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createInt3DParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // createInt3DParam(QString,QString)
+            Int3DParam * cppResult = cppSelf->createInt3DParam(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_INT3DPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createInt3DParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createInt3DParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createIntParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createIntParam", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createIntParam(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // createIntParam(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createIntParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // createIntParam(QString,QString)
+            IntParam * cppResult = cppSelf->createIntParam(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_INTPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createIntParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createIntParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createOutputFileParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createOutputFileParam", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createOutputFileParam(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // createOutputFileParam(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createOutputFileParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // createOutputFileParam(QString,QString)
+            OutputFileParam * cppResult = cppSelf->createOutputFileParam(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_OUTPUTFILEPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createOutputFileParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createOutputFileParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createPageParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createPageParam", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createPageParam(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // createPageParam(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createPageParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // createPageParam(QString,QString)
+            PageParam * cppResult = cppSelf->createPageParam(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PAGEPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createPageParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createPageParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createParametricParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createParametricParam", 3, 3, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createParametricParam(QString,QString,int)
+    if (numArgs == 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+        overloadId = 0; // createParametricParam(QString,QString,int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createParametricParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        int cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+
+        if (!PyErr_Occurred()) {
+            // createParametricParam(QString,QString,int)
+            ParametricParam * cppResult = cppSelf->createParametricParam(cppArg0, cppArg1, cppArg2);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAMETRICPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createParametricParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createParametricParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createPathParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createPathParam", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createPathParam(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // createPathParam(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createPathParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // createPathParam(QString,QString)
+            PathParam * cppResult = cppSelf->createPathParam(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PATHPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createPathParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createPathParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createSeparatorParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createSeparatorParam", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createSeparatorParam(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // createSeparatorParam(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createSeparatorParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // createSeparatorParam(QString,QString)
+            SeparatorParam * cppResult = cppSelf->createSeparatorParam(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_SEPARATORPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createSeparatorParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createSeparatorParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_createStringParam(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "createStringParam", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::createStringParam(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // createStringParam(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_createStringParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // createStringParam(QString,QString)
+            StringParam * cppResult = cppSelf->createStringParam(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_STRINGPARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_createStringParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronEngine.UserParamHolder.createStringParam");
+        return {};
+}
+
+static PyObject *Sbk_UserParamHolderFunc_refreshUserParamsGUI(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // refreshUserParamsGUI()
+            // Begin code injection
+            cppSelf->refreshUserParamsGUI();
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_UserParamHolderFunc_removeParam(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: UserParamHolder::removeParam(Param*)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), (pyArg)))) {
+        overloadId = 0; // removeParam(Param*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_UserParamHolderFunc_removeParam_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::Param *cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // removeParam(Param*)
+            bool cppResult = cppSelf->removeParam(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_UserParamHolderFunc_removeParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronEngine.UserParamHolder.removeParam");
+        return {};
+}
+
+
+static const char *Sbk_UserParamHolder_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_UserParamHolder_methods[] = {
+    {"createBooleanParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createBooleanParam), METH_VARARGS},
+    {"createButtonParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createButtonParam), METH_VARARGS},
+    {"createChoiceParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createChoiceParam), METH_VARARGS},
+    {"createColorParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createColorParam), METH_VARARGS},
+    {"createDouble2DParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createDouble2DParam), METH_VARARGS},
+    {"createDouble3DParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createDouble3DParam), METH_VARARGS},
+    {"createDoubleParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createDoubleParam), METH_VARARGS},
+    {"createFileParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createFileParam), METH_VARARGS},
+    {"createGroupParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createGroupParam), METH_VARARGS},
+    {"createInt2DParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createInt2DParam), METH_VARARGS},
+    {"createInt3DParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createInt3DParam), METH_VARARGS},
+    {"createIntParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createIntParam), METH_VARARGS},
+    {"createOutputFileParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createOutputFileParam), METH_VARARGS},
+    {"createPageParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createPageParam), METH_VARARGS},
+    {"createParametricParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createParametricParam), METH_VARARGS},
+    {"createPathParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createPathParam), METH_VARARGS},
+    {"createSeparatorParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createSeparatorParam), METH_VARARGS},
+    {"createStringParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_createStringParam), METH_VARARGS},
+    {"refreshUserParamsGUI", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_refreshUserParamsGUI), METH_NOARGS},
+    {"removeParam", reinterpret_cast<PyCFunction>(Sbk_UserParamHolderFunc_removeParam), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_UserParamHolder_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::UserParamHolder *>(Shiboken::Conversions::cppPointer(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<UserParamHolderWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_UserParamHolder_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_UserParamHolder_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_UserParamHolder_Type = nullptr;
+static SbkObjectType *Sbk_UserParamHolder_TypeF(void)
+{
+    return _Sbk_UserParamHolder_Type;
+}
+
+static PyType_Slot Sbk_UserParamHolder_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_UserParamHolder_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_UserParamHolder_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_UserParamHolder_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_UserParamHolder_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_UserParamHolder_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_UserParamHolder_spec = {
+    "1:NatronEngine.UserParamHolder",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_UserParamHolder_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void UserParamHolder_PythonToCpp_UserParamHolder_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_UserParamHolder_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_UserParamHolder_PythonToCpp_UserParamHolder_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_UserParamHolder_TypeF())))
+        return UserParamHolder_PythonToCpp_UserParamHolder_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *UserParamHolder_PTR_CppToPython_UserParamHolder(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::UserParamHolder *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_UserParamHolder_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *UserParamHolder_SignatureStrings[] = {
+    "NatronEngine.UserParamHolder(self)",
+    "NatronEngine.UserParamHolder.createBooleanParam(self,name:QString,label:QString)->NatronEngine.BooleanParam",
+    "NatronEngine.UserParamHolder.createButtonParam(self,name:QString,label:QString)->NatronEngine.ButtonParam",
+    "NatronEngine.UserParamHolder.createChoiceParam(self,name:QString,label:QString)->NatronEngine.ChoiceParam",
+    "NatronEngine.UserParamHolder.createColorParam(self,name:QString,label:QString,useAlpha:bool)->NatronEngine.ColorParam",
+    "NatronEngine.UserParamHolder.createDouble2DParam(self,name:QString,label:QString)->NatronEngine.Double2DParam",
+    "NatronEngine.UserParamHolder.createDouble3DParam(self,name:QString,label:QString)->NatronEngine.Double3DParam",
+    "NatronEngine.UserParamHolder.createDoubleParam(self,name:QString,label:QString)->NatronEngine.DoubleParam",
+    "NatronEngine.UserParamHolder.createFileParam(self,name:QString,label:QString)->NatronEngine.FileParam",
+    "NatronEngine.UserParamHolder.createGroupParam(self,name:QString,label:QString)->NatronEngine.GroupParam",
+    "NatronEngine.UserParamHolder.createInt2DParam(self,name:QString,label:QString)->NatronEngine.Int2DParam",
+    "NatronEngine.UserParamHolder.createInt3DParam(self,name:QString,label:QString)->NatronEngine.Int3DParam",
+    "NatronEngine.UserParamHolder.createIntParam(self,name:QString,label:QString)->NatronEngine.IntParam",
+    "NatronEngine.UserParamHolder.createOutputFileParam(self,name:QString,label:QString)->NatronEngine.OutputFileParam",
+    "NatronEngine.UserParamHolder.createPageParam(self,name:QString,label:QString)->NatronEngine.PageParam",
+    "NatronEngine.UserParamHolder.createParametricParam(self,name:QString,label:QString,nbCurves:int)->NatronEngine.ParametricParam",
+    "NatronEngine.UserParamHolder.createPathParam(self,name:QString,label:QString)->NatronEngine.PathParam",
+    "NatronEngine.UserParamHolder.createSeparatorParam(self,name:QString,label:QString)->NatronEngine.SeparatorParam",
+    "NatronEngine.UserParamHolder.createStringParam(self,name:QString,label:QString)->NatronEngine.StringParam",
+    "NatronEngine.UserParamHolder.refreshUserParamsGUI(self)",
+    "NatronEngine.UserParamHolder.removeParam(self,param:NatronEngine.Param)->bool",
+    nullptr}; // Sentinel
+
+void init_UserParamHolder(PyObject *module)
+{
+    _Sbk_UserParamHolder_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "UserParamHolder",
+        "UserParamHolder*",
+        &Sbk_UserParamHolder_spec,
+        &Shiboken::callCppDestructor< ::UserParamHolder >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_UserParamHolder_Type);
+    InitSignatureStrings(pyType, UserParamHolder_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_UserParamHolder_Type), Sbk_UserParamHolder_PropertyStrings);
+    SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_UserParamHolder_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_UserParamHolder_TypeF(),
+        UserParamHolder_PythonToCpp_UserParamHolder_PTR,
+        is_UserParamHolder_PythonToCpp_UserParamHolder_PTR_Convertible,
+        UserParamHolder_PTR_CppToPython_UserParamHolder);
+
+    Shiboken::Conversions::registerConverterName(converter, "UserParamHolder");
+    Shiboken::Conversions::registerConverterName(converter, "UserParamHolder*");
+    Shiboken::Conversions::registerConverterName(converter, "UserParamHolder&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::UserParamHolder).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::UserParamHolderWrapper).name());
+
+
+
+    UserParamHolderWrapper::pysideInitQtMetaTypes();
+}

--- a/Engine/Qt5/NatronEngine/userparamholder_wrapper.h
+++ b/Engine/Qt5/NatronEngine/userparamholder_wrapper.h
@@ -1,0 +1,23 @@
+#ifndef SBK_USERPARAMHOLDERWRAPPER_H
+#define SBK_USERPARAMHOLDERWRAPPER_H
+
+#include <PyNode.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class UserParamHolderWrapper : public UserParamHolder
+{
+public:
+    UserParamHolderWrapper();
+    ~UserParamHolderWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#endif // SBK_USERPARAMHOLDERWRAPPER_H
+


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

See #697.

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

See #697.

**Futher details of this pull request**

Used the following command to generate the sources:

```sh
$ shiboken2 --enable-parent-ctor-heuristic --use-isnull-as-nb_nonzero --avoid-protected-hack \
      --enable-pyside-extensions --include-paths=.:Engine:Global:libs/OpenFX/include:/usr/include/PySide2
      --include-paths=/usr/include/QtCore:/usr/include/python3.9 \
      --typesystem-paths=/usr/share/PySide2/typesystems --output-directory=Engine/Qt5 \
      Engine/PySide2_Engine_Python.h Engine/typesystem_engine.xml
```