### PR TITLE
Use default QFlags construction instead of zero

### DIFF
--- a/Engine/FileSystemModel.cpp
+++ b/Engine/FileSystemModel.cpp
@@ -663,7 +663,11 @@ Qt::ItemFlags
 FileSystemModel::flags(const QModelIndex &index) const
 {
     if ( !index.isValid() ) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+        return Qt::ItemFlags();
+#else
         return 0;
+#endif
     }
 
     // Our model is read only.

--- a/Gui/Label.h
+++ b/Gui/Label.h
@@ -48,10 +48,18 @@ public:
 
     Label(const QString &text,
           QWidget *parent = 0,
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+          Qt::WindowFlags f = Qt::WindowFlags());
+#else
           Qt::WindowFlags f = 0);
+#endif
 
     Label(QWidget *parent = 0,
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+          Qt::WindowFlags f = Qt::WindowFlags());
+#else
           Qt::WindowFlags f = 0);
+#endif
 
     bool getAltered() const;
 


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

The zero constructors in `QFlags` had been [deprecated in Qt 5](https://doc.qt.io/qt-5/qflags-obsolete.html) and the default constructor is recommended instead.

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

Built Natron and used the node graph editor.

**Futher details of this pull request**

N/A.
