### PR TITLE
Initial Qt5 sources for Gui

### DIFF
--- a/Gui/Qt5/NatronGui/guiapp_wrapper.cpp
+++ b/Gui/Qt5/NatronGui/guiapp_wrapper.cpp
@@ -1,0 +1,1776 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natrongui_python.h"
+
+// main header
+#include "guiapp_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void GuiAppWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void GuiAppWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+GuiAppWrapper::~GuiAppWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_GuiAppFunc_clearSelection(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.clearSelection(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:clearSelection", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: GuiApp::clearSelection(Group*)
+    if (numArgs == 0) {
+        overloadId = 0; // clearSelection(Group*)
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]), (pyArgs[0])))) {
+        overloadId = 0; // clearSelection(Group*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_clearSelection_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","group");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.clearSelection(): got multiple values for keyword argument 'group'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]), (pyArgs[0]))))
+                        goto Sbk_GuiAppFunc_clearSelection_TypeError;
+                }
+            }
+        }
+        if (!Shiboken::Object::isValid(pyArgs[0]))
+            return {};
+        ::Group *cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // clearSelection(Group*)
+            cppSelf->clearSelection(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_GuiAppFunc_clearSelection_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.GuiApp.clearSelection");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_copySelectedNodes(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.copySelectedNodes(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:copySelectedNodes", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: GuiApp::copySelectedNodes(Group*)
+    if (numArgs == 0) {
+        overloadId = 0; // copySelectedNodes(Group*)
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]), (pyArgs[0])))) {
+        overloadId = 0; // copySelectedNodes(Group*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_copySelectedNodes_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","group");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.copySelectedNodes(): got multiple values for keyword argument 'group'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]), (pyArgs[0]))))
+                        goto Sbk_GuiAppFunc_copySelectedNodes_TypeError;
+                }
+            }
+        }
+        if (!Shiboken::Object::isValid(pyArgs[0]))
+            return {};
+        ::Group *cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // copySelectedNodes(Group*)
+            cppSelf->copySelectedNodes(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_GuiAppFunc_copySelectedNodes_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.GuiApp.copySelectedNodes");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_createModalDialog(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // createModalDialog()
+            PyModalDialog * cppResult = cppSelf->createModalDialog();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronGuiTypes[SBK_PYMODALDIALOG_IDX]), cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_GuiAppFunc_deselectNode(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: GuiApp::deselectNode(Effect*)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), (pyArg)))) {
+        overloadId = 0; // deselectNode(Effect*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_deselectNode_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::Effect *cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // deselectNode(Effect*)
+            cppSelf->deselectNode(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_GuiAppFunc_deselectNode_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.GuiApp.deselectNode");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_getActiveTabWidget(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getActiveTabWidget()const
+            PyTabWidget * cppResult = const_cast<const ::GuiApp *>(cppSelf)->getActiveTabWidget();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_GuiAppFunc_getActiveViewer(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getActiveViewer()const
+            PyViewer * cppResult = const_cast<const ::GuiApp *>(cppSelf)->getActiveViewer();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronGuiTypes[SBK_PYVIEWER_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_GuiAppFunc_getDirectoryDialog(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.getDirectoryDialog(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getDirectoryDialog", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: GuiApp::getDirectoryDialog(QString)const
+    if (numArgs == 0) {
+        overloadId = 0; // getDirectoryDialog(QString)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))) {
+        overloadId = 0; // getDirectoryDialog(QString)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_getDirectoryDialog_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","location");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.getDirectoryDialog(): got multiple values for keyword argument 'location'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0]))))
+                        goto Sbk_GuiAppFunc_getDirectoryDialog_TypeError;
+                }
+            }
+        }
+        ::QString cppArg0 = QString();
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getDirectoryDialog(QString)const
+            QString cppResult = const_cast<const ::GuiApp *>(cppSelf)->getDirectoryDialog(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_GuiAppFunc_getDirectoryDialog_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.GuiApp.getDirectoryDialog");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_getFilenameDialog(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.getFilenameDialog(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.getFilenameDialog(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:getFilenameDialog", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: GuiApp::getFilenameDialog(QStringList,QString)const
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRINGLIST_IDX], (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // getFilenameDialog(QStringList,QString)const
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+            overloadId = 0; // getFilenameDialog(QStringList,QString)const
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_getFilenameDialog_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","location");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.getFilenameDialog(): got multiple values for keyword argument 'location'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1]))))
+                        goto Sbk_GuiAppFunc_getFilenameDialog_TypeError;
+                }
+            }
+        }
+        ::QStringList cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1 = QString();
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // getFilenameDialog(QStringList,QString)const
+            QString cppResult = const_cast<const ::GuiApp *>(cppSelf)->getFilenameDialog(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_GuiAppFunc_getFilenameDialog_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.GuiApp.getFilenameDialog");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_getRGBColorDialog(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getRGBColorDialog()const
+            ColorTuple* cppResult = new ColorTuple(const_cast<const ::GuiApp *>(cppSelf)->getRGBColorDialog());
+            pyResult = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_COLORTUPLE_IDX]), cppResult, true, true);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_GuiAppFunc_getSelectedNodes(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.getSelectedNodes(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:getSelectedNodes", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: GuiApp::getSelectedNodes(Group*)const
+    if (numArgs == 0) {
+        overloadId = 0; // getSelectedNodes(Group*)const
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]), (pyArgs[0])))) {
+        overloadId = 0; // getSelectedNodes(Group*)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_getSelectedNodes_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","group");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.getSelectedNodes(): got multiple values for keyword argument 'group'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]), (pyArgs[0]))))
+                        goto Sbk_GuiAppFunc_getSelectedNodes_TypeError;
+                }
+            }
+        }
+        if (!Shiboken::Object::isValid(pyArgs[0]))
+            return {};
+        ::Group *cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getSelectedNodes(Group*)const
+            // Begin code injection
+            std::list<Effect*> effects = cppSelf->getSelectedNodes(cppArg0);
+            PyObject* ret = PyList_New((int) effects.size());
+            int idx = 0;
+            for (std::list<Effect*>::iterator it = effects.begin(); it!=effects.end(); ++it,++idx) {
+            PyObject* item = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), *it);
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(item);
+            PyList_SET_ITEM(ret, idx, item);
+            }
+            return ret;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_GuiAppFunc_getSelectedNodes_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.GuiApp.getSelectedNodes");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_getSequenceDialog(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.getSequenceDialog(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.getSequenceDialog(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:getSequenceDialog", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: GuiApp::getSequenceDialog(QStringList,QString)const
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRINGLIST_IDX], (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // getSequenceDialog(QStringList,QString)const
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+            overloadId = 0; // getSequenceDialog(QStringList,QString)const
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_getSequenceDialog_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","location");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.getSequenceDialog(): got multiple values for keyword argument 'location'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1]))))
+                        goto Sbk_GuiAppFunc_getSequenceDialog_TypeError;
+                }
+            }
+        }
+        ::QStringList cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1 = QString();
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // getSequenceDialog(QStringList,QString)const
+            QString cppResult = const_cast<const ::GuiApp *>(cppSelf)->getSequenceDialog(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_GuiAppFunc_getSequenceDialog_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.GuiApp.getSequenceDialog");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_getTabWidget(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: GuiApp::getTabWidget(QString)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // getTabWidget(QString)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_getTabWidget_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getTabWidget(QString)const
+            PyTabWidget * cppResult = const_cast<const ::GuiApp *>(cppSelf)->getTabWidget(cppArg0);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_GuiAppFunc_getTabWidget_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.GuiApp.getTabWidget");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_getUserPanel(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: GuiApp::getUserPanel(QString)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // getUserPanel(QString)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_getUserPanel_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getUserPanel(QString)const
+            PyPanel * cppResult = const_cast<const ::GuiApp *>(cppSelf)->getUserPanel(cppArg0);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronGuiTypes[SBK_PYPANEL_IDX]), cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_GuiAppFunc_getUserPanel_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.GuiApp.getUserPanel");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_getViewer(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: GuiApp::getViewer(QString)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // getViewer(QString)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_getViewer_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getViewer(QString)const
+            PyViewer * cppResult = const_cast<const ::GuiApp *>(cppSelf)->getViewer(cppArg0);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronGuiTypes[SBK_PYVIEWER_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_GuiAppFunc_getViewer_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.GuiApp.getViewer");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_moveTab(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "moveTab", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: GuiApp::moveTab(QString,PyTabWidget*)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX]), (pyArgs[1])))) {
+        overloadId = 0; // moveTab(QString,PyTabWidget*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_moveTab_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        if (!Shiboken::Object::isValid(pyArgs[1]))
+            return {};
+        ::PyTabWidget *cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // moveTab(QString,PyTabWidget*)
+            bool cppResult = cppSelf->moveTab(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_GuiAppFunc_moveTab_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.GuiApp.moveTab");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_pasteNodes(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.pasteNodes(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:pasteNodes", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: GuiApp::pasteNodes(Group*)
+    if (numArgs == 0) {
+        overloadId = 0; // pasteNodes(Group*)
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]), (pyArgs[0])))) {
+        overloadId = 0; // pasteNodes(Group*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_pasteNodes_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","group");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.pasteNodes(): got multiple values for keyword argument 'group'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]), (pyArgs[0]))))
+                        goto Sbk_GuiAppFunc_pasteNodes_TypeError;
+                }
+            }
+        }
+        if (!Shiboken::Object::isValid(pyArgs[0]))
+            return {};
+        ::Group *cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // pasteNodes(Group*)
+            cppSelf->pasteNodes(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_GuiAppFunc_pasteNodes_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.GuiApp.pasteNodes");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_registerPythonPanel(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "registerPythonPanel", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: GuiApp::registerPythonPanel(PyPanel*,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronGuiTypes[SBK_PYPANEL_IDX]), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // registerPythonPanel(PyPanel*,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_registerPythonPanel_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArgs[0]))
+            return {};
+        ::PyPanel *cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // registerPythonPanel(PyPanel*,QString)
+            cppSelf->registerPythonPanel(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_GuiAppFunc_registerPythonPanel_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.GuiApp.registerPythonPanel");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_renderBlocking(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 4) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.renderBlocking(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.renderBlocking(): not enough arguments");
+        return {};
+    } else if (numArgs == 2)
+        goto Sbk_GuiAppFunc_renderBlocking_TypeError;
+
+    if (!PyArg_ParseTuple(args, "|OOOO:renderBlocking", &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: GuiApp::renderBlocking(Effect*,int,int,int)
+    // 1: GuiApp::renderBlocking(std::list<Effect*>,std::list<int>,std::list<int>,std::list<int>)
+    if (numArgs >= 3
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[2])))) {
+        if (numArgs == 3) {
+            overloadId = 0; // renderBlocking(Effect*,int,int,int)
+        } else if ((pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[3])))) {
+            overloadId = 0; // renderBlocking(Effect*,int,int,int)
+        }
+    } else if (numArgs == 1
+        && PyList_Check(pyArgs[0])) {
+        overloadId = 1; // renderBlocking(std::list<Effect*>,std::list<int>,std::list<int>,std::list<int>)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_renderBlocking_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // renderBlocking(Effect * writeNode, int firstFrame, int lastFrame, int frameStep)
+        {
+            if (kwds) {
+                PyObject *keyName = nullptr;
+                PyObject *value = nullptr;
+                keyName = Py_BuildValue("s","frameStep");
+                if (PyDict_Contains(kwds, keyName)) {
+                    value = PyDict_GetItem(kwds, keyName);
+                    if (value && pyArgs[3]) {
+                        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.renderBlocking(): got multiple values for keyword argument 'frameStep'.");
+                        return {};
+                    }
+                    if (value) {
+                        pyArgs[3] = value;
+                        if (!(pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[3]))))
+                            goto Sbk_GuiAppFunc_renderBlocking_TypeError;
+                    }
+                }
+            }
+            if (!Shiboken::Object::isValid(pyArgs[0]))
+                return {};
+            ::Effect *cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            int cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            int cppArg2;
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            int cppArg3 = 1;
+            if (pythonToCpp[3]) pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // renderBlocking(Effect*,int,int,int)
+                cppSelf->renderBlocking(cppArg0, cppArg1, cppArg2, cppArg3);
+            }
+            break;
+        }
+        case 1: // renderBlocking(const std::list<Effect* > & effects, const std::list<int > & firstFrames, const std::list<int > & lastFrames, const std::list<int > & frameSteps)
+        {
+
+            if (!PyErr_Occurred()) {
+                // renderBlocking(std::list<Effect*>,std::list<int>,std::list<int>,std::list<int>)
+                // Begin code injection
+                if (!PyList_Check(pyArgs[1-1])) {
+                PyErr_SetString(PyExc_TypeError, "tasks must be a list of tuple objects.");
+                return 0;
+                }
+                std::list<Effect*> effects;
+
+                std::list<int> firstFrames;
+
+                std::list<int> lastFrames;
+
+                std::list<int> frameSteps;
+
+                int size = (int)PyList_GET_SIZE(pyArgs[1-1]);
+                for (int i = 0; i < size; ++i) {
+                PyObject* tuple = PyList_GET_ITEM(pyArgs[1-1],i);
+                if (!tuple) {
+                PyErr_SetString(PyExc_TypeError, "tasks must be a list of tuple objects.");
+                return 0;
+                }
+
+                int tupleSize = PyTuple_GET_SIZE(tuple);
+                if (tupleSize != 4 && tupleSize != 3) {
+                PyErr_SetString(PyExc_TypeError, "the tuple must have 3 or 4 items.");
+                return 0;
+                }
+                ::Effect* writeNode{nullptr};
+                    Shiboken::Conversions::pythonToCppPointer(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), PyTuple_GET_ITEM(tuple, 0), &(writeNode));
+                int firstFrame;
+                    Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<int>(), PyTuple_GET_ITEM(tuple, 1), &(firstFrame));
+                int lastFrame;
+                    Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<int>(), PyTuple_GET_ITEM(tuple, 2), &(lastFrame));
+                int frameStep;
+                if (tupleSize == 4) {
+                Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<int>(), PyTuple_GET_ITEM(tuple, 3), &(frameStep));
+                } else {
+                frameStep = INT_MIN;
+                }
+                effects.push_back(writeNode);
+                firstFrames.push_back(firstFrame);
+                lastFrames.push_back(lastFrame);
+                frameSteps.push_back(frameStep);
+                }
+
+                cppSelf->renderBlocking(effects,firstFrames,lastFrames, frameSteps);
+
+                // End of code injection
+
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_GuiAppFunc_renderBlocking_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.GuiApp.renderBlocking");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_saveFilenameDialog(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.saveFilenameDialog(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.saveFilenameDialog(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:saveFilenameDialog", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: GuiApp::saveFilenameDialog(QStringList,QString)const
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRINGLIST_IDX], (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // saveFilenameDialog(QStringList,QString)const
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+            overloadId = 0; // saveFilenameDialog(QStringList,QString)const
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_saveFilenameDialog_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","location");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.saveFilenameDialog(): got multiple values for keyword argument 'location'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1]))))
+                        goto Sbk_GuiAppFunc_saveFilenameDialog_TypeError;
+                }
+            }
+        }
+        ::QStringList cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1 = QString();
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // saveFilenameDialog(QStringList,QString)const
+            QString cppResult = const_cast<const ::GuiApp *>(cppSelf)->saveFilenameDialog(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_GuiAppFunc_saveFilenameDialog_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.GuiApp.saveFilenameDialog");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_saveSequenceDialog(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 2) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.saveSequenceDialog(): too many arguments");
+        return {};
+    } else if (numArgs < 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.saveSequenceDialog(): not enough arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|OO:saveSequenceDialog", &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: GuiApp::saveSequenceDialog(QStringList,QString)const
+    if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRINGLIST_IDX], (pyArgs[0])))) {
+        if (numArgs == 1) {
+            overloadId = 0; // saveSequenceDialog(QStringList,QString)const
+        } else if ((pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+            overloadId = 0; // saveSequenceDialog(QStringList,QString)const
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_saveSequenceDialog_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","location");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[1]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.saveSequenceDialog(): got multiple values for keyword argument 'location'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[1] = value;
+                    if (!(pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1]))))
+                        goto Sbk_GuiAppFunc_saveSequenceDialog_TypeError;
+                }
+            }
+        }
+        ::QStringList cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1 = QString();
+        if (pythonToCpp[1]) pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // saveSequenceDialog(QStringList,QString)const
+            QString cppResult = const_cast<const ::GuiApp *>(cppSelf)->saveSequenceDialog(cppArg0, cppArg1);
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_GuiAppFunc_saveSequenceDialog_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.GuiApp.saveSequenceDialog");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_selectAllNodes(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.selectAllNodes(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:selectAllNodes", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: GuiApp::selectAllNodes(Group*)
+    if (numArgs == 0) {
+        overloadId = 0; // selectAllNodes(Group*)
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]), (pyArgs[0])))) {
+        overloadId = 0; // selectAllNodes(Group*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_selectAllNodes_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","group");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronGui.GuiApp.selectAllNodes(): got multiple values for keyword argument 'group'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_GROUP_IDX]), (pyArgs[0]))))
+                        goto Sbk_GuiAppFunc_selectAllNodes_TypeError;
+                }
+            }
+        }
+        if (!Shiboken::Object::isValid(pyArgs[0]))
+            return {};
+        ::Group *cppArg0 = 0;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // selectAllNodes(Group*)
+            cppSelf->selectAllNodes(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_GuiAppFunc_selectAllNodes_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.GuiApp.selectAllNodes");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_selectNode(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "selectNode", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: GuiApp::selectNode(Effect*,bool)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[1])))) {
+        overloadId = 0; // selectNode(Effect*,bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_selectNode_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArgs[0]))
+            return {};
+        ::Effect *cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        bool cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // selectNode(Effect*,bool)
+            cppSelf->selectNode(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_GuiAppFunc_selectNode_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.GuiApp.selectNode");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_setSelection(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: GuiApp::setSelection(std::list<Effect*>)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_LIST_EFFECTPTR_IDX], (pyArg)))) {
+        overloadId = 0; // setSelection(std::list<Effect*>)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_setSelection_TypeError;
+
+    // Call function/method
+    {
+        ::std::list<Effect* > cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setSelection(std::list<Effect*>)
+            cppSelf->setSelection(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_GuiAppFunc_setSelection_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.GuiApp.setSelection");
+        return {};
+}
+
+static PyObject *Sbk_GuiAppFunc_unregisterPythonPanel(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: GuiApp::unregisterPythonPanel(PyPanel*)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronGuiTypes[SBK_PYPANEL_IDX]), (pyArg)))) {
+        overloadId = 0; // unregisterPythonPanel(PyPanel*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_GuiAppFunc_unregisterPythonPanel_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::PyPanel *cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // unregisterPythonPanel(PyPanel*)
+            cppSelf->unregisterPythonPanel(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_GuiAppFunc_unregisterPythonPanel_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.GuiApp.unregisterPythonPanel");
+        return {};
+}
+
+
+static const char *Sbk_GuiApp_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_GuiApp_methods[] = {
+    {"clearSelection", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_clearSelection), METH_VARARGS|METH_KEYWORDS},
+    {"copySelectedNodes", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_copySelectedNodes), METH_VARARGS|METH_KEYWORDS},
+    {"createModalDialog", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_createModalDialog), METH_NOARGS},
+    {"deselectNode", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_deselectNode), METH_O},
+    {"getActiveTabWidget", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_getActiveTabWidget), METH_NOARGS},
+    {"getActiveViewer", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_getActiveViewer), METH_NOARGS},
+    {"getDirectoryDialog", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_getDirectoryDialog), METH_VARARGS|METH_KEYWORDS},
+    {"getFilenameDialog", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_getFilenameDialog), METH_VARARGS|METH_KEYWORDS},
+    {"getRGBColorDialog", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_getRGBColorDialog), METH_NOARGS},
+    {"getSelectedNodes", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_getSelectedNodes), METH_VARARGS|METH_KEYWORDS},
+    {"getSequenceDialog", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_getSequenceDialog), METH_VARARGS|METH_KEYWORDS},
+    {"getTabWidget", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_getTabWidget), METH_O},
+    {"getUserPanel", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_getUserPanel), METH_O},
+    {"getViewer", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_getViewer), METH_O},
+    {"moveTab", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_moveTab), METH_VARARGS},
+    {"pasteNodes", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_pasteNodes), METH_VARARGS|METH_KEYWORDS},
+    {"registerPythonPanel", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_registerPythonPanel), METH_VARARGS},
+    {"renderBlocking", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_renderBlocking), METH_VARARGS|METH_KEYWORDS},
+    {"saveFilenameDialog", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_saveFilenameDialog), METH_VARARGS|METH_KEYWORDS},
+    {"saveSequenceDialog", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_saveSequenceDialog), METH_VARARGS|METH_KEYWORDS},
+    {"selectAllNodes", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_selectAllNodes), METH_VARARGS|METH_KEYWORDS},
+    {"selectNode", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_selectNode), METH_VARARGS},
+    {"setSelection", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_setSelection), METH_O},
+    {"unregisterPythonPanel", reinterpret_cast<PyCFunction>(Sbk_GuiAppFunc_unregisterPythonPanel), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_GuiApp_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::GuiApp *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_GUIAPP_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<GuiAppWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_GuiApp_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_GuiApp_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_GuiApp_Type = nullptr;
+static SbkObjectType *Sbk_GuiApp_TypeF(void)
+{
+    return _Sbk_GuiApp_Type;
+}
+
+static PyType_Slot Sbk_GuiApp_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_GuiApp_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_GuiApp_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_GuiApp_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_GuiApp_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_GuiApp_spec = {
+    "1:NatronGui.GuiApp",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_GuiApp_slots
+};
+
+} //extern "C"
+
+static void *Sbk_GuiApp_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::Group >()))
+        return dynamic_cast< ::GuiApp *>(reinterpret_cast< ::Group *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void GuiApp_PythonToCpp_GuiApp_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_GuiApp_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_GuiApp_PythonToCpp_GuiApp_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_GuiApp_TypeF())))
+        return GuiApp_PythonToCpp_GuiApp_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *GuiApp_PTR_CppToPython_GuiApp(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::GuiApp *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_GuiApp_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *GuiApp_SignatureStrings[] = {
+    "NatronGui.GuiApp.clearSelection(self,group:NatronEngine.Group=0)",
+    "NatronGui.GuiApp.copySelectedNodes(self,group:NatronEngine.Group=0)",
+    "NatronGui.GuiApp.createModalDialog(self)->NatronGui.PyModalDialog",
+    "NatronGui.GuiApp.deselectNode(self,effect:NatronEngine.Effect)",
+    "NatronGui.GuiApp.getActiveTabWidget(self)->NatronGui.PyTabWidget",
+    "NatronGui.GuiApp.getActiveViewer(self)->NatronGui.PyViewer",
+    "NatronGui.GuiApp.getDirectoryDialog(self,location:QString=QString())->QString",
+    "NatronGui.GuiApp.getFilenameDialog(self,filters:QStringList,location:QString=QString())->QString",
+    "NatronGui.GuiApp.getRGBColorDialog(self)->NatronEngine.ColorTuple",
+    "NatronGui.GuiApp.getSelectedNodes(self,group:NatronEngine.Group=0)->std.list[NatronEngine.Effect]",
+    "NatronGui.GuiApp.getSequenceDialog(self,filters:QStringList,location:QString=QString())->QString",
+    "NatronGui.GuiApp.getTabWidget(self,name:QString)->NatronGui.PyTabWidget",
+    "NatronGui.GuiApp.getUserPanel(self,scriptName:QString)->NatronGui.PyPanel",
+    "NatronGui.GuiApp.getViewer(self,scriptName:QString)->NatronGui.PyViewer",
+    "NatronGui.GuiApp.moveTab(self,scriptName:QString,pane:NatronGui.PyTabWidget)->bool",
+    "NatronGui.GuiApp.pasteNodes(self,group:NatronEngine.Group=0)",
+    "NatronGui.GuiApp.registerPythonPanel(self,panel:NatronGui.PyPanel,pythonFunction:QString)",
+    "1:NatronGui.GuiApp.renderBlocking(self,writeNode:NatronEngine.Effect,firstFrame:int,lastFrame:int,frameStep:int=1)",
+    "0:NatronGui.GuiApp.renderBlocking(self,effects:std.list[NatronEngine.Effect],firstFrames:std.list[int],lastFrames:std.list[int],frameSteps:std.list[int])",
+    "NatronGui.GuiApp.saveFilenameDialog(self,filters:QStringList,location:QString=QString())->QString",
+    "NatronGui.GuiApp.saveSequenceDialog(self,filters:QStringList,location:QString=QString())->QString",
+    "NatronGui.GuiApp.selectAllNodes(self,group:NatronEngine.Group=0)",
+    "NatronGui.GuiApp.selectNode(self,effect:NatronEngine.Effect,clearPreviousSelection:bool)",
+    "NatronGui.GuiApp.setSelection(self,nodes:std.list[NatronEngine.Effect])",
+    "NatronGui.GuiApp.unregisterPythonPanel(self,panel:NatronGui.PyPanel)",
+    nullptr}; // Sentinel
+
+void init_GuiApp(PyObject *module)
+{
+    _Sbk_GuiApp_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "GuiApp",
+        "GuiApp*",
+        &Sbk_GuiApp_spec,
+        &Shiboken::callCppDestructor< ::GuiApp >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_APP_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_GuiApp_Type);
+    InitSignatureStrings(pyType, GuiApp_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_GuiApp_Type), Sbk_GuiApp_PropertyStrings);
+    SbkNatronGuiTypes[SBK_GUIAPP_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_GuiApp_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_GuiApp_TypeF(),
+        GuiApp_PythonToCpp_GuiApp_PTR,
+        is_GuiApp_PythonToCpp_GuiApp_PTR_Convertible,
+        GuiApp_PTR_CppToPython_GuiApp);
+
+    Shiboken::Conversions::registerConverterName(converter, "GuiApp");
+    Shiboken::Conversions::registerConverterName(converter, "GuiApp*");
+    Shiboken::Conversions::registerConverterName(converter, "GuiApp&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::GuiApp).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::GuiAppWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_GuiApp_TypeF(), &Sbk_GuiApp_typeDiscovery);
+
+
+    GuiAppWrapper::pysideInitQtMetaTypes();
+}

--- a/Gui/Qt5/NatronGui/guiapp_wrapper.h
+++ b/Gui/Qt5/NatronGui/guiapp_wrapper.h
@@ -1,0 +1,68 @@
+#ifndef SBK_GUIAPPWRAPPER_H
+#define SBK_GUIAPPWRAPPER_H
+
+#include <PyGuiApp.h>
+
+
+// Extra includes
+#include <PythonPanels.h>
+#include <PyParameter.h>
+#include <list>
+#include <PyNode.h>
+#include <PyNodeGroup.h>
+#include <PyGuiApp.h>
+#include <PyAppInstance.h>
+#include <map>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class GuiAppWrapper : public GuiApp
+{
+public:
+    ~GuiAppWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_APPWRAPPER_H
+#  define SBK_APPWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class AppWrapper : public App
+{
+public:
+    inline void renderInternal_protected(bool forceBlocking, Effect * writeNode, int firstFrame, int lastFrame, int frameStep) { App::renderInternal(forceBlocking, writeNode, firstFrame, lastFrame, frameStep); }
+    inline void renderInternal_protected(bool forceBlocking, const std::list<Effect* > & effects, const std::list<int > & firstFrames, const std::list<int > & lastFrames, const std::list<int > & frameSteps) { App::renderInternal(forceBlocking, effects, firstFrames, lastFrames, frameSteps); }
+    ~AppWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_APPWRAPPER_H
+
+#  ifndef SBK_GROUPWRAPPER_H
+#  define SBK_GROUPWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class GroupWrapper : public Group
+{
+public:
+    GroupWrapper();
+    ~GroupWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_GROUPWRAPPER_H
+
+#endif // SBK_GUIAPPWRAPPER_H
+

--- a/Gui/Qt5/NatronGui/natrongui_module_wrapper.cpp
+++ b/Gui/Qt5/NatronGui/natrongui_module_wrapper.cpp
@@ -1,0 +1,507 @@
+
+#include <sbkpython.h>
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#include <algorithm>
+#include <signature.h>
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+#include "natrongui_python.h"
+
+
+
+// Extra includes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+// Current module's type array.
+PyTypeObject **SbkNatronGuiTypes = nullptr;
+// Current module's PyObject pointer.
+PyObject *SbkNatronGuiModuleObject = nullptr;
+// Current module's converter array.
+SbkConverter **SbkNatronGuiTypeConverters = nullptr;
+void cleanGuiTypesAttributes(void) {
+    if (PY_VERSION_HEX >= 0x03000000 && PY_VERSION_HEX < 0x03060000)
+        return; // PYSIDE-953: testbinding crashes in Python 3.5 when hasattr touches types!
+    for (int i = 0, imax = SBK_NatronGui_IDX_COUNT; i < imax; i++) {
+        PyObject *pyType = reinterpret_cast<PyObject *>(SbkNatronGuiTypes[i]);
+        Shiboken::AutoDecRef attrName(Py_BuildValue("s", "staticMetaObject"));
+        if (pyType && PyObject_HasAttr(pyType, attrName))
+            PyObject_SetAttr(pyType, attrName, Py_None);
+    }
+}
+// Global functions ------------------------------------------------------------
+
+static PyMethodDef NatronGui_methods[] = {
+    {0} // Sentinel
+};
+
+// Classes initialization functions ------------------------------------------------------------
+void init_PyViewer(PyObject *module);
+void init_PyTabWidget(PyObject *module);
+void init_PyModalDialog(PyObject *module);
+void init_PyPanel(PyObject *module);
+void init_PyGuiApplication(PyObject *module);
+void init_GuiApp(PyObject *module);
+
+// Required modules' type and converter arrays.
+PyTypeObject **SbkPySide2_QtGuiTypes;
+SbkConverter **SbkPySide2_QtGuiTypeConverters;
+PyTypeObject **SbkPySide2_QtWidgetsTypes;
+SbkConverter **SbkPySide2_QtWidgetsTypeConverters;
+
+// Module initialization ------------------------------------------------------------
+// Container Type converters.
+
+// C++ to Python conversion for type 'const std::map<QString,NodeCreationProperty* > &'.
+static PyObject *_conststd_map_QString_NodeCreationPropertyPTR_REF_CppToPython__conststd_map_QString_NodeCreationPropertyPTR_REF(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::map<QString,NodeCreationProperty* > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdMapToPyDict - START
+    PyObject* pyOut = PyDict_New();
+    ::std::map<QString,NodeCreationProperty* >::const_iterator it = cppInRef.begin();
+    for (; it != cppInRef.end(); ++it) {
+    ::QString key = it->first;
+    ::NodeCreationProperty* value = it->second;
+    PyObject* pyKey = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &key);
+    PyObject* pyValue = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_NODECREATIONPROPERTY_IDX]), value);
+    PyDict_SetItem(pyOut, pyKey, pyValue);
+    Py_DECREF(pyKey);
+    Py_DECREF(pyValue);
+    }
+    return pyOut;
+    // TEMPLATE - stdMapToPyDict - END
+
+}
+static void _conststd_map_QString_NodeCreationPropertyPTR_REF_PythonToCpp__conststd_map_QString_NodeCreationPropertyPTR_REF(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::map<QString,NodeCreationProperty* > *>(cppOut);
+    // TEMPLATE - pyDictToStdMap - START
+    PyObject* key;
+    PyObject* value;
+    Py_ssize_t pos = 0;
+    while (PyDict_Next(pyIn, &pos, &key, &value)) {
+    ::QString cppKey;
+        Shiboken::Conversions::pythonToCppCopy(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], key, &(cppKey));
+    ::NodeCreationProperty* cppValue{nullptr};
+        Shiboken::Conversions::pythonToCppPointer(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_NODECREATIONPROPERTY_IDX]), value, &(cppValue));
+    cppOutRef.insert(std::make_pair(cppKey, cppValue));
+    }
+    // TEMPLATE - pyDictToStdMap - END
+
+}
+static PythonToCppFunc is__conststd_map_QString_NodeCreationPropertyPTR_REF_PythonToCpp__conststd_map_QString_NodeCreationPropertyPTR_REF_Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleDictTypes(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], false, *PepType_SGTP(SbkNatronEngineTypes[SBK_NODECREATIONPROPERTY_IDX])->converter, true, pyIn))
+        return _conststd_map_QString_NodeCreationPropertyPTR_REF_PythonToCpp__conststd_map_QString_NodeCreationPropertyPTR_REF;
+    return {};
+}
+
+// C++ to Python conversion for type 'std::list<Effect* >'.
+static PyObject *_std_list_EffectPTR__CppToPython__std_list_EffectPTR_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::list<Effect* > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdListToPyList - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::std::list<Effect* >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+    ::Effect* cppItem(*it);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdListToPyList - END
+
+}
+static void _std_list_EffectPTR__PythonToCpp__std_list_EffectPTR_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::list<Effect* > *>(cppOut);
+    // TEMPLATE - pyListToStdList - START
+    for (int i = 0; i < PySequence_Size(pyIn); i++) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, i));
+    ::Effect* cppItem{nullptr};
+        Shiboken::Conversions::pythonToCppPointer(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_EFFECT_IDX]), pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pyListToStdList - END
+
+}
+static PythonToCppFunc is__std_list_EffectPTR__PythonToCpp__std_list_EffectPTR__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::checkSequenceTypes(SbkNatronEngineTypes[SBK_EFFECT_IDX], pyIn))
+        return _std_list_EffectPTR__PythonToCpp__std_list_EffectPTR_;
+    return {};
+}
+
+// C++ to Python conversion for type 'std::list<QString >'.
+static PyObject *_std_list_QString__CppToPython__std_list_QString_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::list<QString > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdListToPyList - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::std::list<QString >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+    ::QString cppItem(*it);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdListToPyList - END
+
+}
+static void _std_list_QString__PythonToCpp__std_list_QString_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::list<QString > *>(cppOut);
+    // TEMPLATE - pyListToStdList - START
+    for (int i = 0; i < PySequence_Size(pyIn); i++) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, i));
+    ::QString cppItem;
+        Shiboken::Conversions::pythonToCppCopy(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pyListToStdList - END
+
+}
+static PythonToCppFunc is__std_list_QString__PythonToCpp__std_list_QString__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], pyIn))
+        return _std_list_QString__PythonToCpp__std_list_QString_;
+    return {};
+}
+
+// C++ to Python conversion for type 'const std::list<int > &'.
+static PyObject *_conststd_list_int_REF_CppToPython__conststd_list_int_REF(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::list<int > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdListToPyList - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::std::list<int >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+    int cppItem(*it);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdListToPyList - END
+
+}
+static void _conststd_list_int_REF_PythonToCpp__conststd_list_int_REF(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::list<int > *>(cppOut);
+    // TEMPLATE - pyListToStdList - START
+    for (int i = 0; i < PySequence_Size(pyIn); i++) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, i));
+    int cppItem;
+        Shiboken::Conversions::pythonToCppCopy(Shiboken::Conversions::PrimitiveTypeConverter<int>(), pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pyListToStdList - END
+
+}
+static PythonToCppFunc is__conststd_list_int_REF_PythonToCpp__conststd_list_int_REF_Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(Shiboken::Conversions::PrimitiveTypeConverter<int>(), pyIn))
+        return _conststd_list_int_REF_PythonToCpp__conststd_list_int_REF;
+    return {};
+}
+
+// C++ to Python conversion for type 'std::list<Param* >'.
+static PyObject *_std_list_ParamPTR__CppToPython__std_list_ParamPTR_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::std::list<Param* > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - stdListToPyList - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::std::list<Param* >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+    ::Param* cppItem(*it);
+    PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - stdListToPyList - END
+
+}
+static void _std_list_ParamPTR__PythonToCpp__std_list_ParamPTR_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::std::list<Param* > *>(cppOut);
+    // TEMPLATE - pyListToStdList - START
+    for (int i = 0; i < PySequence_Size(pyIn); i++) {
+    Shiboken::AutoDecRef pyItem(PySequence_GetItem(pyIn, i));
+    ::Param* cppItem{nullptr};
+        Shiboken::Conversions::pythonToCppPointer(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), pyItem, &(cppItem));
+    cppOutRef.push_back(cppItem);
+    }
+    // TEMPLATE - pyListToStdList - END
+
+}
+static PythonToCppFunc is__std_list_ParamPTR__PythonToCpp__std_list_ParamPTR__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::checkSequenceTypes(SbkNatronEngineTypes[SBK_PARAM_IDX], pyIn))
+        return _std_list_ParamPTR__PythonToCpp__std_list_ParamPTR_;
+    return {};
+}
+
+// C++ to Python conversion for type 'QList<QVariant >'.
+static PyObject *_QList_QVariant__CppToPython__QList_QVariant_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::QList<QVariant > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - cpplist_to_pylist_conversion - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::QList<QVariant >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+        ::QVariant cppItem(*it);
+        PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QVARIANT_IDX], &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - cpplist_to_pylist_conversion - END
+
+}
+static void _QList_QVariant__PythonToCpp__QList_QVariant_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::QList<QVariant > *>(cppOut);
+    // TEMPLATE - pyseq_to_cpplist_conversion - START
+    // PYSIDE-795: Turn all sequences into iterables.
+    Shiboken::AutoDecRef it(PyObject_GetIter(pyIn));
+    PyObject *(*iternext)(PyObject *) = *Py_TYPE(it)->tp_iternext;
+    for (;;) {
+        Shiboken::AutoDecRef pyItem(iternext(it));
+        if (pyItem.isNull()) {
+            if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_StopIteration))
+                PyErr_Clear();
+            break;
+        }
+        ::QVariant cppItem;
+        Shiboken::Conversions::pythonToCppCopy(SbkPySide2_QtCoreTypeConverters[SBK_QVARIANT_IDX], pyItem, &(cppItem));
+        cppOutRef << cppItem;
+    }
+    // TEMPLATE - pyseq_to_cpplist_conversion - END
+
+}
+static PythonToCppFunc is__QList_QVariant__PythonToCpp__QList_QVariant__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(SbkPySide2_QtCoreTypeConverters[SBK_QVARIANT_IDX], pyIn))
+        return _QList_QVariant__PythonToCpp__QList_QVariant_;
+    return {};
+}
+
+// C++ to Python conversion for type 'QList<QString >'.
+static PyObject *_QList_QString__CppToPython__QList_QString_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::QList<QString > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - cpplist_to_pylist_conversion - START
+    PyObject* pyOut = PyList_New((int) cppInRef.size());
+    ::QList<QString >::const_iterator it = cppInRef.begin();
+    for (int idx = 0; it != cppInRef.end(); ++it, ++idx) {
+        ::QString cppItem(*it);
+        PyList_SET_ITEM(pyOut, idx, Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppItem));
+    }
+    return pyOut;
+    // TEMPLATE - cpplist_to_pylist_conversion - END
+
+}
+static void _QList_QString__PythonToCpp__QList_QString_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::QList<QString > *>(cppOut);
+    // TEMPLATE - pyseq_to_cpplist_conversion - START
+    // PYSIDE-795: Turn all sequences into iterables.
+    Shiboken::AutoDecRef it(PyObject_GetIter(pyIn));
+    PyObject *(*iternext)(PyObject *) = *Py_TYPE(it)->tp_iternext;
+    for (;;) {
+        Shiboken::AutoDecRef pyItem(iternext(it));
+        if (pyItem.isNull()) {
+            if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_StopIteration))
+                PyErr_Clear();
+            break;
+        }
+        ::QString cppItem;
+        Shiboken::Conversions::pythonToCppCopy(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], pyItem, &(cppItem));
+        cppOutRef << cppItem;
+    }
+    // TEMPLATE - pyseq_to_cpplist_conversion - END
+
+}
+static PythonToCppFunc is__QList_QString__PythonToCpp__QList_QString__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleSequenceTypes(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], pyIn))
+        return _QList_QString__PythonToCpp__QList_QString_;
+    return {};
+}
+
+// C++ to Python conversion for type 'QMap<QString,QVariant >'.
+static PyObject *_QMap_QString_QVariant__CppToPython__QMap_QString_QVariant_(const void *cppIn) {
+    auto &cppInRef = *reinterpret_cast<::QMap<QString,QVariant > *>(const_cast<void *>(cppIn));
+    // TEMPLATE - cppmap_to_pymap_conversion - START
+    PyObject *pyOut = PyDict_New();
+    for (::QMap<QString,QVariant >::const_iterator it = cppInRef.begin(), end = cppInRef.end(); it != end; ++it) {
+        ::QString key = it.key();
+        ::QVariant value = it.value();
+        PyObject *pyKey = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &key);
+        PyObject *pyValue = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QVARIANT_IDX], &value);
+        PyDict_SetItem(pyOut, pyKey, pyValue);
+        Py_DECREF(pyKey);
+        Py_DECREF(pyValue);
+    }
+    return pyOut;
+    // TEMPLATE - cppmap_to_pymap_conversion - END
+
+}
+static void _QMap_QString_QVariant__PythonToCpp__QMap_QString_QVariant_(PyObject *pyIn, void *cppOut) {
+    auto &cppOutRef = *reinterpret_cast<::QMap<QString,QVariant > *>(cppOut);
+    // TEMPLATE - pydict_to_cppmap_conversion - START
+    PyObject *key;
+    PyObject *value;
+    Py_ssize_t pos = 0;
+    while (PyDict_Next(pyIn, &pos, &key, &value)) {
+        ::QString cppKey;
+        Shiboken::Conversions::pythonToCppCopy(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], key, &(cppKey));
+        ::QVariant cppValue;
+        Shiboken::Conversions::pythonToCppCopy(SbkPySide2_QtCoreTypeConverters[SBK_QVARIANT_IDX], value, &(cppValue));
+        cppOutRef.insert(cppKey, cppValue);
+    }
+    // TEMPLATE - pydict_to_cppmap_conversion - END
+
+}
+static PythonToCppFunc is__QMap_QString_QVariant__PythonToCpp__QMap_QString_QVariant__Convertible(PyObject *pyIn) {
+    if (Shiboken::Conversions::convertibleDictTypes(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], false, SbkPySide2_QtCoreTypeConverters[SBK_QVARIANT_IDX], false, pyIn))
+        return _QMap_QString_QVariant__PythonToCpp__QMap_QString_QVariant_;
+    return {};
+}
+
+
+#ifdef IS_PY3K
+static struct PyModuleDef moduledef = {
+    /* m_base     */ PyModuleDef_HEAD_INIT,
+    /* m_name     */ "NatronGui",
+    /* m_doc      */ nullptr,
+    /* m_size     */ -1,
+    /* m_methods  */ NatronGui_methods,
+    /* m_reload   */ nullptr,
+    /* m_traverse */ nullptr,
+    /* m_clear    */ nullptr,
+    /* m_free     */ nullptr
+};
+
+#endif
+
+// The signatures string for the global functions.
+// Multiple signatures have their index "n:" in front.
+static const char *NatronGui_SignatureStrings[] = {
+    nullptr}; // Sentinel
+
+SBK_MODULE_INIT_FUNCTION_BEGIN(NatronGui)
+    {
+        Shiboken::AutoDecRef requiredModule(Shiboken::Module::import("PySide2.QtGui"));
+        if (requiredModule.isNull())
+            return SBK_MODULE_INIT_ERROR;
+        SbkPySide2_QtGuiTypes = Shiboken::Module::getTypes(requiredModule);
+        SbkPySide2_QtGuiTypeConverters = Shiboken::Module::getTypeConverters(requiredModule);
+    }
+
+    {
+        Shiboken::AutoDecRef requiredModule(Shiboken::Module::import("PySide2.QtCore"));
+        if (requiredModule.isNull())
+            return SBK_MODULE_INIT_ERROR;
+        SbkPySide2_QtCoreTypes = Shiboken::Module::getTypes(requiredModule);
+        SbkPySide2_QtCoreTypeConverters = Shiboken::Module::getTypeConverters(requiredModule);
+    }
+
+    {
+        Shiboken::AutoDecRef requiredModule(Shiboken::Module::import("PySide2.QtWidgets"));
+        if (requiredModule.isNull())
+            return SBK_MODULE_INIT_ERROR;
+        SbkPySide2_QtWidgetsTypes = Shiboken::Module::getTypes(requiredModule);
+        SbkPySide2_QtWidgetsTypeConverters = Shiboken::Module::getTypeConverters(requiredModule);
+    }
+
+    {
+        Shiboken::AutoDecRef requiredModule(Shiboken::Module::import("NatronEngine"));
+        if (requiredModule.isNull())
+            return SBK_MODULE_INIT_ERROR;
+        SbkNatronEngineTypes = Shiboken::Module::getTypes(requiredModule);
+        SbkNatronEngineTypeConverters = Shiboken::Module::getTypeConverters(requiredModule);
+    }
+
+    // Create an array of wrapper types for the current module.
+    static PyTypeObject *cppApi[SBK_NatronGui_IDX_COUNT];
+    SbkNatronGuiTypes = cppApi;
+
+    // Create an array of primitive type converters for the current module.
+    static SbkConverter *sbkConverters[SBK_NatronGui_CONVERTERS_IDX_COUNT];
+    SbkNatronGuiTypeConverters = sbkConverters;
+
+#ifdef IS_PY3K
+    PyObject *module = Shiboken::Module::create("NatronGui", &moduledef);
+#else
+    PyObject *module = Shiboken::Module::create("NatronGui", NatronGui_methods);
+#endif
+
+    // Make module available from global scope
+    SbkNatronGuiModuleObject = module;
+
+    // Initialize classes in the type system
+    init_PyViewer(module);
+    init_PyTabWidget(module);
+    init_PyModalDialog(module);
+    init_PyPanel(module);
+    init_PyGuiApplication(module);
+    init_GuiApp(module);
+
+    // Register converter for type 'const std::map<QString,NodeCreationProperty*>&'.
+    SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_MAP_QSTRING_NODECREATIONPROPERTYPTR_IDX] = Shiboken::Conversions::createConverter(&PyDict_Type, _conststd_map_QString_NodeCreationPropertyPTR_REF_CppToPython__conststd_map_QString_NodeCreationPropertyPTR_REF);
+    Shiboken::Conversions::registerConverterName(SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_MAP_QSTRING_NODECREATIONPROPERTYPTR_IDX], "const std::map<QString,NodeCreationProperty*>&");
+    Shiboken::Conversions::registerConverterName(SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_MAP_QSTRING_NODECREATIONPROPERTYPTR_IDX], "std::map<QString,NodeCreationProperty*>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_MAP_QSTRING_NODECREATIONPROPERTYPTR_IDX],
+        _conststd_map_QString_NodeCreationPropertyPTR_REF_PythonToCpp__conststd_map_QString_NodeCreationPropertyPTR_REF,
+        is__conststd_map_QString_NodeCreationPropertyPTR_REF_PythonToCpp__conststd_map_QString_NodeCreationPropertyPTR_REF_Convertible);
+
+    // Register converter for type 'std::list<Effect*>'.
+    SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_LIST_EFFECTPTR_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, _std_list_EffectPTR__CppToPython__std_list_EffectPTR_);
+    Shiboken::Conversions::registerConverterName(SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_LIST_EFFECTPTR_IDX], "std::list<Effect*>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_LIST_EFFECTPTR_IDX],
+        _std_list_EffectPTR__PythonToCpp__std_list_EffectPTR_,
+        is__std_list_EffectPTR__PythonToCpp__std_list_EffectPTR__Convertible);
+
+    // Register converter for type 'std::list<QString>'.
+    SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_LIST_QSTRING_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, _std_list_QString__CppToPython__std_list_QString_);
+    Shiboken::Conversions::registerConverterName(SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_LIST_QSTRING_IDX], "std::list<QString>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_LIST_QSTRING_IDX],
+        _std_list_QString__PythonToCpp__std_list_QString_,
+        is__std_list_QString__PythonToCpp__std_list_QString__Convertible);
+
+    // Register converter for type 'const std::list<int>&'.
+    SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_LIST_INT_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, _conststd_list_int_REF_CppToPython__conststd_list_int_REF);
+    Shiboken::Conversions::registerConverterName(SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_LIST_INT_IDX], "const std::list<int>&");
+    Shiboken::Conversions::registerConverterName(SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_LIST_INT_IDX], "std::list<int>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_LIST_INT_IDX],
+        _conststd_list_int_REF_PythonToCpp__conststd_list_int_REF,
+        is__conststd_list_int_REF_PythonToCpp__conststd_list_int_REF_Convertible);
+
+    // Register converter for type 'std::list<Param*>'.
+    SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_LIST_PARAMPTR_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, _std_list_ParamPTR__CppToPython__std_list_ParamPTR_);
+    Shiboken::Conversions::registerConverterName(SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_LIST_PARAMPTR_IDX], "std::list<Param*>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronGuiTypeConverters[SBK_NATRONGUI_STD_LIST_PARAMPTR_IDX],
+        _std_list_ParamPTR__PythonToCpp__std_list_ParamPTR_,
+        is__std_list_ParamPTR__PythonToCpp__std_list_ParamPTR__Convertible);
+
+    // Register converter for type 'QList<QVariant>'.
+    SbkNatronGuiTypeConverters[SBK_NATRONGUI_QLIST_QVARIANT_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, _QList_QVariant__CppToPython__QList_QVariant_);
+    Shiboken::Conversions::registerConverterName(SbkNatronGuiTypeConverters[SBK_NATRONGUI_QLIST_QVARIANT_IDX], "QList<QVariant>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronGuiTypeConverters[SBK_NATRONGUI_QLIST_QVARIANT_IDX],
+        _QList_QVariant__PythonToCpp__QList_QVariant_,
+        is__QList_QVariant__PythonToCpp__QList_QVariant__Convertible);
+
+    // Register converter for type 'QList<QString>'.
+    SbkNatronGuiTypeConverters[SBK_NATRONGUI_QLIST_QSTRING_IDX] = Shiboken::Conversions::createConverter(&PyList_Type, _QList_QString__CppToPython__QList_QString_);
+    Shiboken::Conversions::registerConverterName(SbkNatronGuiTypeConverters[SBK_NATRONGUI_QLIST_QSTRING_IDX], "QList<QString>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronGuiTypeConverters[SBK_NATRONGUI_QLIST_QSTRING_IDX],
+        _QList_QString__PythonToCpp__QList_QString_,
+        is__QList_QString__PythonToCpp__QList_QString__Convertible);
+
+    // Register converter for type 'QMap<QString,QVariant>'.
+    SbkNatronGuiTypeConverters[SBK_NATRONGUI_QMAP_QSTRING_QVARIANT_IDX] = Shiboken::Conversions::createConverter(&PyDict_Type, _QMap_QString_QVariant__CppToPython__QMap_QString_QVariant_);
+    Shiboken::Conversions::registerConverterName(SbkNatronGuiTypeConverters[SBK_NATRONGUI_QMAP_QSTRING_QVARIANT_IDX], "QMap<QString,QVariant>");
+    Shiboken::Conversions::addPythonToCppValueConversion(SbkNatronGuiTypeConverters[SBK_NATRONGUI_QMAP_QSTRING_QVARIANT_IDX],
+        _QMap_QString_QVariant__PythonToCpp__QMap_QString_QVariant_,
+        is__QMap_QString_QVariant__PythonToCpp__QMap_QString_QVariant__Convertible);
+
+    // Register primitive types converters.
+
+    Shiboken::Module::registerTypes(module, SbkNatronGuiTypes);
+    Shiboken::Module::registerTypeConverters(module, SbkNatronGuiTypeConverters);
+
+    if (PyErr_Occurred()) {
+        PyErr_Print();
+        Py_FatalError("can't initialize module NatronGui");
+    }
+    PySide::registerCleanupFunction(cleanGuiTypesAttributes);
+
+    FinishSignatureInitialization(module, NatronGui_SignatureStrings);
+
+SBK_MODULE_INIT_FUNCTION_END

--- a/Gui/Qt5/NatronGui/natrongui_python.h
+++ b/Gui/Qt5/NatronGui/natrongui_python.h
@@ -1,0 +1,104 @@
+
+
+#ifndef SBK_NATRONGUI_PYTHON_H
+#define SBK_NATRONGUI_PYTHON_H
+
+#include <sbkpython.h>
+#include <sbkconverter.h>
+// Module Includes
+CLANG_DIAG_OFF(deprecated)
+CLANG_DIAG_OFF(uninitialized)
+CLANG_DIAG_OFF(keyword-macro)
+#include <pyside2_qtgui_python.h> // produces warnings
+CLANG_DIAG_ON(deprecated)
+CLANG_DIAG_ON(uninitialized)
+CLANG_DIAG_ON(keyword-macro)
+CLANG_DIAG_OFF(deprecated)
+CLANG_DIAG_OFF(uninitialized)
+CLANG_DIAG_OFF(keyword-macro)
+#include <pyside2_qtcore_python.h> // produces warnings
+CLANG_DIAG_ON(deprecated)
+CLANG_DIAG_ON(uninitialized)
+CLANG_DIAG_ON(keyword-macro)
+#include <pyside2_qtwidgets_python.h>
+#include <natronengine_python.h>
+
+// Bound library includes
+#include <PythonPanels.h>
+#include <PyGlobalGui.h>
+#include <PyGuiApp.h>
+// Conversion Includes - Primitive Types
+#include <qabstractitemmodel.h>
+#include <QString>
+#include <QStringList>
+#include <signalmanager.h>
+
+// Conversion Includes - Container Types
+#include <pysideqflags.h>
+#include <QLinkedList>
+#include <QList>
+#include <QMap>
+#include <QMultiMap>
+#include <QPair>
+#include <QQueue>
+#include <QSet>
+#include <QStack>
+#include <QVector>
+#include <list>
+#include <map>
+#include <map>
+#include <utility>
+#include <set>
+#include <vector>
+
+// Type indices
+enum : int {
+    SBK_GUIAPP_IDX                                           = 0,
+    SBK_PYGUIAPPLICATION_IDX                                 = 1,
+    SBK_PYMODALDIALOG_IDX                                    = 2,
+    SBK_PYPANEL_IDX                                          = 3,
+    SBK_PYTABWIDGET_IDX                                      = 4,
+    SBK_PYVIEWER_IDX                                         = 5,
+    SBK_NatronGui_IDX_COUNT                                  = 6
+};
+// This variable stores all Python types exported by this module.
+extern PyTypeObject **SbkNatronGuiTypes;
+
+// This variable stores the Python module object exported by this module.
+extern PyObject *SbkNatronGuiModuleObject;
+
+// This variable stores all type converters exported by this module.
+extern SbkConverter **SbkNatronGuiTypeConverters;
+
+// Converter indices
+enum : int {
+    SBK_NATRONGUI_STD_MAP_QSTRING_NODECREATIONPROPERTYPTR_IDX = 0, // const std::map<QString,NodeCreationProperty* > &
+    SBK_NATRONGUI_STD_LIST_EFFECTPTR_IDX                     = 1, // std::list<Effect* >
+    SBK_NATRONGUI_STD_LIST_QSTRING_IDX                       = 2, // std::list<QString >
+    SBK_NATRONGUI_STD_LIST_INT_IDX                           = 3, // const std::list<int > &
+    SBK_NATRONGUI_STD_LIST_PARAMPTR_IDX                      = 4, // std::list<Param* >
+    SBK_NATRONGUI_QLIST_QVARIANT_IDX                         = 5, // QList<QVariant >
+    SBK_NATRONGUI_QLIST_QSTRING_IDX                          = 6, // QList<QString >
+    SBK_NATRONGUI_QMAP_QSTRING_QVARIANT_IDX                  = 7, // QMap<QString,QVariant >
+    SBK_NatronGui_CONVERTERS_IDX_COUNT                       = 8
+};
+// Macros for type check
+
+namespace Shiboken
+{
+
+// PyType functions, to get the PyObjectType for a type T
+QT_WARNING_PUSH
+QT_WARNING_DISABLE_DEPRECATED
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::GuiApp >() { return reinterpret_cast<PyTypeObject *>(SbkNatronGuiTypes[SBK_GUIAPP_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::PyGuiApplication >() { return reinterpret_cast<PyTypeObject *>(SbkNatronGuiTypes[SBK_PYGUIAPPLICATION_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::PyModalDialog >() { return reinterpret_cast<PyTypeObject *>(SbkNatronGuiTypes[SBK_PYMODALDIALOG_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::PyPanel >() { return reinterpret_cast<PyTypeObject *>(SbkNatronGuiTypes[SBK_PYPANEL_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::PyTabWidget >() { return reinterpret_cast<PyTypeObject *>(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX]); }
+template<> inline PyTypeObject *SbkType<NATRON_NAMESPACE::NATRON_PYTHON_NAMESPACE::PyViewer >() { return reinterpret_cast<PyTypeObject *>(SbkNatronGuiTypes[SBK_PYVIEWER_IDX]); }
+QT_WARNING_POP
+
+} // namespace Shiboken
+
+#endif // SBK_NATRONGUI_PYTHON_H
+

--- a/Gui/Qt5/NatronGui/pyguiapplication_wrapper.cpp
+++ b/Gui/Qt5/NatronGui/pyguiapplication_wrapper.cpp
@@ -1,0 +1,685 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natrongui_python.h"
+
+// main header
+#include "pyguiapplication_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void PyGuiApplicationWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void PyGuiApplicationWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+PyGuiApplicationWrapper::PyGuiApplicationWrapper() : PyGuiApplication()
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+PyGuiApplicationWrapper::~PyGuiApplicationWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_PyGuiApplication_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::PyGuiApplication >()))
+        return -1;
+
+    ::PyGuiApplicationWrapper *cptr{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // PyGuiApplication()
+            cptr = new ::PyGuiApplicationWrapper();
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::PyGuiApplication >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    Shiboken::Object::setHasCppWrapper(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+}
+
+static PyObject *Sbk_PyGuiApplicationFunc_addMenuCommand(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyGuiApplication *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYGUIAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+    if (numArgs == 3)
+        goto Sbk_PyGuiApplicationFunc_addMenuCommand_TypeError;
+
+    if (!PyArg_UnpackTuple(args, "addMenuCommand", 2, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: PyGuiApplication::addMenuCommand(QString,QString)
+    // 1: PyGuiApplication::addMenuCommand(QString,QString,Qt::Key,QFlags<Qt::KeyboardModifier>)
+    if (numArgs >= 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        if (numArgs == 2) {
+            overloadId = 0; // addMenuCommand(QString,QString)
+        } else if (numArgs == 4
+            && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(*PepType_SGTP(SbkPySide2_QtCoreTypes[SBK_QT_KEY_IDX])->converter, (pyArgs[2])))
+            && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppConvertible(*PepType_SGTP(SbkPySide2_QtCoreTypes[SBK_QFLAGS_QT_KEYBOARDMODIFIER_IDX])->converter, (pyArgs[3])))) {
+            overloadId = 1; // addMenuCommand(QString,QString,Qt::Key,QFlags<Qt::KeyboardModifier>)
+        }
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyGuiApplicationFunc_addMenuCommand_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // addMenuCommand(const QString & grouping, const QString & pythonFunctionName)
+        {
+            ::QString cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            ::QString cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+
+            if (!PyErr_Occurred()) {
+                // addMenuCommand(QString,QString)
+                cppSelf->addMenuCommand(cppArg0, cppArg1);
+            }
+            break;
+        }
+        case 1: // addMenuCommand(const QString & grouping, const QString & pythonFunctionName, Qt::Key key, const QFlags<Qt::KeyboardModifier> & modifiers)
+        {
+            ::QString cppArg0;
+            pythonToCpp[0](pyArgs[0], &cppArg0);
+            ::QString cppArg1;
+            pythonToCpp[1](pyArgs[1], &cppArg1);
+            ::Qt::Key cppArg2 = static_cast< ::Qt::Key>(0);
+            pythonToCpp[2](pyArgs[2], &cppArg2);
+            ::QFlags<Qt::KeyboardModifier> cppArg3 = QFlags<Qt::KeyboardModifier>(0);
+            pythonToCpp[3](pyArgs[3], &cppArg3);
+
+            if (!PyErr_Occurred()) {
+                // addMenuCommand(QString,QString,Qt::Key,QFlags<Qt::KeyboardModifier>)
+                cppSelf->addMenuCommand(cppArg0, cppArg1, cppArg2, cppArg3);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyGuiApplicationFunc_addMenuCommand_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.PyGuiApplication.addMenuCommand");
+        return {};
+}
+
+static PyObject *Sbk_PyGuiApplicationFunc_errorDialog(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyGuiApplication *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYGUIAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "errorDialog", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: PyGuiApplication::errorDialog(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // errorDialog(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyGuiApplicationFunc_errorDialog_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // errorDialog(QString,QString)
+            cppSelf->errorDialog(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyGuiApplicationFunc_errorDialog_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.PyGuiApplication.errorDialog");
+        return {};
+}
+
+static PyObject *Sbk_PyGuiApplicationFunc_getGuiInstance(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyGuiApplication *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYGUIAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyGuiApplication::getGuiInstance(int)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // getGuiInstance(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyGuiApplicationFunc_getGuiInstance_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getGuiInstance(int)const
+            GuiApp * cppResult = const_cast<const ::PyGuiApplication *>(cppSelf)->getGuiInstance(cppArg0);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronGuiTypes[SBK_GUIAPP_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_PyGuiApplicationFunc_getGuiInstance_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyGuiApplication.getGuiInstance");
+        return {};
+}
+
+static PyObject *Sbk_PyGuiApplicationFunc_getIcon(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyGuiApplication *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYGUIAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyGuiApplication::getIcon(NATRON_ENUM::PixmapEnum)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_PIXMAPENUM_IDX])->converter, (pyArg)))) {
+        overloadId = 0; // getIcon(NATRON_ENUM::PixmapEnum)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyGuiApplicationFunc_getIcon_TypeError;
+
+    // Call function/method
+    {
+        ::NATRON_ENUM::PixmapEnum cppArg0{NATRON_ENUM::NATRON_PIXMAP_PLAYER_PREVIOUS};
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getIcon(NATRON_ENUM::PixmapEnum)const
+            QPixmap cppResult = const_cast<const ::PyGuiApplication *>(cppSelf)->getIcon(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtGuiTypes[SBK_QPIXMAP_IDX]), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_PyGuiApplicationFunc_getIcon_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyGuiApplication.getIcon");
+        return {};
+}
+
+static PyObject *Sbk_PyGuiApplicationFunc_informationDialog(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyGuiApplication *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYGUIAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "informationDialog", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: PyGuiApplication::informationDialog(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // informationDialog(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyGuiApplicationFunc_informationDialog_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // informationDialog(QString,QString)
+            cppSelf->informationDialog(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyGuiApplicationFunc_informationDialog_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.PyGuiApplication.informationDialog");
+        return {};
+}
+
+static PyObject *Sbk_PyGuiApplicationFunc_questionDialog(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyGuiApplication *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYGUIAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "questionDialog", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: PyGuiApplication::questionDialog(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // questionDialog(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyGuiApplicationFunc_questionDialog_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // questionDialog(QString,QString)
+            NATRON_ENUM::StandardButtonEnum cppResult = NATRON_ENUM::StandardButtonEnum(cppSelf->questionDialog(cppArg0, cppArg1));
+            pyResult = Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_STANDARDBUTTONENUM_IDX])->converter, &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_PyGuiApplicationFunc_questionDialog_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.PyGuiApplication.questionDialog");
+        return {};
+}
+
+static PyObject *Sbk_PyGuiApplicationFunc_warningDialog(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyGuiApplication *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYGUIAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "warningDialog", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: PyGuiApplication::warningDialog(QString,QString)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))) {
+        overloadId = 0; // warningDialog(QString,QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyGuiApplicationFunc_warningDialog_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // warningDialog(QString,QString)
+            cppSelf->warningDialog(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyGuiApplicationFunc_warningDialog_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.PyGuiApplication.warningDialog");
+        return {};
+}
+
+
+static const char *Sbk_PyGuiApplication_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_PyGuiApplication_methods[] = {
+    {"addMenuCommand", reinterpret_cast<PyCFunction>(Sbk_PyGuiApplicationFunc_addMenuCommand), METH_VARARGS},
+    {"errorDialog", reinterpret_cast<PyCFunction>(Sbk_PyGuiApplicationFunc_errorDialog), METH_VARARGS},
+    {"getGuiInstance", reinterpret_cast<PyCFunction>(Sbk_PyGuiApplicationFunc_getGuiInstance), METH_O},
+    {"getIcon", reinterpret_cast<PyCFunction>(Sbk_PyGuiApplicationFunc_getIcon), METH_O},
+    {"informationDialog", reinterpret_cast<PyCFunction>(Sbk_PyGuiApplicationFunc_informationDialog), METH_VARARGS},
+    {"questionDialog", reinterpret_cast<PyCFunction>(Sbk_PyGuiApplicationFunc_questionDialog), METH_VARARGS},
+    {"warningDialog", reinterpret_cast<PyCFunction>(Sbk_PyGuiApplicationFunc_warningDialog), METH_VARARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_PyGuiApplication_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::PyGuiApplication *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYGUIAPPLICATION_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<PyGuiApplicationWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_PyGuiApplication_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_PyGuiApplication_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_PyGuiApplication_Type = nullptr;
+static SbkObjectType *Sbk_PyGuiApplication_TypeF(void)
+{
+    return _Sbk_PyGuiApplication_Type;
+}
+
+static PyType_Slot Sbk_PyGuiApplication_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_PyGuiApplication_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_PyGuiApplication_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_PyGuiApplication_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_PyGuiApplication_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_PyGuiApplication_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_PyGuiApplication_spec = {
+    "1:NatronGui.PyGuiApplication",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_PyGuiApplication_slots
+};
+
+} //extern "C"
+
+static void *Sbk_PyGuiApplication_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::PyCoreApplication >()))
+        return dynamic_cast< ::PyGuiApplication *>(reinterpret_cast< ::PyCoreApplication *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void PyGuiApplication_PythonToCpp_PyGuiApplication_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_PyGuiApplication_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_PyGuiApplication_PythonToCpp_PyGuiApplication_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_PyGuiApplication_TypeF())))
+        return PyGuiApplication_PythonToCpp_PyGuiApplication_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *PyGuiApplication_PTR_CppToPython_PyGuiApplication(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::PyGuiApplication *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_PyGuiApplication_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *PyGuiApplication_SignatureStrings[] = {
+    "NatronGui.PyGuiApplication(self)",
+    "1:NatronGui.PyGuiApplication.addMenuCommand(self,grouping:QString,pythonFunctionName:QString)",
+    "0:NatronGui.PyGuiApplication.addMenuCommand(self,grouping:QString,pythonFunctionName:QString,key:PySide2.QtCore.Qt.Key,modifiers:PySide2.QtCore.Qt.KeyboardModifiers)",
+    "NatronGui.PyGuiApplication.errorDialog(self,title:QString,message:QString)",
+    "NatronGui.PyGuiApplication.getGuiInstance(self,idx:int)->NatronGui.GuiApp",
+    "NatronGui.PyGuiApplication.getIcon(self,val:NatronEngine.NATRON_ENUM.PixmapEnum)->PySide2.QtGui.QPixmap",
+    "NatronGui.PyGuiApplication.informationDialog(self,title:QString,message:QString)",
+    "NatronGui.PyGuiApplication.questionDialog(self,title:QString,message:QString)->NatronEngine.NATRON_ENUM.StandardButtonEnum",
+    "NatronGui.PyGuiApplication.warningDialog(self,title:QString,message:QString)",
+    nullptr}; // Sentinel
+
+void init_PyGuiApplication(PyObject *module)
+{
+    _Sbk_PyGuiApplication_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "PyGuiApplication",
+        "PyGuiApplication*",
+        &Sbk_PyGuiApplication_spec,
+        &Shiboken::callCppDestructor< ::PyGuiApplication >,
+        reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PYCOREAPPLICATION_IDX]),
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_PyGuiApplication_Type);
+    InitSignatureStrings(pyType, PyGuiApplication_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_PyGuiApplication_Type), Sbk_PyGuiApplication_PropertyStrings);
+    SbkNatronGuiTypes[SBK_PYGUIAPPLICATION_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_PyGuiApplication_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_PyGuiApplication_TypeF(),
+        PyGuiApplication_PythonToCpp_PyGuiApplication_PTR,
+        is_PyGuiApplication_PythonToCpp_PyGuiApplication_PTR_Convertible,
+        PyGuiApplication_PTR_CppToPython_PyGuiApplication);
+
+    Shiboken::Conversions::registerConverterName(converter, "PyGuiApplication");
+    Shiboken::Conversions::registerConverterName(converter, "PyGuiApplication*");
+    Shiboken::Conversions::registerConverterName(converter, "PyGuiApplication&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::PyGuiApplication).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::PyGuiApplicationWrapper).name());
+
+
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_PyGuiApplication_TypeF(), &Sbk_PyGuiApplication_typeDiscovery);
+
+
+    PyGuiApplicationWrapper::pysideInitQtMetaTypes();
+}

--- a/Gui/Qt5/NatronGui/pyguiapplication_wrapper.h
+++ b/Gui/Qt5/NatronGui/pyguiapplication_wrapper.h
@@ -1,0 +1,43 @@
+#ifndef SBK_PYGUIAPPLICATIONWRAPPER_H
+#define SBK_PYGUIAPPLICATIONWRAPPER_H
+
+#include <PyGlobalGui.h>
+
+
+// Extra includes
+#include <PyGuiApp.h>
+#include <PyAppInstance.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class PyGuiApplicationWrapper : public PyGuiApplication
+{
+public:
+    PyGuiApplicationWrapper();
+    ~PyGuiApplicationWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_PYCOREAPPLICATIONWRAPPER_H
+#  define SBK_PYCOREAPPLICATIONWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class PyCoreApplicationWrapper : public PyCoreApplication
+{
+public:
+    PyCoreApplicationWrapper();
+    ~PyCoreApplicationWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[1];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_PYCOREAPPLICATIONWRAPPER_H
+
+#endif // SBK_PYGUIAPPLICATIONWRAPPER_H
+

--- a/Gui/Qt5/NatronGui/pymodaldialog_wrapper.cpp
+++ b/Gui/Qt5/NatronGui/pymodaldialog_wrapper.cpp
@@ -1,0 +1,888 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <algorithm>
+#include <set>
+#include <iterator>
+
+// module include
+#include "natrongui_python.h"
+
+// main header
+#include "pymodaldialog_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void PyModalDialogWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void PyModalDialogWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+void PyModalDialogWrapper::accept()
+{
+    if (m_PyMethodCache[0]) {
+        return this->::QDialog::accept();
+    }
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "accept";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[0] = true;
+        return this->::QDialog::accept();
+    }
+
+    Shiboken::AutoDecRef pyArgs(PyTuple_New(0));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return;
+    }
+}
+
+void PyModalDialogWrapper::closeEvent(QCloseEvent * arg__1)
+{
+    if (m_PyMethodCache[1]) {
+        return this->::QDialog::closeEvent(arg__1);
+    }
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "closeEvent";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[1] = true;
+        return this->::QDialog::closeEvent(arg__1);
+    }
+
+    Shiboken::AutoDecRef pyArgs(Py_BuildValue("(N)",
+    Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtGuiTypes[SBK_QCLOSEEVENT_IDX]), arg__1)
+    ));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return;
+    }
+}
+
+void PyModalDialogWrapper::contextMenuEvent(QContextMenuEvent * arg__1)
+{
+    if (m_PyMethodCache[2]) {
+        return this->::QDialog::contextMenuEvent(arg__1);
+    }
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "contextMenuEvent";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[2] = true;
+        return this->::QDialog::contextMenuEvent(arg__1);
+    }
+
+    Shiboken::AutoDecRef pyArgs(Py_BuildValue("(N)",
+    Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtGuiTypes[SBK_QCONTEXTMENUEVENT_IDX]), arg__1)
+    ));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return;
+    }
+}
+
+void PyModalDialogWrapper::done(int arg__1)
+{
+    if (m_PyMethodCache[3]) {
+        return this->::QDialog::done(arg__1);
+    }
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "done";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[3] = true;
+        return this->::QDialog::done(arg__1);
+    }
+
+    Shiboken::AutoDecRef pyArgs(Py_BuildValue("(i)",
+    arg__1
+    ));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return;
+    }
+}
+
+bool PyModalDialogWrapper::eventFilter(QObject * arg__1, QEvent * arg__2)
+{
+    if (m_PyMethodCache[4])
+        return this->::QDialog::eventFilter(arg__1, arg__2);
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return false;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "eventFilter";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[4] = true;
+        return this->::QDialog::eventFilter(arg__1, arg__2);
+    }
+
+    Shiboken::AutoDecRef pyArgs(Py_BuildValue("(NN)",
+    Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtCoreTypes[SBK_QOBJECT_IDX]), arg__1),
+    Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtCoreTypes[SBK_QEVENT_IDX]), arg__2)
+    ));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return false;
+    }
+    // Check return type
+    PythonToCppFunc pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), pyResult);
+    if (!pythonToCpp) {
+        Shiboken::warning(PyExc_RuntimeWarning, 2, "Invalid return value in function %s, expected %s, got %s.", "PyModalDialog.eventFilter", "bool", Py_TYPE(pyResult)->tp_name);
+        return false;
+    }
+    bool cppResult;
+    pythonToCpp(pyResult, &cppResult);
+    return cppResult;
+}
+
+int PyModalDialogWrapper::exec()
+{
+    if (m_PyMethodCache[5])
+        return this->::QDialog::exec();
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return 0;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "exec_";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[5] = true;
+        return this->::QDialog::exec();
+    }
+
+    Shiboken::AutoDecRef pyArgs(PyTuple_New(0));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return 0;
+    }
+    // Check return type
+    PythonToCppFunc pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), pyResult);
+    if (!pythonToCpp) {
+        Shiboken::warning(PyExc_RuntimeWarning, 2, "Invalid return value in function %s, expected %s, got %s.", "PyModalDialog.exec_", "int", Py_TYPE(pyResult)->tp_name);
+        return 0;
+    }
+    int cppResult;
+    pythonToCpp(pyResult, &cppResult);
+    return cppResult;
+}
+
+void PyModalDialogWrapper::keyPressEvent(QKeyEvent * arg__1)
+{
+    if (m_PyMethodCache[6]) {
+        return this->::QDialog::keyPressEvent(arg__1);
+    }
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "keyPressEvent";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[6] = true;
+        return this->::QDialog::keyPressEvent(arg__1);
+    }
+
+    Shiboken::AutoDecRef pyArgs(Py_BuildValue("(N)",
+    Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtGuiTypes[SBK_QKEYEVENT_IDX]), arg__1)
+    ));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return;
+    }
+}
+
+void PyModalDialogWrapper::open()
+{
+    if (m_PyMethodCache[7]) {
+        return this->::QDialog::open();
+    }
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "open";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[7] = true;
+        return this->::QDialog::open();
+    }
+
+    Shiboken::AutoDecRef pyArgs(PyTuple_New(0));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return;
+    }
+}
+
+void PyModalDialogWrapper::reject()
+{
+    if (m_PyMethodCache[8]) {
+        return this->::QDialog::reject();
+    }
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "reject";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[8] = true;
+        return this->::QDialog::reject();
+    }
+
+    Shiboken::AutoDecRef pyArgs(PyTuple_New(0));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return;
+    }
+}
+
+void PyModalDialogWrapper::resizeEvent(QResizeEvent * arg__1)
+{
+    if (m_PyMethodCache[9]) {
+        return this->::QDialog::resizeEvent(arg__1);
+    }
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "resizeEvent";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[9] = true;
+        return this->::QDialog::resizeEvent(arg__1);
+    }
+
+    Shiboken::AutoDecRef pyArgs(Py_BuildValue("(N)",
+    Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtGuiTypes[SBK_QRESIZEEVENT_IDX]), arg__1)
+    ));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return;
+    }
+}
+
+void PyModalDialogWrapper::setVisible(bool visible)
+{
+    if (m_PyMethodCache[10]) {
+        return this->::QDialog::setVisible(visible);
+    }
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "setVisible";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[10] = true;
+        return this->::QDialog::setVisible(visible);
+    }
+
+    Shiboken::AutoDecRef pyArgs(Py_BuildValue("(N)",
+    Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &visible)
+    ));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return;
+    }
+}
+
+void PyModalDialogWrapper::showEvent(QShowEvent * arg__1)
+{
+    if (m_PyMethodCache[11]) {
+        return this->::QDialog::showEvent(arg__1);
+    }
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "showEvent";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[11] = true;
+        return this->::QDialog::showEvent(arg__1);
+    }
+
+    Shiboken::AutoDecRef pyArgs(Py_BuildValue("(N)",
+    Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtGuiTypes[SBK_QSHOWEVENT_IDX]), arg__1)
+    ));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return;
+    }
+}
+
+PyModalDialogWrapper::~PyModalDialogWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_PyModalDialogFunc_addWidget(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyModalDialogWrapper *>(reinterpret_cast< ::PyModalDialog *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYMODALDIALOG_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyModalDialog::addWidget(QWidget*)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtWidgetsTypes[SBK_QWIDGET_IDX]), (pyArg)))) {
+        overloadId = 0; // addWidget(QWidget*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyModalDialogFunc_addWidget_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::QWidget *cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // addWidget(QWidget*)
+            cppSelf->addWidget(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyModalDialogFunc_addWidget_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyModalDialog.addWidget");
+        return {};
+}
+
+static PyObject *Sbk_PyModalDialogFunc_getParam(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyModalDialogWrapper *>(reinterpret_cast< ::PyModalDialog *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYMODALDIALOG_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyModalDialog::getParam(QString)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // getParam(QString)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyModalDialogFunc_getParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getParam(QString)const
+            Param * cppResult = const_cast<const ::PyModalDialogWrapper *>(cppSelf)->getParam(cppArg0);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_PyModalDialogFunc_getParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyModalDialog.getParam");
+        return {};
+}
+
+static PyObject *Sbk_PyModalDialogFunc_insertWidget(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyModalDialogWrapper *>(reinterpret_cast< ::PyModalDialog *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYMODALDIALOG_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "insertWidget", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: PyModalDialog::insertWidget(int,QWidget*)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtWidgetsTypes[SBK_QWIDGET_IDX]), (pyArgs[1])))) {
+        overloadId = 0; // insertWidget(int,QWidget*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyModalDialogFunc_insertWidget_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        if (!Shiboken::Object::isValid(pyArgs[1]))
+            return {};
+        ::QWidget *cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // insertWidget(int,QWidget*)
+            cppSelf->insertWidget(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyModalDialogFunc_insertWidget_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.PyModalDialog.insertWidget");
+        return {};
+}
+
+static PyObject *Sbk_PyModalDialogFunc_minimumSizeHint(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyModalDialogWrapper *>(reinterpret_cast< ::PyModalDialog *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYMODALDIALOG_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // minimumSizeHint()const
+            QSize cppResult = Shiboken::Object::hasCppWrapper(reinterpret_cast<SbkObject *>(self))
+                ? const_cast<const ::PyModalDialogWrapper *>(cppSelf)->::PyModalDialog::minimumSizeHint()
+                : const_cast<const ::PyModalDialogWrapper *>(cppSelf)->minimumSizeHint();
+            pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtCoreTypes[SBK_QSIZE_IDX]), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyModalDialogFunc_setParamChangedCallback(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyModalDialogWrapper *>(reinterpret_cast< ::PyModalDialog *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYMODALDIALOG_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyModalDialog::setParamChangedCallback(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setParamChangedCallback(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyModalDialogFunc_setParamChangedCallback_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setParamChangedCallback(QString)
+            cppSelf->setParamChangedCallback(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyModalDialogFunc_setParamChangedCallback_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyModalDialog.setParamChangedCallback");
+        return {};
+}
+
+static PyObject *Sbk_PyModalDialogFunc_sizeHint(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyModalDialogWrapper *>(reinterpret_cast< ::PyModalDialog *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYMODALDIALOG_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // sizeHint()const
+            QSize cppResult = Shiboken::Object::hasCppWrapper(reinterpret_cast<SbkObject *>(self))
+                ? const_cast<const ::PyModalDialogWrapper *>(cppSelf)->::PyModalDialog::sizeHint()
+                : const_cast<const ::PyModalDialogWrapper *>(cppSelf)->sizeHint();
+            pyResult = Shiboken::Conversions::copyToPython(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtCoreTypes[SBK_QSIZE_IDX]), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+
+static const char *Sbk_PyModalDialog_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_PyModalDialog_methods[] = {
+    {"addWidget", reinterpret_cast<PyCFunction>(Sbk_PyModalDialogFunc_addWidget), METH_O},
+    {"getParam", reinterpret_cast<PyCFunction>(Sbk_PyModalDialogFunc_getParam), METH_O},
+    {"insertWidget", reinterpret_cast<PyCFunction>(Sbk_PyModalDialogFunc_insertWidget), METH_VARARGS},
+    {"minimumSizeHint", reinterpret_cast<PyCFunction>(Sbk_PyModalDialogFunc_minimumSizeHint), METH_NOARGS},
+    {"setParamChangedCallback", reinterpret_cast<PyCFunction>(Sbk_PyModalDialogFunc_setParamChangedCallback), METH_O},
+    {"sizeHint", reinterpret_cast<PyCFunction>(Sbk_PyModalDialogFunc_sizeHint), METH_NOARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_PyModalDialog_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::PyModalDialog *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYMODALDIALOG_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<PyModalDialogWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_PyModalDialog_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_PyModalDialog_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+static int mi_offsets[] = { -1, -1, -1, -1, -1 };
+int *
+Sbk_PyModalDialog_mi_init(const void *cptr)
+{
+    if (mi_offsets[0] == -1) {
+        std::set<int> offsets;
+        const auto *class_ptr = reinterpret_cast<const PyModalDialog *>(cptr);
+        const auto base = reinterpret_cast<uintptr_t>(class_ptr);
+        offsets.insert(int(reinterpret_cast<uintptr_t>(static_cast<const QDialog *>(class_ptr)) - base));
+        offsets.insert(int(reinterpret_cast<uintptr_t>(static_cast<const QDialog *>(static_cast<const PyModalDialog *>(static_cast<const void *>(class_ptr)))) - base));
+        offsets.insert(int(reinterpret_cast<uintptr_t>(static_cast<const UserParamHolder *>(class_ptr)) - base));
+        offsets.insert(int(reinterpret_cast<uintptr_t>(static_cast<const UserParamHolder *>(static_cast<const PyModalDialog *>(static_cast<const void *>(class_ptr)))) - base));
+
+        offsets.erase(0);
+
+        std::copy(offsets.cbegin(), offsets.cend(), mi_offsets);
+    }
+    return mi_offsets;
+}
+static void * Sbk_PyModalDialogSpecialCastFunction(void *obj, SbkObjectType *desiredType)
+{
+    auto me = reinterpret_cast< ::PyModalDialog *>(obj);
+    if (desiredType == reinterpret_cast<SbkObjectType *>(SbkPySide2_QtWidgetsTypes[SBK_QDIALOG_IDX]))
+        return static_cast< ::QDialog *>(me);
+    else if (desiredType == reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX]))
+        return static_cast< ::UserParamHolder *>(me);
+    return me;
+}
+
+
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_PyModalDialog_Type = nullptr;
+static SbkObjectType *Sbk_PyModalDialog_TypeF(void)
+{
+    return _Sbk_PyModalDialog_Type;
+}
+
+static PyType_Slot Sbk_PyModalDialog_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_PyModalDialog_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_PyModalDialog_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_PyModalDialog_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_PyModalDialog_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_PyModalDialog_spec = {
+    "1:NatronGui.PyModalDialog",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_PyModalDialog_slots
+};
+
+} //extern "C"
+
+static void *Sbk_PyModalDialog_typeDiscovery(void *cptr, SbkObjectType *instanceType)
+{
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::QDialog >()))
+        return dynamic_cast< ::PyModalDialog *>(reinterpret_cast< ::QDialog *>(cptr));
+    if (instanceType == reinterpret_cast<SbkObjectType *>(Shiboken::SbkType< ::UserParamHolder >()))
+        return dynamic_cast< ::PyModalDialog *>(reinterpret_cast< ::UserParamHolder *>(cptr));
+    return {};
+}
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void PyModalDialog_PythonToCpp_PyModalDialog_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_PyModalDialog_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_PyModalDialog_PythonToCpp_PyModalDialog_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_PyModalDialog_TypeF())))
+        return PyModalDialog_PythonToCpp_PyModalDialog_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *PyModalDialog_PTR_CppToPython_PyModalDialog(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::PyModalDialog *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_PyModalDialog_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *PyModalDialog_SignatureStrings[] = {
+    "NatronGui.PyModalDialog.addWidget(self,widget:PySide2.QtWidgets.QWidget)",
+    "NatronGui.PyModalDialog.getParam(self,scriptName:QString)->NatronEngine.Param",
+    "NatronGui.PyModalDialog.insertWidget(self,index:int,widget:PySide2.QtWidgets.QWidget)",
+    "NatronGui.PyModalDialog.minimumSizeHint(self)->PySide2.QtCore.QSize",
+    "NatronGui.PyModalDialog.setParamChangedCallback(self,callback:QString)",
+    "NatronGui.PyModalDialog.sizeHint(self)->PySide2.QtCore.QSize",
+    nullptr}; // Sentinel
+
+void init_PyModalDialog(PyObject *module)
+{
+    PyObject *Sbk_PyModalDialog_Type_bases = PyTuple_Pack(2,
+        reinterpret_cast<PyObject *>(SbkPySide2_QtWidgetsTypes[SBK_QDIALOG_IDX]),
+        reinterpret_cast<PyObject *>(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX]));
+
+    _Sbk_PyModalDialog_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "PyModalDialog",
+        "PyModalDialog*",
+        &Sbk_PyModalDialog_spec,
+        &Shiboken::callCppDestructor< ::PyModalDialog >,
+        reinterpret_cast<SbkObjectType *>(SbkPySide2_QtWidgetsTypes[SBK_QDIALOG_IDX]),
+        Sbk_PyModalDialog_Type_bases,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_PyModalDialog_Type);
+    InitSignatureStrings(pyType, PyModalDialog_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_PyModalDialog_Type), Sbk_PyModalDialog_PropertyStrings);
+    SbkNatronGuiTypes[SBK_PYMODALDIALOG_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_PyModalDialog_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_PyModalDialog_TypeF(),
+        PyModalDialog_PythonToCpp_PyModalDialog_PTR,
+        is_PyModalDialog_PythonToCpp_PyModalDialog_PTR_Convertible,
+        PyModalDialog_PTR_CppToPython_PyModalDialog);
+
+    Shiboken::Conversions::registerConverterName(converter, "PyModalDialog");
+    Shiboken::Conversions::registerConverterName(converter, "PyModalDialog*");
+    Shiboken::Conversions::registerConverterName(converter, "PyModalDialog&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::PyModalDialog).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::PyModalDialogWrapper).name());
+
+
+    MultipleInheritanceInitFunction func = Sbk_PyModalDialog_mi_init;
+    Shiboken::ObjectType::setMultipleInheritanceFunction(Sbk_PyModalDialog_TypeF(), func);
+    Shiboken::ObjectType::setCastFunction(Sbk_PyModalDialog_TypeF(), &Sbk_PyModalDialogSpecialCastFunction);
+    Shiboken::ObjectType::setTypeDiscoveryFunctionV2(Sbk_PyModalDialog_TypeF(), &Sbk_PyModalDialog_typeDiscovery);
+
+    PySide::Signal::registerSignals(Sbk_PyModalDialog_TypeF(), &::PyModalDialog::staticMetaObject);
+
+    PyModalDialogWrapper::pysideInitQtMetaTypes();
+}

--- a/Gui/Qt5/NatronGui/pymodaldialog_wrapper.h
+++ b/Gui/Qt5/NatronGui/pymodaldialog_wrapper.h
@@ -1,0 +1,81 @@
+#ifndef SBK_PYMODALDIALOGWRAPPER_H
+#define SBK_PYMODALDIALOGWRAPPER_H
+
+#include <PythonPanels.h>
+
+
+// Extra includes
+#include <PyParameter.h>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class PyModalDialogWrapper : public PyModalDialog
+{
+public:
+    void accept() override;
+    inline void adjustPosition_protected(QWidget * arg__1) { PyModalDialog::adjustPosition(arg__1); }
+    inline void closeEvent_protected(QCloseEvent * arg__1) { PyModalDialog::closeEvent(arg__1); }
+    void closeEvent(QCloseEvent * arg__1) override;
+    inline void contextMenuEvent_protected(QContextMenuEvent * arg__1) { PyModalDialog::contextMenuEvent(arg__1); }
+    void contextMenuEvent(QContextMenuEvent * arg__1) override;
+    void done(int arg__1) override;
+    inline bool eventFilter_protected(QObject * arg__1, QEvent * arg__2) { return PyModalDialog::eventFilter(arg__1, arg__2); }
+    bool eventFilter(QObject * arg__1, QEvent * arg__2) override;
+    int exec() override;
+    inline void keyPressEvent_protected(QKeyEvent * arg__1) { PyModalDialog::keyPressEvent(arg__1); }
+    void keyPressEvent(QKeyEvent * arg__1) override;
+    void open() override;
+    void reject() override;
+    inline void resizeEvent_protected(QResizeEvent * arg__1) { PyModalDialog::resizeEvent(arg__1); }
+    void resizeEvent(QResizeEvent * arg__1) override;
+    void setVisible(bool visible) override;
+    inline void showEvent_protected(QShowEvent * arg__1) { PyModalDialog::showEvent(arg__1); }
+    void showEvent(QShowEvent * arg__1) override;
+    ~PyModalDialogWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[12];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  ifndef SBK_QDIALOGWRAPPER_H
+#  define SBK_QDIALOGWRAPPER_H
+
+// Inherited base class:
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class QDialogWrapper : public QDialog
+{
+public:
+    QDialogWrapper(QWidget * parent = nullptr, QFlags<Qt::WindowType> f = Qt::WindowFlags());
+    void accept() override;
+    inline void adjustPosition_protected(QWidget * arg__1) { QDialog::adjustPosition(arg__1); }
+    inline void closeEvent_protected(QCloseEvent * arg__1) { QDialog::closeEvent(arg__1); }
+    void closeEvent(QCloseEvent * arg__1) override;
+    inline void contextMenuEvent_protected(QContextMenuEvent * arg__1) { QDialog::contextMenuEvent(arg__1); }
+    void contextMenuEvent(QContextMenuEvent * arg__1) override;
+    void done(int arg__1) override;
+    inline bool eventFilter_protected(QObject * arg__1, QEvent * arg__2) { return QDialog::eventFilter(arg__1, arg__2); }
+    bool eventFilter(QObject * arg__1, QEvent * arg__2) override;
+    int exec() override;
+    inline void keyPressEvent_protected(QKeyEvent * arg__1) { QDialog::keyPressEvent(arg__1); }
+    void keyPressEvent(QKeyEvent * arg__1) override;
+    QSize minimumSizeHint() const override;
+    void open() override;
+    void reject() override;
+    inline void resizeEvent_protected(QResizeEvent * arg__1) { QDialog::resizeEvent(arg__1); }
+    void resizeEvent(QResizeEvent * arg__1) override;
+    void setVisible(bool visible) override;
+    inline void showEvent_protected(QShowEvent * arg__1) { QDialog::showEvent(arg__1); }
+    void showEvent(QShowEvent * arg__1) override;
+    QSize sizeHint() const override;
+    ~QDialogWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[14];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#  endif // SBK_QDIALOGWRAPPER_H
+
+#endif // SBK_PYMODALDIALOGWRAPPER_H
+

--- a/Gui/Qt5/NatronGui/pypanel_wrapper.cpp
+++ b/Gui/Qt5/NatronGui/pypanel_wrapper.cpp
@@ -1,0 +1,1129 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <algorithm>
+#include <set>
+#include <iterator>
+
+// module include
+#include "natrongui_python.h"
+
+// main header
+#include "pypanel_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+// Native ---------------------------------------------------------
+
+void PyPanelWrapper::pysideInitQtMetaTypes()
+{
+}
+
+void PyPanelWrapper::resetPyMethodCache()
+{
+    std::fill_n(m_PyMethodCache, sizeof(m_PyMethodCache) / sizeof(m_PyMethodCache[0]), false);
+}
+
+PyPanelWrapper::PyPanelWrapper(const QString & scriptName, const QString & label, bool useUserParameters, GuiApp * app) : PyPanel(scriptName, label, useUserParameters, app)
+{
+    resetPyMethodCache();
+    // ... middle
+}
+
+void PyPanelWrapper::enterEvent(QEvent * e)
+{
+    if (m_PyMethodCache[0]) {
+        return this->::PyPanel::enterEvent(e);
+    }
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "enterEvent";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[0] = true;
+        return this->::PyPanel::enterEvent(e);
+    }
+
+    Shiboken::AutoDecRef pyArgs(Py_BuildValue("(N)",
+    Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtCoreTypes[SBK_QEVENT_IDX]), e)
+    ));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return;
+    }
+}
+
+void PyPanelWrapper::keyPressEvent(QKeyEvent * e)
+{
+    if (m_PyMethodCache[1]) {
+        return this->::PyPanel::keyPressEvent(e);
+    }
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "keyPressEvent";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[1] = true;
+        return this->::PyPanel::keyPressEvent(e);
+    }
+
+    Shiboken::AutoDecRef pyArgs(Py_BuildValue("(N)",
+    Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtGuiTypes[SBK_QKEYEVENT_IDX]), e)
+    ));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return;
+    }
+}
+
+void PyPanelWrapper::leaveEvent(QEvent * e)
+{
+    if (m_PyMethodCache[2]) {
+        return this->::PyPanel::leaveEvent(e);
+    }
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "leaveEvent";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[2] = true;
+        return this->::PyPanel::leaveEvent(e);
+    }
+
+    Shiboken::AutoDecRef pyArgs(Py_BuildValue("(N)",
+    Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtCoreTypes[SBK_QEVENT_IDX]), e)
+    ));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return;
+    }
+}
+
+void PyPanelWrapper::mousePressEvent(QMouseEvent * e)
+{
+    if (m_PyMethodCache[3]) {
+        return this->::PyPanel::mousePressEvent(e);
+    }
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "mousePressEvent";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[3] = true;
+        return this->::PyPanel::mousePressEvent(e);
+    }
+
+    Shiboken::AutoDecRef pyArgs(Py_BuildValue("(N)",
+    Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtGuiTypes[SBK_QMOUSEEVENT_IDX]), e)
+    ));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return;
+    }
+}
+
+void PyPanelWrapper::restore(const QString & arg__1)
+{
+    if (m_PyMethodCache[4]) {
+        return this->::PyPanel::restore(arg__1);
+    }
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return;
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "restore";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[4] = true;
+        return this->::PyPanel::restore(arg__1);
+    }
+
+    Shiboken::AutoDecRef pyArgs(Py_BuildValue("(N)",
+    Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &arg__1)
+    ));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return;
+    }
+}
+
+QString PyPanelWrapper::save()
+{
+    if (m_PyMethodCache[5])
+        return this->::PyPanel::save();
+    Shiboken::GilState gil;
+    if (PyErr_Occurred())
+        return ::QString();
+    static PyObject *nameCache[2] = {};
+    static const char *funcName = "save";
+    Shiboken::AutoDecRef pyOverride(Shiboken::BindingManager::instance().getOverride(this, nameCache, funcName));
+    if (pyOverride.isNull()) {
+        gil.release();
+        m_PyMethodCache[5] = true;
+        return this->::PyPanel::save();
+    }
+
+    Shiboken::AutoDecRef pyArgs(PyTuple_New(0));
+
+    Shiboken::AutoDecRef pyResult(PyObject_Call(pyOverride, pyArgs, nullptr));
+    // An error happened in python code!
+    if (pyResult.isNull()) {
+        PyErr_Print();
+        return ::QString();
+    }
+    // Check return type
+    PythonToCppFunc pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], pyResult);
+    if (!pythonToCpp) {
+        Shiboken::warning(PyExc_RuntimeWarning, 2, "Invalid return value in function %s, expected %s, got %s.", "PyPanel.save", "QString", Py_TYPE(pyResult)->tp_name);
+        return ::QString();
+    }
+    ::QString cppResult;
+    pythonToCpp(pyResult, &cppResult);
+    return cppResult;
+}
+
+PyPanelWrapper::~PyPanelWrapper()
+{
+    SbkObject *wrapper = Shiboken::BindingManager::instance().retrieveWrapper(this);
+    Shiboken::Object::destroy(wrapper, this);
+}
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static int
+Sbk_PyPanel_Init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    SbkObject *sbkSelf = reinterpret_cast<SbkObject *>(self);
+    SbkObjectType *type = reinterpret_cast<SbkObjectType *>(self->ob_type);
+    SbkObjectType *myType = reinterpret_cast<SbkObjectType *>(SbkNatronGuiTypes[SBK_PYPANEL_IDX]);
+    if (type != myType)
+        Shiboken::ObjectType::copyMultipleInheritance(type, myType);
+
+    if (Shiboken::Object::isUserType(self) && !Shiboken::ObjectType::canCallConstructor(self->ob_type, Shiboken::SbkType< ::PyPanel >()))
+        return -1;
+
+    ::PyPanelWrapper *cptr{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr, nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0, 0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "PyPanel", 4, 4, &(pyArgs[0]), &(pyArgs[1]), &(pyArgs[2]), &(pyArgs[3])))
+        return -1;
+
+
+    // Overloaded function decisor
+    // 0: PyPanel::PyPanel(QString,QString,bool,GuiApp*)
+    if (numArgs == 4
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArgs[1])))
+        && (pythonToCpp[2] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[2])))
+        && (pythonToCpp[3] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronGuiTypes[SBK_GUIAPP_IDX]), (pyArgs[3])))) {
+        overloadId = 0; // PyPanel(QString,QString,bool,GuiApp*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyPanel_Init_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        ::QString cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+        bool cppArg2;
+        pythonToCpp[2](pyArgs[2], &cppArg2);
+        if (!Shiboken::Object::isValid(pyArgs[3]))
+            return -1;
+        ::GuiApp *cppArg3;
+        pythonToCpp[3](pyArgs[3], &cppArg3);
+
+        if (!PyErr_Occurred()) {
+            // PyPanel(QString,QString,bool,GuiApp*)
+            cptr = new ::PyPanelWrapper(cppArg0, cppArg1, cppArg2, cppArg3);
+        }
+    }
+
+    if (PyErr_Occurred() || !Shiboken::Object::setCppPointer(sbkSelf, Shiboken::SbkType< ::PyPanel >(), cptr)) {
+        delete cptr;
+        return -1;
+    }
+    if (!cptr) goto Sbk_PyPanel_Init_TypeError;
+
+    Shiboken::Object::setValidCpp(sbkSelf, true);
+    Shiboken::Object::setHasCppWrapper(sbkSelf, true);
+    if (Shiboken::BindingManager::instance().hasWrapper(cptr)) {
+        Shiboken::BindingManager::instance().releaseWrapper(Shiboken::BindingManager::instance().retrieveWrapper(cptr));
+    }
+    Shiboken::BindingManager::instance().registerWrapper(sbkSelf, cptr);
+
+
+    return 1;
+
+    Sbk_PyPanel_Init_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.PyPanel");
+        return -1;
+}
+
+static PyObject *Sbk_PyPanelFunc_addWidget(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyPanelWrapper *>(reinterpret_cast< ::PyPanel *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYPANEL_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyPanel::addWidget(QWidget*)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtWidgetsTypes[SBK_QWIDGET_IDX]), (pyArg)))) {
+        overloadId = 0; // addWidget(QWidget*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyPanelFunc_addWidget_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::QWidget *cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // addWidget(QWidget*)
+            cppSelf->addWidget(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyPanelFunc_addWidget_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyPanel.addWidget");
+        return {};
+}
+
+static PyObject *Sbk_PyPanelFunc_enterEvent(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyPanelWrapper *>(reinterpret_cast< ::PyPanel *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYPANEL_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyPanel::enterEvent(QEvent*)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtCoreTypes[SBK_QEVENT_IDX]), (pyArg)))) {
+        overloadId = 0; // enterEvent(QEvent*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyPanelFunc_enterEvent_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::QEvent *cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // enterEvent(QEvent*)
+            static_cast<::PyPanelWrapper *>(cppSelf)->PyPanelWrapper::enterEvent_protected(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyPanelFunc_enterEvent_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyPanel.enterEvent");
+        return {};
+}
+
+static PyObject *Sbk_PyPanelFunc_getPanelLabel(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyPanelWrapper *>(reinterpret_cast< ::PyPanel *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYPANEL_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getPanelLabel()const
+            QString cppResult = const_cast<const ::PyPanelWrapper *>(cppSelf)->getPanelLabel();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyPanelFunc_getPanelScriptName(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyPanelWrapper *>(reinterpret_cast< ::PyPanel *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYPANEL_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getPanelScriptName()const
+            QString cppResult = const_cast<const ::PyPanelWrapper *>(cppSelf)->getPanelScriptName();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyPanelFunc_getParam(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyPanelWrapper *>(reinterpret_cast< ::PyPanel *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYPANEL_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyPanel::getParam(QString)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // getParam(QString)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyPanelFunc_getParam_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getParam(QString)const
+            Param * cppResult = const_cast<const ::PyPanelWrapper *>(cppSelf)->getParam(cppArg0);
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_PyPanelFunc_getParam_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyPanel.getParam");
+        return {};
+}
+
+static PyObject *Sbk_PyPanelFunc_getParams(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyPanelWrapper *>(reinterpret_cast< ::PyPanel *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYPANEL_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getParams()const
+            // Begin code injection
+            std::list<Param*> params = cppSelf->getParams();
+            PyObject* ret = PyList_New((int) params.size());
+            int idx = 0;
+            for (std::list<Param*>::iterator it = params.begin(); it!=params.end(); ++it,++idx) {
+            PyObject* item = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_PARAM_IDX]), *it);
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(item);
+            PyList_SET_ITEM(ret, idx, item);
+            }
+            return ret;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyPanelFunc_insertWidget(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyPanelWrapper *>(reinterpret_cast< ::PyPanel *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYPANEL_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "insertWidget", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: PyPanel::insertWidget(int,QWidget*)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtWidgetsTypes[SBK_QWIDGET_IDX]), (pyArgs[1])))) {
+        overloadId = 0; // insertWidget(int,QWidget*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyPanelFunc_insertWidget_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        if (!Shiboken::Object::isValid(pyArgs[1]))
+            return {};
+        ::QWidget *cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // insertWidget(int,QWidget*)
+            cppSelf->insertWidget(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyPanelFunc_insertWidget_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.PyPanel.insertWidget");
+        return {};
+}
+
+static PyObject *Sbk_PyPanelFunc_keyPressEvent(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyPanelWrapper *>(reinterpret_cast< ::PyPanel *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYPANEL_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyPanel::keyPressEvent(QKeyEvent*)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtGuiTypes[SBK_QKEYEVENT_IDX]), (pyArg)))) {
+        overloadId = 0; // keyPressEvent(QKeyEvent*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyPanelFunc_keyPressEvent_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::QKeyEvent *cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // keyPressEvent(QKeyEvent*)
+            static_cast<::PyPanelWrapper *>(cppSelf)->PyPanelWrapper::keyPressEvent_protected(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyPanelFunc_keyPressEvent_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyPanel.keyPressEvent");
+        return {};
+}
+
+static PyObject *Sbk_PyPanelFunc_leaveEvent(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyPanelWrapper *>(reinterpret_cast< ::PyPanel *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYPANEL_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyPanel::leaveEvent(QEvent*)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtCoreTypes[SBK_QEVENT_IDX]), (pyArg)))) {
+        overloadId = 0; // leaveEvent(QEvent*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyPanelFunc_leaveEvent_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::QEvent *cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // leaveEvent(QEvent*)
+            static_cast<::PyPanelWrapper *>(cppSelf)->PyPanelWrapper::leaveEvent_protected(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyPanelFunc_leaveEvent_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyPanel.leaveEvent");
+        return {};
+}
+
+static PyObject *Sbk_PyPanelFunc_mousePressEvent(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyPanelWrapper *>(reinterpret_cast< ::PyPanel *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYPANEL_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyPanel::mousePressEvent(QMouseEvent*)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtGuiTypes[SBK_QMOUSEEVENT_IDX]), (pyArg)))) {
+        overloadId = 0; // mousePressEvent(QMouseEvent*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyPanelFunc_mousePressEvent_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::QMouseEvent *cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // mousePressEvent(QMouseEvent*)
+            static_cast<::PyPanelWrapper *>(cppSelf)->PyPanelWrapper::mousePressEvent_protected(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyPanelFunc_mousePressEvent_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyPanel.mousePressEvent");
+        return {};
+}
+
+static PyObject *Sbk_PyPanelFunc_onUserDataChanged(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyPanelWrapper *>(reinterpret_cast< ::PyPanel *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYPANEL_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // onUserDataChanged()
+            static_cast<::PyPanelWrapper *>(cppSelf)->PyPanelWrapper::onUserDataChanged_protected();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_PyPanelFunc_restore(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyPanelWrapper *>(reinterpret_cast< ::PyPanel *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYPANEL_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyPanel::restore(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // restore(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyPanelFunc_restore_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // restore(QString)
+            Shiboken::Object::hasCppWrapper(reinterpret_cast<SbkObject *>(self))
+                ? cppSelf->::PyPanel::restore(cppArg0)
+                : cppSelf->restore(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyPanelFunc_restore_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyPanel.restore");
+        return {};
+}
+
+static PyObject *Sbk_PyPanelFunc_save(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyPanelWrapper *>(reinterpret_cast< ::PyPanel *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYPANEL_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // save()
+            QString cppResult = static_cast<::PyPanelWrapper *>(cppSelf)->PyPanelWrapper::save_protected();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyPanelFunc_setPanelLabel(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyPanelWrapper *>(reinterpret_cast< ::PyPanel *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYPANEL_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyPanel::setPanelLabel(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setPanelLabel(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyPanelFunc_setPanelLabel_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setPanelLabel(QString)
+            cppSelf->setPanelLabel(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyPanelFunc_setPanelLabel_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyPanel.setPanelLabel");
+        return {};
+}
+
+static PyObject *Sbk_PyPanelFunc_setParamChangedCallback(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = static_cast<PyPanelWrapper *>(reinterpret_cast< ::PyPanel *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYPANEL_IDX], reinterpret_cast<SbkObject *>(self))));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyPanel::setParamChangedCallback(QString)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], (pyArg)))) {
+        overloadId = 0; // setParamChangedCallback(QString)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyPanelFunc_setParamChangedCallback_TypeError;
+
+    // Call function/method
+    {
+        ::QString cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setParamChangedCallback(QString)
+            cppSelf->setParamChangedCallback(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyPanelFunc_setParamChangedCallback_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyPanel.setParamChangedCallback");
+        return {};
+}
+
+
+static const char *Sbk_PyPanel_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_PyPanel_methods[] = {
+    {"addWidget", reinterpret_cast<PyCFunction>(Sbk_PyPanelFunc_addWidget), METH_O},
+    {"enterEvent", reinterpret_cast<PyCFunction>(Sbk_PyPanelFunc_enterEvent), METH_O},
+    {"getPanelLabel", reinterpret_cast<PyCFunction>(Sbk_PyPanelFunc_getPanelLabel), METH_NOARGS},
+    {"getPanelScriptName", reinterpret_cast<PyCFunction>(Sbk_PyPanelFunc_getPanelScriptName), METH_NOARGS},
+    {"getParam", reinterpret_cast<PyCFunction>(Sbk_PyPanelFunc_getParam), METH_O},
+    {"getParams", reinterpret_cast<PyCFunction>(Sbk_PyPanelFunc_getParams), METH_NOARGS},
+    {"insertWidget", reinterpret_cast<PyCFunction>(Sbk_PyPanelFunc_insertWidget), METH_VARARGS},
+    {"keyPressEvent", reinterpret_cast<PyCFunction>(Sbk_PyPanelFunc_keyPressEvent), METH_O},
+    {"leaveEvent", reinterpret_cast<PyCFunction>(Sbk_PyPanelFunc_leaveEvent), METH_O},
+    {"mousePressEvent", reinterpret_cast<PyCFunction>(Sbk_PyPanelFunc_mousePressEvent), METH_O},
+    {"onUserDataChanged", reinterpret_cast<PyCFunction>(Sbk_PyPanelFunc_onUserDataChanged), METH_NOARGS},
+    {"restore", reinterpret_cast<PyCFunction>(Sbk_PyPanelFunc_restore), METH_O},
+    {"save", reinterpret_cast<PyCFunction>(Sbk_PyPanelFunc_save), METH_NOARGS},
+    {"setPanelLabel", reinterpret_cast<PyCFunction>(Sbk_PyPanelFunc_setPanelLabel), METH_O},
+    {"setParamChangedCallback", reinterpret_cast<PyCFunction>(Sbk_PyPanelFunc_setParamChangedCallback), METH_O},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+static int Sbk_PyPanel_setattro(PyObject *self, PyObject *name, PyObject *value)
+{
+    PySide::Feature::Select(self);
+    if (value && PyCallable_Check(value)) {
+        auto plain_inst = reinterpret_cast< ::PyPanel *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYPANEL_IDX], reinterpret_cast<SbkObject *>(self)));
+        auto inst = dynamic_cast<PyPanelWrapper *>(plain_inst);
+        if (inst)
+            inst->resetPyMethodCache();
+    }
+    return PyObject_GenericSetAttr(self, name, value);
+}
+
+} // extern "C"
+
+static int Sbk_PyPanel_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_PyPanel_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+static int mi_offsets[] = { -1, -1, -1 };
+int *
+Sbk_PyPanel_mi_init(const void *cptr)
+{
+    if (mi_offsets[0] == -1) {
+        std::set<int> offsets;
+        const auto *class_ptr = reinterpret_cast<const PyPanel *>(cptr);
+        const auto base = reinterpret_cast<uintptr_t>(class_ptr);
+        offsets.insert(int(reinterpret_cast<uintptr_t>(static_cast<const UserParamHolder *>(class_ptr)) - base));
+        offsets.insert(int(reinterpret_cast<uintptr_t>(static_cast<const UserParamHolder *>(static_cast<const PyPanel *>(static_cast<const void *>(class_ptr)))) - base));
+
+        offsets.erase(0);
+
+        std::copy(offsets.cbegin(), offsets.cend(), mi_offsets);
+    }
+    return mi_offsets;
+}
+static void * Sbk_PyPanelSpecialCastFunction(void *obj, SbkObjectType *desiredType)
+{
+    auto me = reinterpret_cast< ::PyPanel *>(obj);
+    if (desiredType == reinterpret_cast<SbkObjectType *>(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX]))
+        return static_cast< ::UserParamHolder *>(me);
+    return me;
+}
+
+
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_PyPanel_Type = nullptr;
+static SbkObjectType *Sbk_PyPanel_TypeF(void)
+{
+    return _Sbk_PyPanel_Type;
+}
+
+static PyType_Slot Sbk_PyPanel_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    reinterpret_cast<void *>(Sbk_PyPanel_setattro)},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_PyPanel_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_PyPanel_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_PyPanel_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        reinterpret_cast<void *>(Sbk_PyPanel_Init)},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkObjectTpNew)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_PyPanel_spec = {
+    "1:NatronGui.PyPanel",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_PyPanel_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void PyPanel_PythonToCpp_PyPanel_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_PyPanel_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_PyPanel_PythonToCpp_PyPanel_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_PyPanel_TypeF())))
+        return PyPanel_PythonToCpp_PyPanel_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *PyPanel_PTR_CppToPython_PyPanel(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::PyPanel *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_PyPanel_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *PyPanel_SignatureStrings[] = {
+    "NatronGui.PyPanel(self,scriptName:QString,label:QString,useUserParameters:bool,app:NatronGui.GuiApp)",
+    "NatronGui.PyPanel.addWidget(self,widget:PySide2.QtWidgets.QWidget)",
+    "NatronGui.PyPanel.enterEvent(self,e:PySide2.QtCore.QEvent)",
+    "NatronGui.PyPanel.getPanelLabel(self)->QString",
+    "NatronGui.PyPanel.getPanelScriptName(self)->QString",
+    "NatronGui.PyPanel.getParam(self,scriptName:QString)->NatronEngine.Param",
+    "NatronGui.PyPanel.getParams(self)->std.list[NatronEngine.Param]",
+    "NatronGui.PyPanel.insertWidget(self,index:int,widget:PySide2.QtWidgets.QWidget)",
+    "NatronGui.PyPanel.keyPressEvent(self,e:PySide2.QtGui.QKeyEvent)",
+    "NatronGui.PyPanel.leaveEvent(self,e:PySide2.QtCore.QEvent)",
+    "NatronGui.PyPanel.mousePressEvent(self,e:PySide2.QtGui.QMouseEvent)",
+    "NatronGui.PyPanel.onUserDataChanged(self)",
+    "NatronGui.PyPanel.restore(self,arg__1:QString)",
+    "NatronGui.PyPanel.save(self)->QString",
+    "NatronGui.PyPanel.setPanelLabel(self,label:QString)",
+    "NatronGui.PyPanel.setParamChangedCallback(self,callback:QString)",
+    nullptr}; // Sentinel
+
+void init_PyPanel(PyObject *module)
+{
+    PyObject *Sbk_PyPanel_Type_bases = PyTuple_Pack(1,
+        reinterpret_cast<PyObject *>(SbkNatronEngineTypes[SBK_USERPARAMHOLDER_IDX]));
+
+    _Sbk_PyPanel_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "PyPanel",
+        "PyPanel*",
+        &Sbk_PyPanel_spec,
+        &Shiboken::callCppDestructor< ::PyPanel >,
+        0,
+        Sbk_PyPanel_Type_bases,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_PyPanel_Type);
+    InitSignatureStrings(pyType, PyPanel_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_PyPanel_Type), Sbk_PyPanel_PropertyStrings);
+    SbkNatronGuiTypes[SBK_PYPANEL_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_PyPanel_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_PyPanel_TypeF(),
+        PyPanel_PythonToCpp_PyPanel_PTR,
+        is_PyPanel_PythonToCpp_PyPanel_PTR_Convertible,
+        PyPanel_PTR_CppToPython_PyPanel);
+
+    Shiboken::Conversions::registerConverterName(converter, "PyPanel");
+    Shiboken::Conversions::registerConverterName(converter, "PyPanel*");
+    Shiboken::Conversions::registerConverterName(converter, "PyPanel&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::PyPanel).name());
+    Shiboken::Conversions::registerConverterName(converter, typeid(::PyPanelWrapper).name());
+
+
+    MultipleInheritanceInitFunction func = Sbk_PyPanel_mi_init;
+    Shiboken::ObjectType::setMultipleInheritanceFunction(Sbk_PyPanel_TypeF(), func);
+    Shiboken::ObjectType::setCastFunction(Sbk_PyPanel_TypeF(), &Sbk_PyPanelSpecialCastFunction);
+
+    PyPanelWrapper::pysideInitQtMetaTypes();
+}

--- a/Gui/Qt5/NatronGui/pypanel_wrapper.h
+++ b/Gui/Qt5/NatronGui/pypanel_wrapper.h
@@ -1,0 +1,37 @@
+#ifndef SBK_PYPANELWRAPPER_H
+#define SBK_PYPANELWRAPPER_H
+
+#include <PythonPanels.h>
+
+
+// Extra includes
+#include <PyGuiApp.h>
+#include <PyParameter.h>
+#include <list>
+NATRON_NAMESPACE_ENTER NATRON_PYTHON_NAMESPACE_ENTER
+class PyPanelWrapper : public PyPanel
+{
+public:
+    PyPanelWrapper(const QString & scriptName, const QString & label, bool useUserParameters, GuiApp * app);
+    inline void enterEvent_protected(QEvent * e) { PyPanel::enterEvent(e); }
+    void enterEvent(QEvent * e) override;
+    inline void keyPressEvent_protected(QKeyEvent * e) { PyPanel::keyPressEvent(e); }
+    void keyPressEvent(QKeyEvent * e) override;
+    inline void leaveEvent_protected(QEvent * e) { PyPanel::leaveEvent(e); }
+    void leaveEvent(QEvent * e) override;
+    inline void mousePressEvent_protected(QMouseEvent * e) { PyPanel::mousePressEvent(e); }
+    void mousePressEvent(QMouseEvent * e) override;
+    inline void onUserDataChanged_protected() { PyPanel::onUserDataChanged(); }
+    void restore(const QString & arg__1) override;
+    inline QString save_protected() { return PyPanel::save(); }
+    QString save() override;
+    ~PyPanelWrapper();
+    static void pysideInitQtMetaTypes();
+    void resetPyMethodCache();
+private:
+    mutable bool m_PyMethodCache[6];
+};
+NATRON_PYTHON_NAMESPACE_EXIT NATRON_NAMESPACE_EXIT
+
+#endif // SBK_PYPANELWRAPPER_H
+

--- a/Gui/Qt5/NatronGui/pytabwidget_wrapper.cpp
+++ b/Gui/Qt5/NatronGui/pytabwidget_wrapper.cpp
@@ -1,0 +1,797 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natrongui_python.h"
+
+// main header
+#include "pytabwidget_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+// Extra includes
+#include <PythonPanels.h>
+
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_PyTabWidgetFunc_appendTab(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyTabWidget::appendTab(PyPanel*)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronGuiTypes[SBK_PYPANEL_IDX]), (pyArg)))) {
+        overloadId = 0; // appendTab(PyPanel*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyTabWidgetFunc_appendTab_TypeError;
+
+    // Call function/method
+    {
+        if (!Shiboken::Object::isValid(pyArg))
+            return {};
+        ::PyPanel *cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // appendTab(PyPanel*)
+            // Begin code injection
+            bool cppResult = cppSelf->appendTab(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_PyTabWidgetFunc_appendTab_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyTabWidget.appendTab");
+        return {};
+}
+
+static PyObject *Sbk_PyTabWidgetFunc_closeCurrentTab(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // closeCurrentTab()
+            cppSelf->closeCurrentTab();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_PyTabWidgetFunc_closePane(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // closePane()
+            cppSelf->closePane();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_PyTabWidgetFunc_closeTab(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyTabWidget::closeTab(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // closeTab(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyTabWidgetFunc_closeTab_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // closeTab(int)
+            cppSelf->closeTab(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyTabWidgetFunc_closeTab_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyTabWidget.closeTab");
+        return {};
+}
+
+static PyObject *Sbk_PyTabWidgetFunc_count(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // count()
+            int cppResult = cppSelf->count();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyTabWidgetFunc_currentWidget(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // currentWidget()
+            QWidget * cppResult = cppSelf->currentWidget();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtWidgetsTypes[SBK_QWIDGET_IDX]), cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyTabWidgetFunc_floatCurrentTab(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // floatCurrentTab()
+            cppSelf->floatCurrentTab();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_PyTabWidgetFunc_floatPane(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // floatPane()
+            cppSelf->floatPane();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_PyTabWidgetFunc_getCurrentIndex(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getCurrentIndex()const
+            int cppResult = const_cast<const ::PyTabWidget *>(cppSelf)->getCurrentIndex();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyTabWidgetFunc_getScriptName(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getScriptName()const
+            QString cppResult = const_cast<const ::PyTabWidget *>(cppSelf)->getScriptName();
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyTabWidgetFunc_getTabLabel(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyTabWidget::getTabLabel(int)const
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // getTabLabel(int)const
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyTabWidgetFunc_getTabLabel_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // getTabLabel(int)const
+            QString cppResult = const_cast<const ::PyTabWidget *>(cppSelf)->getTabLabel(cppArg0);
+            pyResult = Shiboken::Conversions::copyToPython(SbkPySide2_QtCoreTypeConverters[SBK_QSTRING_IDX], &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+
+    Sbk_PyTabWidgetFunc_getTabLabel_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyTabWidget.getTabLabel");
+        return {};
+}
+
+static PyObject *Sbk_PyTabWidgetFunc_insertTab(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "insertTab", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: PyTabWidget::insertTab(int,PyPanel*)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkNatronGuiTypes[SBK_PYPANEL_IDX]), (pyArgs[1])))) {
+        overloadId = 0; // insertTab(int,PyPanel*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyTabWidgetFunc_insertTab_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        if (!Shiboken::Object::isValid(pyArgs[1]))
+            return {};
+        ::PyPanel *cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // insertTab(int,PyPanel*)
+            // Begin code injection
+            cppSelf->insertTab(cppArg0,cppArg1);
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyTabWidgetFunc_insertTab_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.PyTabWidget.insertTab");
+        return {};
+}
+
+static PyObject *Sbk_PyTabWidgetFunc_removeTab(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyTabWidget::removeTab(QWidget*)
+    // 1: PyTabWidget::removeTab(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 1; // removeTab(int)
+    } else if ((pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkPySide2_QtWidgetsTypes[SBK_QWIDGET_IDX]), (pyArg)))) {
+        overloadId = 0; // removeTab(QWidget*)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyTabWidgetFunc_removeTab_TypeError;
+
+    // Call function/method
+    switch (overloadId) {
+        case 0: // removeTab(QWidget * tab)
+        {
+            if (!Shiboken::Object::isValid(pyArg))
+                return {};
+            ::QWidget *cppArg0;
+            pythonToCpp(pyArg, &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // removeTab(QWidget*)
+                cppSelf->removeTab(cppArg0);
+            }
+            break;
+        }
+        case 1: // removeTab(int index)
+        {
+            int cppArg0;
+            pythonToCpp(pyArg, &cppArg0);
+
+            if (!PyErr_Occurred()) {
+                // removeTab(int)
+                cppSelf->removeTab(cppArg0);
+            }
+            break;
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyTabWidgetFunc_removeTab_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyTabWidget.removeTab");
+        return {};
+}
+
+static PyObject *Sbk_PyTabWidgetFunc_setCurrentIndex(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyTabWidget::setCurrentIndex(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // setCurrentIndex(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyTabWidgetFunc_setCurrentIndex_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setCurrentIndex(int)
+            cppSelf->setCurrentIndex(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyTabWidgetFunc_setCurrentIndex_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyTabWidget.setCurrentIndex");
+        return {};
+}
+
+static PyObject *Sbk_PyTabWidgetFunc_setNextTabCurrent(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // setNextTabCurrent()
+            cppSelf->setNextTabCurrent();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_PyTabWidgetFunc_splitHorizontally(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // splitHorizontally()
+            PyTabWidget * cppResult = cppSelf->splitHorizontally();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyTabWidgetFunc_splitVertically(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyTabWidget *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // splitVertically()
+            PyTabWidget * cppResult = cppSelf->splitVertically();
+            pyResult = Shiboken::Conversions::pointerToPython(reinterpret_cast<SbkObjectType *>(SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX]), cppResult);
+
+            // Ownership transferences.
+            Shiboken::Object::getOwnership(pyResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+
+static const char *Sbk_PyTabWidget_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_PyTabWidget_methods[] = {
+    {"appendTab", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_appendTab), METH_O},
+    {"closeCurrentTab", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_closeCurrentTab), METH_NOARGS},
+    {"closePane", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_closePane), METH_NOARGS},
+    {"closeTab", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_closeTab), METH_O},
+    {"count", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_count), METH_NOARGS},
+    {"currentWidget", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_currentWidget), METH_NOARGS},
+    {"floatCurrentTab", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_floatCurrentTab), METH_NOARGS},
+    {"floatPane", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_floatPane), METH_NOARGS},
+    {"getCurrentIndex", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_getCurrentIndex), METH_NOARGS},
+    {"getScriptName", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_getScriptName), METH_NOARGS},
+    {"getTabLabel", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_getTabLabel), METH_O},
+    {"insertTab", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_insertTab), METH_VARARGS},
+    {"removeTab", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_removeTab), METH_O},
+    {"setCurrentIndex", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_setCurrentIndex), METH_O},
+    {"setNextTabCurrent", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_setNextTabCurrent), METH_NOARGS},
+    {"splitHorizontally", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_splitHorizontally), METH_NOARGS},
+    {"splitVertically", reinterpret_cast<PyCFunction>(Sbk_PyTabWidgetFunc_splitVertically), METH_NOARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+} // extern "C"
+
+static int Sbk_PyTabWidget_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_PyTabWidget_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_PyTabWidget_Type = nullptr;
+static SbkObjectType *Sbk_PyTabWidget_TypeF(void)
+{
+    return _Sbk_PyTabWidget_Type;
+}
+
+static PyType_Slot Sbk_PyTabWidget_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    nullptr},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_PyTabWidget_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_PyTabWidget_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_PyTabWidget_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_PyTabWidget_spec = {
+    "1:NatronGui.PyTabWidget",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_PyTabWidget_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void PyTabWidget_PythonToCpp_PyTabWidget_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_PyTabWidget_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_PyTabWidget_PythonToCpp_PyTabWidget_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_PyTabWidget_TypeF())))
+        return PyTabWidget_PythonToCpp_PyTabWidget_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *PyTabWidget_PTR_CppToPython_PyTabWidget(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::PyTabWidget *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_PyTabWidget_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *PyTabWidget_SignatureStrings[] = {
+    "NatronGui.PyTabWidget.appendTab(self,tab:NatronGui.PyPanel)->bool",
+    "NatronGui.PyTabWidget.closeCurrentTab(self)",
+    "NatronGui.PyTabWidget.closePane(self)",
+    "NatronGui.PyTabWidget.closeTab(self,index:int)",
+    "NatronGui.PyTabWidget.count(self)->int",
+    "NatronGui.PyTabWidget.currentWidget(self)->PySide2.QtWidgets.QWidget",
+    "NatronGui.PyTabWidget.floatCurrentTab(self)",
+    "NatronGui.PyTabWidget.floatPane(self)",
+    "NatronGui.PyTabWidget.getCurrentIndex(self)->int",
+    "NatronGui.PyTabWidget.getScriptName(self)->QString",
+    "NatronGui.PyTabWidget.getTabLabel(self,index:int)->QString",
+    "NatronGui.PyTabWidget.insertTab(self,index:int,tab:NatronGui.PyPanel)",
+    "1:NatronGui.PyTabWidget.removeTab(self,tab:PySide2.QtWidgets.QWidget)",
+    "0:NatronGui.PyTabWidget.removeTab(self,index:int)",
+    "NatronGui.PyTabWidget.setCurrentIndex(self,index:int)",
+    "NatronGui.PyTabWidget.setNextTabCurrent(self)",
+    "NatronGui.PyTabWidget.splitHorizontally(self)->NatronGui.PyTabWidget",
+    "NatronGui.PyTabWidget.splitVertically(self)->NatronGui.PyTabWidget",
+    nullptr}; // Sentinel
+
+void init_PyTabWidget(PyObject *module)
+{
+    _Sbk_PyTabWidget_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "PyTabWidget",
+        "PyTabWidget*",
+        &Sbk_PyTabWidget_spec,
+        &Shiboken::callCppDestructor< ::PyTabWidget >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_PyTabWidget_Type);
+    InitSignatureStrings(pyType, PyTabWidget_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_PyTabWidget_Type), Sbk_PyTabWidget_PropertyStrings);
+    SbkNatronGuiTypes[SBK_PYTABWIDGET_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_PyTabWidget_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_PyTabWidget_TypeF(),
+        PyTabWidget_PythonToCpp_PyTabWidget_PTR,
+        is_PyTabWidget_PythonToCpp_PyTabWidget_PTR_Convertible,
+        PyTabWidget_PTR_CppToPython_PyTabWidget);
+
+    Shiboken::Conversions::registerConverterName(converter, "PyTabWidget");
+    Shiboken::Conversions::registerConverterName(converter, "PyTabWidget*");
+    Shiboken::Conversions::registerConverterName(converter, "PyTabWidget&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::PyTabWidget).name());
+
+
+
+}

--- a/Gui/Qt5/NatronGui/pytabwidget_wrapper.h
+++ b/Gui/Qt5/NatronGui/pytabwidget_wrapper.h
@@ -1,0 +1,7 @@
+#ifndef SBK_PYTABWIDGET_H
+#define SBK_PYTABWIDGET_H
+
+#include <PythonPanels.h>
+
+#endif // SBK_PYTABWIDGET_H
+

--- a/Gui/Qt5/NatronGui/pyviewer_wrapper.cpp
+++ b/Gui/Qt5/NatronGui/pyviewer_wrapper.cpp
@@ -1,0 +1,1083 @@
+
+// default includes
+#include "Global/Macros.h"
+CLANG_DIAG_OFF(mismatched-tags)
+GCC_DIAG_OFF(unused-parameter)
+GCC_DIAG_OFF(missing-field-initializers)
+GCC_DIAG_OFF(missing-declarations)
+GCC_DIAG_OFF(uninitialized)
+GCC_DIAG_UNUSED_LOCAL_TYPEDEFS_OFF
+#include <pysidesignal.h>
+#include <shiboken.h> // produces many warnings
+#ifndef QT_NO_VERSION_TAGGING
+#  define QT_NO_VERSION_TAGGING
+#endif
+#include <QDebug>
+#include <pysidesignal.h>
+#include <pysideproperty.h>
+#include <pyside.h>
+#include <pysideqenum.h>
+#include <feature_select.h>
+#include <qapp_macro.h>
+
+QT_WARNING_DISABLE_DEPRECATED
+
+#include <typeinfo>
+#include <iterator>
+
+// module include
+#include "natrongui_python.h"
+
+// main header
+#include "pyviewer_wrapper.h"
+
+// inner classes
+NATRON_NAMESPACE_USING NATRON_PYTHON_NAMESPACE_USING
+
+#include <cctype>
+#include <cstring>
+
+
+
+template <class T>
+static const char *typeNameOf(const T &t)
+{
+    const char *typeName =  typeid(t).name();
+    auto size = std::strlen(typeName);
+#if defined(Q_CC_MSVC) // MSVC: "class QPaintDevice * __ptr64"
+    if (auto lastStar = strchr(typeName, '*')) {
+        // MSVC: "class QPaintDevice * __ptr64"
+        while (*--lastStar == ' ') {
+        }
+        size = lastStar - typeName + 1;
+    }
+#else // g++, Clang: "QPaintDevice *" -> "P12QPaintDevice"
+    if (size > 2 && typeName[0] == 'P' && std::isdigit(typeName[1])) {
+        ++typeName;
+        --size;
+    }
+#endif
+    char *result = new char[size + 1];
+    result[size] = '\0';
+    memcpy(result, typeName, size);
+    return result;
+}
+
+
+// Target ---------------------------------------------------------
+
+extern "C" {
+static PyObject *Sbk_PyViewerFunc_getAInput(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getAInput()const
+            int cppResult = const_cast<const ::PyViewer *>(cppSelf)->getAInput();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyViewerFunc_getBInput(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getBInput()const
+            int cppResult = const_cast<const ::PyViewer *>(cppSelf)->getBInput();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyViewerFunc_getChannels(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getChannels()const
+            NATRON_ENUM::DisplayChannelsEnum cppResult = NATRON_ENUM::DisplayChannelsEnum(const_cast<const ::PyViewer *>(cppSelf)->getChannels());
+            pyResult = Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX])->converter, &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyViewerFunc_getCompositingOperator(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getCompositingOperator()const
+            NATRON_ENUM::ViewerCompositingOperatorEnum cppResult = NATRON_ENUM::ViewerCompositingOperatorEnum(const_cast<const ::PyViewer *>(cppSelf)->getCompositingOperator());
+            pyResult = Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX])->converter, &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyViewerFunc_getCurrentFrame(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getCurrentFrame()
+            int cppResult = cppSelf->getCurrentFrame();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyViewerFunc_getCurrentView(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getCurrentView()const
+            int cppResult = const_cast<const ::PyViewer *>(cppSelf)->getCurrentView();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyViewerFunc_getFrameRange(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getFrameRange(int*,int*)const
+            // Begin code injection
+            int x,y;
+            cppSelf->getFrameRange(&x,&y);
+            pyResult = PyTuple_New(2);
+            PyTuple_SET_ITEM(pyResult, 0, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &x));
+            PyTuple_SET_ITEM(pyResult, 1, Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &y));
+            return pyResult;
+
+            // End of code injection
+
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyViewerFunc_getPlaybackMode(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getPlaybackMode()const
+            NATRON_ENUM::PlaybackModeEnum cppResult = NATRON_ENUM::PlaybackModeEnum(const_cast<const ::PyViewer *>(cppSelf)->getPlaybackMode());
+            pyResult = Shiboken::Conversions::copyToPython(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_PLAYBACKMODEENUM_IDX])->converter, &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyViewerFunc_getProxyIndex(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // getProxyIndex()const
+            int cppResult = const_cast<const ::PyViewer *>(cppSelf)->getProxyIndex();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<int>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyViewerFunc_isProxyModeEnabled(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    PyObject *pyResult{};
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // isProxyModeEnabled()const
+            bool cppResult = const_cast<const ::PyViewer *>(cppSelf)->isProxyModeEnabled();
+            pyResult = Shiboken::Conversions::copyToPython(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), &cppResult);
+        }
+    }
+
+    if (PyErr_Occurred() || !pyResult) {
+        Py_XDECREF(pyResult);
+        return {};
+    }
+    return pyResult;
+}
+
+static PyObject *Sbk_PyViewerFunc_pause(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // pause()
+            cppSelf->pause();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_PyViewerFunc_redraw(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // redraw()
+            cppSelf->redraw();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_PyViewerFunc_renderCurrentFrame(PyObject *self, PyObject *args, PyObject *kwds)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numNamedArgs = (kwds ? PyDict_Size(kwds) : 0);
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0};
+
+    // invalid argument lengths
+    if (numArgs + numNamedArgs > 1) {
+        PyErr_SetString(PyExc_TypeError, "NatronGui.PyViewer.renderCurrentFrame(): too many arguments");
+        return {};
+    }
+
+    if (!PyArg_ParseTuple(args, "|O:renderCurrentFrame", &(pyArgs[0])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: PyViewer::renderCurrentFrame(bool)
+    if (numArgs == 0) {
+        overloadId = 0; // renderCurrentFrame(bool)
+    } else if ((pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[0])))) {
+        overloadId = 0; // renderCurrentFrame(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyViewerFunc_renderCurrentFrame_TypeError;
+
+    // Call function/method
+    {
+        if (kwds) {
+            PyObject *keyName = nullptr;
+            PyObject *value = nullptr;
+            keyName = Py_BuildValue("s","useCache");
+            if (PyDict_Contains(kwds, keyName)) {
+                value = PyDict_GetItem(kwds, keyName);
+                if (value && pyArgs[0]) {
+                    PyErr_SetString(PyExc_TypeError, "NatronGui.PyViewer.renderCurrentFrame(): got multiple values for keyword argument 'useCache'.");
+                    return {};
+                }
+                if (value) {
+                    pyArgs[0] = value;
+                    if (!(pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArgs[0]))))
+                        goto Sbk_PyViewerFunc_renderCurrentFrame_TypeError;
+                }
+            }
+        }
+        bool cppArg0 = true;
+        if (pythonToCpp[0]) pythonToCpp[0](pyArgs[0], &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // renderCurrentFrame(bool)
+            cppSelf->renderCurrentFrame(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyViewerFunc_renderCurrentFrame_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.PyViewer.renderCurrentFrame");
+        return {};
+}
+
+static PyObject *Sbk_PyViewerFunc_seek(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyViewer::seek(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // seek(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyViewerFunc_seek_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // seek(int)
+            cppSelf->seek(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyViewerFunc_seek_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyViewer.seek");
+        return {};
+}
+
+static PyObject *Sbk_PyViewerFunc_setAInput(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyViewer::setAInput(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // setAInput(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyViewerFunc_setAInput_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setAInput(int)
+            cppSelf->setAInput(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyViewerFunc_setAInput_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyViewer.setAInput");
+        return {};
+}
+
+static PyObject *Sbk_PyViewerFunc_setBInput(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyViewer::setBInput(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // setBInput(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyViewerFunc_setBInput_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setBInput(int)
+            cppSelf->setBInput(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyViewerFunc_setBInput_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyViewer.setBInput");
+        return {};
+}
+
+static PyObject *Sbk_PyViewerFunc_setChannels(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyViewer::setChannels(NATRON_ENUM::DisplayChannelsEnum)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_DISPLAYCHANNELSENUM_IDX])->converter, (pyArg)))) {
+        overloadId = 0; // setChannels(NATRON_ENUM::DisplayChannelsEnum)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyViewerFunc_setChannels_TypeError;
+
+    // Call function/method
+    {
+        ::NATRON_ENUM::DisplayChannelsEnum cppArg0{NATRON_ENUM::eDisplayChannelsRGB};
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setChannels(NATRON_ENUM::DisplayChannelsEnum)
+            cppSelf->setChannels(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyViewerFunc_setChannels_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyViewer.setChannels");
+        return {};
+}
+
+static PyObject *Sbk_PyViewerFunc_setCompositingOperator(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyViewer::setCompositingOperator(NATRON_ENUM::ViewerCompositingOperatorEnum)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_VIEWERCOMPOSITINGOPERATORENUM_IDX])->converter, (pyArg)))) {
+        overloadId = 0; // setCompositingOperator(NATRON_ENUM::ViewerCompositingOperatorEnum)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyViewerFunc_setCompositingOperator_TypeError;
+
+    // Call function/method
+    {
+        ::NATRON_ENUM::ViewerCompositingOperatorEnum cppArg0{NATRON_ENUM::eViewerCompositingOperatorNone};
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setCompositingOperator(NATRON_ENUM::ViewerCompositingOperatorEnum)
+            cppSelf->setCompositingOperator(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyViewerFunc_setCompositingOperator_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyViewer.setCompositingOperator");
+        return {};
+}
+
+static PyObject *Sbk_PyViewerFunc_setCurrentView(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyViewer::setCurrentView(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // setCurrentView(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyViewerFunc_setCurrentView_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setCurrentView(int)
+            cppSelf->setCurrentView(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyViewerFunc_setCurrentView_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyViewer.setCurrentView");
+        return {};
+}
+
+static PyObject *Sbk_PyViewerFunc_setFrameRange(PyObject *self, PyObject *args)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp[] = { nullptr, nullptr };
+    SBK_UNUSED(pythonToCpp)
+    const Py_ssize_t numArgs = PyTuple_GET_SIZE(args);
+    SBK_UNUSED(numArgs)
+    PyObject *pyArgs[] = {0, 0};
+
+    // invalid argument lengths
+
+
+    if (!PyArg_UnpackTuple(args, "setFrameRange", 2, 2, &(pyArgs[0]), &(pyArgs[1])))
+        return {};
+
+
+    // Overloaded function decisor
+    // 0: PyViewer::setFrameRange(int,int)
+    if (numArgs == 2
+        && (pythonToCpp[0] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[0])))
+        && (pythonToCpp[1] = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArgs[1])))) {
+        overloadId = 0; // setFrameRange(int,int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyViewerFunc_setFrameRange_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp[0](pyArgs[0], &cppArg0);
+        int cppArg1;
+        pythonToCpp[1](pyArgs[1], &cppArg1);
+
+        if (!PyErr_Occurred()) {
+            // setFrameRange(int,int)
+            cppSelf->setFrameRange(cppArg0, cppArg1);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyViewerFunc_setFrameRange_TypeError:
+        Shiboken::setErrorAboutWrongArguments(args, "NatronGui.PyViewer.setFrameRange");
+        return {};
+}
+
+static PyObject *Sbk_PyViewerFunc_setPlaybackMode(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyViewer::setPlaybackMode(NATRON_ENUM::PlaybackModeEnum)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(*PepType_SGTP(SbkNatronEngineTypes[SBK_NATRON_ENUM_PLAYBACKMODEENUM_IDX])->converter, (pyArg)))) {
+        overloadId = 0; // setPlaybackMode(NATRON_ENUM::PlaybackModeEnum)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyViewerFunc_setPlaybackMode_TypeError;
+
+    // Call function/method
+    {
+        ::NATRON_ENUM::PlaybackModeEnum cppArg0{NATRON_ENUM::ePlaybackModeLoop};
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setPlaybackMode(NATRON_ENUM::PlaybackModeEnum)
+            cppSelf->setPlaybackMode(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyViewerFunc_setPlaybackMode_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyViewer.setPlaybackMode");
+        return {};
+}
+
+static PyObject *Sbk_PyViewerFunc_setProxyIndex(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyViewer::setProxyIndex(int)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<int>(), (pyArg)))) {
+        overloadId = 0; // setProxyIndex(int)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyViewerFunc_setProxyIndex_TypeError;
+
+    // Call function/method
+    {
+        int cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setProxyIndex(int)
+            cppSelf->setProxyIndex(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyViewerFunc_setProxyIndex_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyViewer.setProxyIndex");
+        return {};
+}
+
+static PyObject *Sbk_PyViewerFunc_setProxyModeEnabled(PyObject *self, PyObject *pyArg)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+    int overloadId = -1;
+    PythonToCppFunc pythonToCpp{};
+    SBK_UNUSED(pythonToCpp)
+
+    // Overloaded function decisor
+    // 0: PyViewer::setProxyModeEnabled(bool)
+    if ((pythonToCpp = Shiboken::Conversions::isPythonToCppConvertible(Shiboken::Conversions::PrimitiveTypeConverter<bool>(), (pyArg)))) {
+        overloadId = 0; // setProxyModeEnabled(bool)
+    }
+
+    // Function signature not found.
+    if (overloadId == -1) goto Sbk_PyViewerFunc_setProxyModeEnabled_TypeError;
+
+    // Call function/method
+    {
+        bool cppArg0;
+        pythonToCpp(pyArg, &cppArg0);
+
+        if (!PyErr_Occurred()) {
+            // setProxyModeEnabled(bool)
+            cppSelf->setProxyModeEnabled(cppArg0);
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+
+    Sbk_PyViewerFunc_setProxyModeEnabled_TypeError:
+        Shiboken::setErrorAboutWrongArguments(pyArg, "NatronGui.PyViewer.setProxyModeEnabled");
+        return {};
+}
+
+static PyObject *Sbk_PyViewerFunc_startBackward(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // startBackward()
+            cppSelf->startBackward();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject *Sbk_PyViewerFunc_startForward(PyObject *self)
+{
+    if (!Shiboken::Object::isValid(self))
+        return {};
+    auto cppSelf = reinterpret_cast< ::PyViewer *>(Shiboken::Conversions::cppPointer(SbkNatronGuiTypes[SBK_PYVIEWER_IDX], reinterpret_cast<SbkObject *>(self)));
+    SBK_UNUSED(cppSelf)
+
+    // Call function/method
+    {
+
+        if (!PyErr_Occurred()) {
+            // startForward()
+            cppSelf->startForward();
+        }
+    }
+
+    if (PyErr_Occurred()) {
+        return {};
+    }
+    Py_RETURN_NONE;
+}
+
+
+static const char *Sbk_PyViewer_PropertyStrings[] = {
+    nullptr // Sentinel
+};
+
+static PyMethodDef Sbk_PyViewer_methods[] = {
+    {"getAInput", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_getAInput), METH_NOARGS},
+    {"getBInput", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_getBInput), METH_NOARGS},
+    {"getChannels", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_getChannels), METH_NOARGS},
+    {"getCompositingOperator", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_getCompositingOperator), METH_NOARGS},
+    {"getCurrentFrame", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_getCurrentFrame), METH_NOARGS},
+    {"getCurrentView", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_getCurrentView), METH_NOARGS},
+    {"getFrameRange", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_getFrameRange), METH_NOARGS},
+    {"getPlaybackMode", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_getPlaybackMode), METH_NOARGS},
+    {"getProxyIndex", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_getProxyIndex), METH_NOARGS},
+    {"isProxyModeEnabled", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_isProxyModeEnabled), METH_NOARGS},
+    {"pause", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_pause), METH_NOARGS},
+    {"redraw", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_redraw), METH_NOARGS},
+    {"renderCurrentFrame", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_renderCurrentFrame), METH_VARARGS|METH_KEYWORDS},
+    {"seek", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_seek), METH_O},
+    {"setAInput", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_setAInput), METH_O},
+    {"setBInput", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_setBInput), METH_O},
+    {"setChannels", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_setChannels), METH_O},
+    {"setCompositingOperator", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_setCompositingOperator), METH_O},
+    {"setCurrentView", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_setCurrentView), METH_O},
+    {"setFrameRange", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_setFrameRange), METH_VARARGS},
+    {"setPlaybackMode", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_setPlaybackMode), METH_O},
+    {"setProxyIndex", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_setProxyIndex), METH_O},
+    {"setProxyModeEnabled", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_setProxyModeEnabled), METH_O},
+    {"startBackward", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_startBackward), METH_NOARGS},
+    {"startForward", reinterpret_cast<PyCFunction>(Sbk_PyViewerFunc_startForward), METH_NOARGS},
+
+    {nullptr, nullptr} // Sentinel
+};
+
+} // extern "C"
+
+static int Sbk_PyViewer_traverse(PyObject *self, visitproc visit, void *arg)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_traverse(self, visit, arg);
+}
+static int Sbk_PyViewer_clear(PyObject *self)
+{
+    return reinterpret_cast<PyTypeObject *>(SbkObject_TypeF())->tp_clear(self);
+}
+// Class Definition -----------------------------------------------
+extern "C" {
+static SbkObjectType *_Sbk_PyViewer_Type = nullptr;
+static SbkObjectType *Sbk_PyViewer_TypeF(void)
+{
+    return _Sbk_PyViewer_Type;
+}
+
+static PyType_Slot Sbk_PyViewer_slots[] = {
+    {Py_tp_base,        nullptr}, // inserted by introduceWrapperType
+    {Py_tp_dealloc,     reinterpret_cast<void *>(&SbkDeallocWrapper)},
+    {Py_tp_repr,        nullptr},
+    {Py_tp_hash,        nullptr},
+    {Py_tp_call,        nullptr},
+    {Py_tp_str,         nullptr},
+    {Py_tp_getattro,    nullptr},
+    {Py_tp_setattro,    nullptr},
+    {Py_tp_traverse,    reinterpret_cast<void *>(Sbk_PyViewer_traverse)},
+    {Py_tp_clear,       reinterpret_cast<void *>(Sbk_PyViewer_clear)},
+    {Py_tp_richcompare, nullptr},
+    {Py_tp_iter,        nullptr},
+    {Py_tp_iternext,    nullptr},
+    {Py_tp_methods,     reinterpret_cast<void *>(Sbk_PyViewer_methods)},
+    {Py_tp_getset,      nullptr},
+    {Py_tp_init,        nullptr},
+    {Py_tp_new,         reinterpret_cast<void *>(SbkDummyNew /* PYSIDE-595: Prevent replacement of "0" with base->tp_new. */)},
+    {0, nullptr}
+};
+static PyType_Spec Sbk_PyViewer_spec = {
+    "1:NatronGui.PyViewer",
+    sizeof(SbkObject),
+    0,
+    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_GC,
+    Sbk_PyViewer_slots
+};
+
+} //extern "C"
+
+
+// Type conversion functions.
+
+// Python to C++ pointer conversion - returns the C++ object of the Python wrapper (keeps object identity).
+static void PyViewer_PythonToCpp_PyViewer_PTR(PyObject *pyIn, void *cppOut) {
+    Shiboken::Conversions::pythonToCppPointer(Sbk_PyViewer_TypeF(), pyIn, cppOut);
+}
+static PythonToCppFunc is_PyViewer_PythonToCpp_PyViewer_PTR_Convertible(PyObject *pyIn) {
+    if (pyIn == Py_None)
+        return Shiboken::Conversions::nonePythonToCppNullPtr;
+    if (PyObject_TypeCheck(pyIn, reinterpret_cast<PyTypeObject *>(Sbk_PyViewer_TypeF())))
+        return PyViewer_PythonToCpp_PyViewer_PTR;
+    return {};
+}
+
+// C++ to Python pointer conversion - tries to find the Python wrapper for the C++ object (keeps object identity).
+static PyObject *PyViewer_PTR_CppToPython_PyViewer(const void *cppIn) {
+    auto pyOut = reinterpret_cast<PyObject *>(Shiboken::BindingManager::instance().retrieveWrapper(cppIn));
+    if (pyOut) {
+        Py_INCREF(pyOut);
+        return pyOut;
+    }
+    bool changedTypeName = false;
+    auto tCppIn = reinterpret_cast<const ::PyViewer *>(cppIn);
+    const char *typeName = typeid(*tCppIn).name();
+    auto sbkType = Shiboken::ObjectType::typeForTypeName(typeName);
+    if (sbkType && Shiboken::ObjectType::hasSpecialCastFunction(sbkType)) {
+        typeName = typeNameOf(tCppIn);
+        changedTypeName = true;
+    }
+    PyObject *result = Shiboken::Object::newObject(Sbk_PyViewer_TypeF(), const_cast<void *>(cppIn), false, /* exactType */ changedTypeName, typeName);
+    if (changedTypeName)
+        delete [] typeName;
+    return result;
+}
+
+// The signatures string for the functions.
+// Multiple signatures have their index "n:" in front.
+static const char *PyViewer_SignatureStrings[] = {
+    "NatronGui.PyViewer.getAInput(self)->int",
+    "NatronGui.PyViewer.getBInput(self)->int",
+    "NatronGui.PyViewer.getChannels(self)->NatronEngine.NATRON_ENUM.DisplayChannelsEnum",
+    "NatronGui.PyViewer.getCompositingOperator(self)->NatronEngine.NATRON_ENUM.ViewerCompositingOperatorEnum",
+    "NatronGui.PyViewer.getCurrentFrame(self)->int",
+    "NatronGui.PyViewer.getCurrentView(self)->int",
+    "NatronGui.PyViewer.getFrameRange(self,firstFrame:int*,lastFrame:int*)",
+    "NatronGui.PyViewer.getPlaybackMode(self)->NatronEngine.NATRON_ENUM.PlaybackModeEnum",
+    "NatronGui.PyViewer.getProxyIndex(self)->int",
+    "NatronGui.PyViewer.isProxyModeEnabled(self)->bool",
+    "NatronGui.PyViewer.pause(self)",
+    "NatronGui.PyViewer.redraw(self)",
+    "NatronGui.PyViewer.renderCurrentFrame(self,useCache:bool=true)",
+    "NatronGui.PyViewer.seek(self,frame:int)",
+    "NatronGui.PyViewer.setAInput(self,index:int)",
+    "NatronGui.PyViewer.setBInput(self,index:int)",
+    "NatronGui.PyViewer.setChannels(self,channels:NatronEngine.NATRON_ENUM.DisplayChannelsEnum)",
+    "NatronGui.PyViewer.setCompositingOperator(self,op:NatronEngine.NATRON_ENUM.ViewerCompositingOperatorEnum)",
+    "NatronGui.PyViewer.setCurrentView(self,index:int)",
+    "NatronGui.PyViewer.setFrameRange(self,firstFrame:int,lastFrame:int)",
+    "NatronGui.PyViewer.setPlaybackMode(self,mode:NatronEngine.NATRON_ENUM.PlaybackModeEnum)",
+    "NatronGui.PyViewer.setProxyIndex(self,index:int)",
+    "NatronGui.PyViewer.setProxyModeEnabled(self,enabled:bool)",
+    "NatronGui.PyViewer.startBackward(self)",
+    "NatronGui.PyViewer.startForward(self)",
+    nullptr}; // Sentinel
+
+void init_PyViewer(PyObject *module)
+{
+    _Sbk_PyViewer_Type = Shiboken::ObjectType::introduceWrapperType(
+        module,
+        "PyViewer",
+        "PyViewer*",
+        &Sbk_PyViewer_spec,
+        &Shiboken::callCppDestructor< ::PyViewer >,
+        0,
+        0,
+        0    );
+    
+    auto pyType = reinterpret_cast<PyTypeObject *>(_Sbk_PyViewer_Type);
+    InitSignatureStrings(pyType, PyViewer_SignatureStrings);
+    SbkObjectType_SetPropertyStrings(reinterpret_cast<PyTypeObject *>(_Sbk_PyViewer_Type), Sbk_PyViewer_PropertyStrings);
+    SbkNatronGuiTypes[SBK_PYVIEWER_IDX]
+        = reinterpret_cast<PyTypeObject *>(Sbk_PyViewer_TypeF());
+
+    // Register Converter
+    SbkConverter *converter = Shiboken::Conversions::createConverter(Sbk_PyViewer_TypeF(),
+        PyViewer_PythonToCpp_PyViewer_PTR,
+        is_PyViewer_PythonToCpp_PyViewer_PTR_Convertible,
+        PyViewer_PTR_CppToPython_PyViewer);
+
+    Shiboken::Conversions::registerConverterName(converter, "PyViewer");
+    Shiboken::Conversions::registerConverterName(converter, "PyViewer*");
+    Shiboken::Conversions::registerConverterName(converter, "PyViewer&");
+    Shiboken::Conversions::registerConverterName(converter, typeid(::PyViewer).name());
+
+
+
+}

--- a/Gui/Qt5/NatronGui/pyviewer_wrapper.h
+++ b/Gui/Qt5/NatronGui/pyviewer_wrapper.h
@@ -1,0 +1,7 @@
+#ifndef SBK_PYVIEWER_H
+#define SBK_PYVIEWER_H
+
+#include <PyGuiApp.h>
+
+#endif // SBK_PYVIEWER_H
+


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

See #698.

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

See #698.

**Futher details of this pull request**

Used the following command to generate the sources:

```sh
$ shiboken2 --enable-parent-ctor-heuristic --use-isnull-as-nb_nonzero --avoid-protected-hack \
      --enable-pyside-extensions --include-paths=.:Global:Engine:Gui:libs/OpenFX/include \
      --include-paths=/usr/include/PySide2:/usr/include/QtCore:/usr/include/QtGui:/usr/include/QtWidgets \
      --include-paths=/usr/include/python3.9 --typesystem-paths=Engine:/usr/share/PySide2/typesystems \
      --output-directory=Gui/Qt5 Gui/PySide2_Gui_Python.h Gui/typesystem_natronGui.xml
```
