### PR TITLE
Renovate usages of QLineF intersections

### DIFF
--- a/Engine/RotoContext.cpp
+++ b/Engine/RotoContext.cpp
@@ -4477,10 +4477,11 @@ RotoContextPrivate::bezulate(double time,
                 for (; cur != polygon.end(); ++cur, ++last_pt) {
                     QLineF polygonSegment( QPointF(last_pt->x, last_pt->y), QPointF(cur->x, cur->y) );
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-                    if (line.intersects(polygonSegment, &intersectionPoint) == QLineF::BoundedIntersection) {
+                    QLineF::IntersectionType intersectType = line.intersects(polygonSegment, &intersectionPoint);
 #else
-                    if (line.intersect(polygonSegment, &intersectionPoint) == QLineF::BoundedIntersection) {
+                    QLineF::IntersectType intersectType = line.intersect(polygonSegment, &intersectionPoint);
 #endif
+                    if (intersectType == QLineF::BoundedIntersection) {
                         intersections.insert(intersectionPoint);
                     }
                     if (intersections.size() > 2) {

--- a/Engine/RotoContext.cpp
+++ b/Engine/RotoContext.cpp
@@ -4476,7 +4476,11 @@ RotoContextPrivate::bezulate(double time,
                 QPointF intersectionPoint;
                 for (; cur != polygon.end(); ++cur, ++last_pt) {
                     QLineF polygonSegment( QPointF(last_pt->x, last_pt->y), QPointF(cur->x, cur->y) );
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+                    if (line.intersects(polygonSegment, &intersectionPoint) == QLineF::BoundedIntersection) {
+#else
                     if (line.intersect(polygonSegment, &intersectionPoint) == QLineF::BoundedIntersection) {
+#endif
                         intersections.insert(intersectionPoint);
                     }
                     if (intersections.size() > 2) {

--- a/Gui/Edge.cpp
+++ b/Gui/Edge.cpp
@@ -487,7 +487,11 @@ Edge::initLine()
 
     if (dest) {
         for (int i = 0; i < 4; ++i) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+            QLineF::IntersectionType type = dstEdges[i].intersects(line(), &dstIntersection);
+#else
             QLineF::IntersectType type = dstEdges[i].intersect(line(), &dstIntersection);
+#endif
             if (type == QLineF::BoundedIntersection) {
                 setLine( QLineF( dstIntersection, line().p2() ) );
                 foundDstIntersection = true;
@@ -502,7 +506,11 @@ Edge::initLine()
         if (foundDstIntersection) {
             ///Find the intersection with the source bbox
             for (int i = 0; i < 4; ++i) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+                QLineF::IntersectionType type = srcEdges[i].intersects(line(), &srcInteresect);
+#else
                 QLineF::IntersectType type = srcEdges[i].intersect(line(), &srcInteresect);
+#endif
                 if (type == QLineF::BoundedIntersection) {
                     foundSrcIntersection = true;
                     break;
@@ -544,7 +552,11 @@ Edge::initLine()
         QPointF intersection;
         bool foundIntersection = false;
         for (int i = 0; i < 4; ++i) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+            QLineF::IntersectionType type = dstEdges[i].intersects(line(), &intersection);
+#else
             QLineF::IntersectType type = dstEdges[i].intersect(line(), &intersection);
+#endif
             if (type == QLineF::BoundedIntersection) {
                 setLine( QLineF( intersection, line().p2() ) );
                 foundIntersection = true;
@@ -884,7 +896,11 @@ LinkArrow::refreshPosition()
     QPointF slaveIntersect;
     bool foundIntersection = false;
     for (int i = 0; i < 4; ++i) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        QLineF::IntersectionType type = slaveEdges[i].intersects(line(), &slaveIntersect);
+#else
         QLineF::IntersectType type = slaveEdges[i].intersect(line(), &slaveIntersect);
+#endif
         if (type == QLineF::BoundedIntersection) {
             foundIntersection = true;
             break;
@@ -900,7 +916,11 @@ LinkArrow::refreshPosition()
 
     foundIntersection = false;
     for (int i = 0; i < 4; ++i) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        QLineF::IntersectionType type = masterEdges[i].intersects(line(), &masterIntersect);
+#else
         QLineF::IntersectType type = masterEdges[i].intersect(line(), &masterIntersect);
+#endif
         if (type == QLineF::BoundedIntersection) {
             foundIntersection = true;
             break;

--- a/Gui/NodeGui.cpp
+++ b/Gui/NodeGui.cpp
@@ -1868,7 +1868,11 @@ NodeGui::hasEdgeNearbyRect(const QRectF & rect)
         edgeLine.setP1( (*it)->mapToScene( edgeLine.p1() ) );
         edgeLine.setP2( (*it)->mapToScene( edgeLine.p2() ) );
         for (int j = 0; j < 4; ++j) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+            if (edgeLine.intersects(rectEdges[j], &intersection) == QLineF::BoundedIntersection) {
+#else
             if (edgeLine.intersect(rectEdges[j], &intersection) == QLineF::BoundedIntersection) {
+#endif
                 if (!closest) {
                     closest = *it;
                     closestSquareDist = ( intersection.x() - middleRect.x() ) * ( intersection.x() - middleRect.x() )
@@ -1895,7 +1899,11 @@ NodeGui::hasEdgeNearbyRect(const QRectF & rect)
             edgeLine.setP1( (_outputEdge)->mapToScene( edgeLine.p1() ) );
             edgeLine.setP2( (_outputEdge)->mapToScene( edgeLine.p2() ) );
             for (int j = 0; j < 4; ++j) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+                if (edgeLine.intersects(rectEdges[j], &intersection) == QLineF::BoundedIntersection) {
+#else
                 if (edgeLine.intersect(rectEdges[j], &intersection) == QLineF::BoundedIntersection) {
+#endif
                     return _outputEdge;
                 }
             }

--- a/Gui/NodeGui.cpp
+++ b/Gui/NodeGui.cpp
@@ -1869,10 +1869,11 @@ NodeGui::hasEdgeNearbyRect(const QRectF & rect)
         edgeLine.setP2( (*it)->mapToScene( edgeLine.p2() ) );
         for (int j = 0; j < 4; ++j) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-            if (edgeLine.intersects(rectEdges[j], &intersection) == QLineF::BoundedIntersection) {
+            QLineF::IntersectionType intersectType = edgeLine.intersects(rectEdges[j], &intersection);
 #else
-            if (edgeLine.intersect(rectEdges[j], &intersection) == QLineF::BoundedIntersection) {
+            QLineF::IntersectType intersectType = edgeLine.intersect(rectEdges[j], &intersection);
 #endif
+            if (intersectType == QLineF::BoundedIntersection) {
                 if (!closest) {
                     closest = *it;
                     closestSquareDist = ( intersection.x() - middleRect.x() ) * ( intersection.x() - middleRect.x() )
@@ -1900,10 +1901,11 @@ NodeGui::hasEdgeNearbyRect(const QRectF & rect)
             edgeLine.setP2( (_outputEdge)->mapToScene( edgeLine.p2() ) );
             for (int j = 0; j < 4; ++j) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-                if (edgeLine.intersects(rectEdges[j], &intersection) == QLineF::BoundedIntersection) {
+                QLineF::IntersectionType intersectType = edgeLine.intersects(rectEdges[j], &intersection);
 #else
-                if (edgeLine.intersect(rectEdges[j], &intersection) == QLineF::BoundedIntersection) {
+                QLineF::IntersectType intersectType = edgeLine.intersect(rectEdges[j], &intersection);
 #endif
+                if (intersectType == QLineF::BoundedIntersection) {
                     return _outputEdge;
                 }
             }

--- a/Gui/ViewerGLPrivate.cpp
+++ b/Gui/ViewerGLPrivate.cpp
@@ -564,7 +564,11 @@ ViewerGL::Implementation::getWipePolygon(const RectD & texRectClipped,
     if (crossProd11 * crossProd21 < 0) {
         QLineF e(texRectClipped.x1, texRectClipped.y1, texRectClipped.x2, texRectClipped.y1);
         QPointF p;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        QLineF::IntersectionType t = inter.intersects(e, &p);
+#else
         QLineF::IntersectType t = inter.intersect(e, &p);
+#endif
         if (t == QLineF::BoundedIntersection) {
             *polygonPoints << p;
         }
@@ -575,7 +579,11 @@ ViewerGL::Implementation::getWipePolygon(const RectD & texRectClipped,
     if (crossProd21 * crossProd22 < 0) {
         QLineF e(texRectClipped.x2, texRectClipped.y1, texRectClipped.x2, texRectClipped.y2);
         QPointF p;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        QLineF::IntersectionType t = inter.intersects(e, &p);
+#else
         QLineF::IntersectType t = inter.intersect(e, &p);
+#endif
         if (t == QLineF::BoundedIntersection) {
             *polygonPoints << p;
         }
@@ -586,7 +594,11 @@ ViewerGL::Implementation::getWipePolygon(const RectD & texRectClipped,
     if (crossProd22 * crossProd12 < 0) {
         QLineF e(texRectClipped.x2, texRectClipped.y2, texRectClipped.x1, texRectClipped.y2);
         QPointF p;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        QLineF::IntersectionType t = inter.intersects(e, &p);
+#else
         QLineF::IntersectType t = inter.intersect(e, &p);
+#endif
         if (t == QLineF::BoundedIntersection) {
             *polygonPoints << p;
         }
@@ -597,7 +609,11 @@ ViewerGL::Implementation::getWipePolygon(const RectD & texRectClipped,
     if (crossProd12 * crossProd11 < 0) {
         QLineF e(texRectClipped.x1, texRectClipped.y2, texRectClipped.x1, texRectClipped.y1);
         QPointF p;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        QLineF::IntersectionType t = inter.intersects(e, &p);
+#else
         QLineF::IntersectType t = inter.intersect(e, &p);
+#endif
         if (t == QLineF::BoundedIntersection) {
             *polygonPoints << p;
         }


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Both `QLineF::intersect` plus `QLineF::IntersectType` were [deprecated in Qt 5.14](https://doc.qt.io/qt-5/qlinef-obsolete.html) and `QLineF::intersects` plus `QLineF::IntersectionType` are recommended to be used instead.

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

Built Natron and used the node graph editor.

**Futher details of this pull request**

N/A.
