### PR TITLE
Substitute recursive mutex enum with QRecursiveMutex

### DIFF
--- a/Engine/AppManager.cpp
+++ b/Engine/AppManager.cpp
@@ -2023,10 +2023,18 @@ AppManager::registerPlugin(const QString& resourcesPath,
                            int minor,
                            bool isDeprecated)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QRecursiveMutex* pluginMutex = nullptr;
+#else
     QMutex* pluginMutex = 0;
+#endif
 
     if (mustCreateMutex) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        pluginMutex = new QRecursiveMutex();
+#else
         pluginMutex = new QMutex(QMutex::Recursive);
+#endif
     }
     Plugin* plugin = new Plugin(binary, resourcesPath, pluginID, pluginLabel, pluginIconPath, groupIconPath, groups, pluginMutex, major, minor,
                                 isReader, isWriter, isDeprecated);

--- a/Engine/CurvePrivate.h
+++ b/Engine/CurvePrivate.h
@@ -33,6 +33,9 @@
 #endif
 
 #include <QtCore/QMutex>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+#include <QRecursiveMutex>
+#endif
 
 #include "Engine/Variant.h"
 #include "Engine/Knob.h"
@@ -67,7 +70,11 @@ struct CurvePrivate
     CurveTypeEnum type;
     double xMin, xMax;
     double yMin, yMax;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    mutable QRecursiveMutex _lock;
+#else
     mutable QMutex _lock; //< the plug-ins can call getValueAt at any moment and we must make sure the user is not playing around
+#endif
     bool isParametric;
     bool isPeriodic;
 
@@ -83,14 +90,22 @@ struct CurvePrivate
         , xMax(std::numeric_limits<double>::infinity())
         , yMin(-std::numeric_limits<double>::infinity())
         , yMax(std::numeric_limits<double>::infinity())
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        , _lock()
+#else
         , _lock(QMutex::Recursive)
+#endif
         , isParametric(false)
         , isPeriodic(false)
     {
     }
 
     CurvePrivate(const CurvePrivate & other)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        : _lock()
+#else
         : _lock(QMutex::Recursive)
+#endif
     {
         *this = other;
     }

--- a/Engine/EffectInstancePrivate.cpp
+++ b/Engine/EffectInstancePrivate.cpp
@@ -423,7 +423,11 @@ EffectInstance::Implementation::Implementation(EffectInstance* publicInterface)
     , metadata()
     , runningClipPreferences(false)
     , overlaysViewport(0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    , attachedContextsMutex()
+#else
     , attachedContextsMutex(QMutex::Recursive)
+#endif
     , attachedContexts()
     , mainInstance(0)
     , isDoingInstanceSafeRender(false)
@@ -453,7 +457,11 @@ EffectInstance::Implementation::Implementation(const Implementation& other)
 , metadata(other.metadata)
 , runningClipPreferences(other.runningClipPreferences)
 , overlaysViewport(other.overlaysViewport)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+, attachedContextsMutex()
+#else
 , attachedContextsMutex(QMutex::Recursive)
+#endif
 , attachedContexts()
 , mainInstance(other._publicInterface)
 , isDoingInstanceSafeRender(false)

--- a/Engine/EffectInstancePrivate.h
+++ b/Engine/EffectInstancePrivate.h
@@ -37,6 +37,9 @@
 #include <QtCore/QCoreApplication>
 #include <QtCore/QWaitCondition>
 #include <QtCore/QMutex>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+#include <QRecursiveMutex>
+#endif
 
 #include "Global/GlobalDefines.h"
 
@@ -224,7 +227,11 @@ public:
 
     // set during interact actions on main-thread
     OverlaySupport* overlaysViewport;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    mutable QRecursiveMutex attachedContextsMutex;
+#else
     mutable QMutex attachedContextsMutex;
+#endif
     // A list of context that are currently attached (i.e attachOpenGLContext() has been called on them but not yet dettachOpenGLContext).
     // If a plug-in returns false to supportsConcurrentOpenGLRenders() then whenever trying to attach a context, we take a lock in attachOpenGLContext
     // that is released in dettachOpenGLContext so that there can only be a single attached OpenGL context at any time.

--- a/Engine/Knob.cpp
+++ b/Engine/Knob.cpp
@@ -4887,7 +4887,11 @@ struct KnobHolder::KnobHolderPrivate
         , isDequeingValuesSet(false)
         , paramsEditLevel(eMultipleParamsEditOff)
         , paramsEditRecursionLevel(0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        , evaluationBlockedMutex()
+#else
         , evaluationBlockedMutex(QMutex::Recursive)
+#endif
         , evaluationBlocked(0)
         , canCurrentlySetValue(true)
         , knobChanged()
@@ -4915,7 +4919,11 @@ struct KnobHolder::KnobHolderPrivate
     , isDequeingValuesSet(other.isDequeingValuesSet)
     , paramsEditLevel(other.paramsEditLevel)
     , paramsEditRecursionLevel(other.paramsEditRecursionLevel)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    , evaluationBlockedMutex()
+#else
     , evaluationBlockedMutex(QMutex::Recursive)
+#endif
     , evaluationBlocked(0)
     , canCurrentlySetValue(other.canCurrentlySetValue)
     , knobChanged()

--- a/Engine/Knob.h
+++ b/Engine/Knob.h
@@ -42,6 +42,9 @@
 #include <QtCore/QMutex>
 #include <QtCore/QString>
 #include <QtCore/QCoreApplication>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+#include <QRecursiveMutex>
+#endif
 
 #include "Engine/Variant.h"
 #include "Engine/AppManager.h" // for AppManager::createKnob
@@ -2246,7 +2249,11 @@ private:
     typedef boost::shared_ptr<QueuedSetValueAtTime> QueuedSetValueAtTimePtr;
 
     ///Here is all the stuff we couldn't get rid of the template parameter
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    mutable QRecursiveMutex _valueMutex;
+#else
     mutable QMutex _valueMutex; //< protects _values & _guiValues & _defaultValues & ExprResults
+#endif
     std::vector<T> _values, _guiValues;
 
     struct DefaultValue
@@ -2260,11 +2267,19 @@ private:
     //Only for double and int
     mutable QReadWriteLock _minMaxMutex;
     std::vector<T>  _minimums, _maximums, _displayMins, _displayMaxs;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    mutable QRecursiveMutex _setValuesQueueMutex;
+#else
     mutable QMutex _setValuesQueueMutex;
+#endif
     std::list<boost::shared_ptr<QueuedSetValue> > _setValuesQueue;
 
     ///this flag is to avoid recursive setValue calls
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    mutable QRecursiveMutex _setValueRecursionLevelMutex;
+#else
     mutable QMutex _setValueRecursionLevelMutex;
+#endif
     int _setValueRecursionLevel;
 };
 

--- a/Engine/KnobImpl.h
+++ b/Engine/KnobImpl.h
@@ -105,19 +105,31 @@ Knob<T>::Knob(KnobHolder*  holder,
               int dimension,
               bool declaredByPlugin )
     : KnobHelper(holder, description, dimension, declaredByPlugin)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    , _valueMutex()
+#else
     , _valueMutex(QMutex::Recursive)
+#endif
     , _values(dimension)
     , _guiValues(dimension)
     , _defaultValues(dimension)
     , _exprRes(dimension)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    , _minMaxMutex()
+#else
     , _minMaxMutex(QReadWriteLock::Recursive)
+#endif
     , _minimums(dimension)
     , _maximums(dimension)
     , _displayMins(dimension)
     , _displayMaxs(dimension)
     , _setValuesQueueMutex()
     , _setValuesQueue()
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    , _setValueRecursionLevelMutex()
+#else
     , _setValueRecursionLevelMutex(QMutex::Recursive)
+#endif
     , _setValueRecursionLevel(0)
 {
     initMinMax();

--- a/Engine/NodeGroup.cpp
+++ b/Engine/NodeGroup.cpp
@@ -1055,7 +1055,11 @@ NodeCollection::getParallelRenderArgs(std::map<NodePtr, ParallelRenderArgsPtr>& 
 
 struct NodeGroupPrivate
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    mutable QRecursiveMutex nodesLock;
+#else
     mutable QMutex nodesLock; // protects inputs & outputs
+#endif
     std::vector<NodeWPtr> inputs, guiInputs;
     NodesWList outputs, guiOutputs;
     bool isDeactivatingGroup;
@@ -1064,7 +1068,11 @@ struct NodeGroupPrivate
     KnobButtonPtr exportAsTemplate, convertToGroup;
 
     NodeGroupPrivate()
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    : nodesLock()
+#else
     : nodesLock(QMutex::Recursive)
+#endif
     , inputs()
     , guiInputs()
     , outputs()

--- a/Engine/NodePrivate.h
+++ b/Engine/NodePrivate.h
@@ -173,7 +173,11 @@ public:
         , mustQuitPreview(0)
         , mustQuitPreviewMutex()
         , mustQuitPreviewCond()
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        , renderInstancesSharedMutex()
+#else
         , renderInstancesSharedMutex(QMutex::Recursive)
+#endif
         , knobsAge(0)
         , knobsAgeMutex()
         , masterNodeMutex()

--- a/Engine/OfxHost.cpp
+++ b/Engine/OfxHost.cpp
@@ -1534,7 +1534,11 @@ OfxHost::mutexCreate(OfxMutexHandle *mutex,
 
     // suite functions should not throw
     try {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        QRecursiveMutex* m = new QRecursiveMutex();
+#else
         QMutex* m = new QMutex(QMutex::Recursive);
+#endif
         for (int i = 0; i < lockCount; ++i) {
             m->lock();
         }

--- a/Engine/Plugin.cpp
+++ b/Engine/Plugin.cpp
@@ -180,7 +180,11 @@ Plugin::getGrouping() const
     return _grouping;
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+QRecursiveMutex*
+#else
 QMutex*
+#endif
 Plugin::getPluginLock() const
 {
     return _lock;

--- a/Engine/Plugin.h
+++ b/Engine/Plugin.h
@@ -34,6 +34,9 @@
 #include <list>
 #include <QtCore/QString>
 #include <QtCore/QStringList>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+#include <QRecursiveMutex>
+#endif
 
 #if !defined(Q_MOC_RUN) && !defined(SBK_RUN)
 #include <boost/shared_ptr.hpp>
@@ -173,7 +176,11 @@ class Plugin
     QString _pythonModule;
     OFX::Host::ImageEffect::ImageEffectPlugin* _ofxPlugin;
     OFX::Host::ImageEffect::Descriptor* _ofxDescriptor;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QRecursiveMutex* _lock;
+#else
     QMutex* _lock;
+#endif
     int _majorVersion;
     int _minorVersion;
     NATRON_ENUM::ContextEnum _ofxContext;
@@ -239,7 +246,11 @@ public:
            const QString & iconFilePath,
            const QStringList & groupIconFilePath,
            const QStringList & grouping,
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+           QRecursiveMutex* lock,
+#else
            QMutex* lock,
+#endif
            int majorVersion,
            int minorVersion,
            bool isReader,
@@ -338,7 +349,11 @@ public:
 
     bool getToolsetScript() const;
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QRecursiveMutex* getPluginLock() const;
+#else
     QMutex* getPluginLock() const;
+#endif
     LibraryBinary* getLibraryBinary() const;
 
     int getMajorVersion() const;

--- a/Engine/ProjectPrivate.cpp
+++ b/Engine/ProjectPrivate.cpp
@@ -64,7 +64,11 @@ ProjectPrivate::ProjectPrivate(Project* project)
     , projectCreationTime(ageSinceLastSave)
     , builtinFormats()
     , additionalFormats()
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    , formatMutex()
+#else
     , formatMutex(QMutex::Recursive)
+#endif
     , envVars()
     , projectName()
     , projectPath()

--- a/Engine/ProjectPrivate.h
+++ b/Engine/ProjectPrivate.h
@@ -68,7 +68,11 @@ public:
     QDateTime projectCreationTime; //< the project creation time
     std::list<Format> builtinFormats;
     std::list<Format> additionalFormats; //< added by the user
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    mutable QRecursiveMutex formatMutex;
+#else
     mutable QMutex formatMutex; //< protects builtinFormats & additionalFormats
+#endif
 
 
     ///Project parameters (settings)

--- a/Gui/GuiPrivate.cpp
+++ b/Gui/GuiPrivate.cpp
@@ -198,7 +198,11 @@ GuiPrivate::GuiPrivate(const GuiAppInstancePtr& app,
     , _lastPluginDir()
     , _nextViewerTabPlace(0)
     , _leftRightSplitter(0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    , _viewerTabsMutex()
+#else
     , _viewerTabsMutex(QMutex::Recursive) // Gui::createNodeViewerInterface() may cause a resizeEvent, which calls Gui:redrawAllViewers()
+#endif
     , _viewerTabs()
     , _masterSyncViewer(0)
     , _activeViewer(0)

--- a/Gui/GuiPrivate.h
+++ b/Gui/GuiPrivate.h
@@ -156,7 +156,11 @@ public:
     Splitter* _leftRightSplitter;
 
     ///a list of ptrs to all the viewer tabs.
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    mutable QRecursiveMutex _viewerTabsMutex;
+#else
     mutable QMutex _viewerTabsMutex;
+#endif
     std::list<ViewerTab*> _viewerTabs;
 
     ///Used when all viewers are synchronized to determine which one triggered the sync


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

`QMutex::Recursive` was [deprecated in Qt 5.14](https://doc.qt.io/qt-5/qmutex-obsolete.html) and `QRecursiveMutex` is recommended to be used instead.

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

Built Natron and used the node graph editor.

**Futher details of this pull request**

N/A.
