### PR TITLE
Set tab stop distance with tabStopDistance in Gui

### DIFF
--- a/Gui/EditScriptDialog.cpp
+++ b/Gui/EditScriptDialog.cpp
@@ -230,7 +230,11 @@ EditScriptDialog::create(const QString& initialScript,
         _imp->resultEdit->setFont(font);
     }
     QFontMetrics fm = _imp->expressionEdit->fontMetrics();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    _imp->expressionEdit->setTabStopDistance( 4 * fm.horizontalAdvance( QLatin1Char(' ') ) );
+#else
     _imp->expressionEdit->setTabStopWidth( 4 * fm.width( QLatin1Char(' ') ) );
+#endif
 } // EditScriptDialog::create
 
 void

--- a/Gui/KnobGuiString.cpp
+++ b/Gui/KnobGuiString.cpp
@@ -96,7 +96,11 @@ AnimatingTextEdit::AnimatingTextEdit(const KnobGuiPtr& knob,
     , dirty(false)
     , _dnd( KnobWidgetDnD::create(knob, dimension, this) )
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+    setTabStopDistance(20);
+#else
     setTabStopWidth(20); // a tab width of 20 is more reasonable than 80 for programming languages (e.g. Shadertoy)
+#endif
 }
 
 AnimatingTextEdit::~AnimatingTextEdit()

--- a/Gui/ScriptEditor.cpp
+++ b/Gui/ScriptEditor.cpp
@@ -249,8 +249,13 @@ ScriptEditor::ScriptEditor(Gui* gui)
     _imp->inputEdit = new InputScriptTextEdit(gui, this);
     QObject::connect( _imp->inputEdit, SIGNAL(textChanged()), this, SLOT(onInputScriptTextChanged()) );
     QFontMetrics fm = _imp->inputEdit->fontMetrics();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    _imp->inputEdit->setTabStopDistance(fm.horizontalAdvance( QLatin1Char(' ') ) * 4);
+    _imp->outputEdit->setTabStopDistance(fm.horizontalAdvance( QLatin1Char(' ') ) * 4);
+#else
     _imp->inputEdit->setTabStopWidth(fm.width( QLatin1Char(' ') ) * 4);
     _imp->outputEdit->setTabStopWidth(fm.width( QLatin1Char(' ') ) * 4);
+#endif
 
     _imp->mainLayout->addWidget(_imp->buttonsContainer);
     splitter->addWidget(_imp->outputEdit);


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

`tabStopWidth` was [deprecated in Qt 5.10](https://doc.qt.io/qt-5/qtextedit-obsolete.html) and `tabStopDistance` is recommended to be used instead.

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

Built Natron and used the script editor.

**Futher details of this pull request**

Used `horizontalAdvance` from the font metrics to be coherent with the Qt recommendations, which in turn will be done in another PR too.
This was a blocker of one of the things I've been working on.

