### PR TITLE
Deprecate usage of qSort in ToolButton

### DIFF
--- a/Gui/ToolButton.cpp
+++ b/Gui/ToolButton.cpp
@@ -216,7 +216,7 @@ ToolButton::sortChildren()
     }
     assert(_imp->_menu);
     QList<QAction*> actions = _imp->_menu->actions();
-    qSort( actions.begin(), actions.end(), ToolButtonChildrenSortFunctor() );
+    std::sort( actions.begin(), actions.end(), ToolButtonChildrenSortFunctor() );
     _imp->_menu->clear();
 
     std::vector<ToolButton*> sortedChildren;


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Beginning with Qt5 most of the offered methods in `QAlgorithm` that have a corresponding STL counterpart in `algorithm` [are deprecated](https://doc.qt.io/qt-5/qtalgorithms.html#qt-and-the-stl-algorithms). This PR substitutes the `qSort` usage in `Gui/ToolButton` with `std::sort`.

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

By building and running the Natron GUI.

**Futher details of this pull request**

N/A.
