### PR TITLE
Renovate QString splits with newer enum in Gui

### DIFF
--- a/Gui/DocumentationManager.cpp
+++ b/Gui/DocumentationManager.cpp
@@ -229,12 +229,21 @@ DocumentationManager::handler(QHttpRequest *req,
     // get options
     QStringList options;
     if ( page.contains( QString::fromUtf8("?") ) ) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        QStringList split = page.split(QString::fromUtf8("?"), Qt::SkipEmptyParts);
+        page = split.takeFirst();
+        if (split.length() > 0) {
+            QString rawOptions = split.takeLast();
+            options = rawOptions.split(QString::fromUtf8("&"), Qt::SkipEmptyParts);
+        }
+#else
         QStringList split = page.split(QString::fromUtf8("?"), QString::SkipEmptyParts);
         page = split.takeFirst();
         if (split.length() > 0) {
             QString rawOptions = split.takeLast();
             options = rawOptions.split(QString::fromUtf8("&"), QString::SkipEmptyParts);
         }
+#endif
     }
 
     // default page
@@ -368,7 +377,11 @@ DocumentationManager::handler(QHttpRequest *req,
                                               "</div>");
         for (int i = 0; i < options.size(); ++i) {
             if ( options.at(i).contains( QString::fromUtf8("id=") ) ) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+                QStringList split = options.at(i).split(QString::fromUtf8("="), Qt::SkipEmptyParts);
+#else
                 QStringList split = options.at(i).split(QString::fromUtf8("="), QString::SkipEmptyParts);
+#endif
                 if (split.length() > 0) {
                     QString groupID = split.takeLast();
                     group = groupID;

--- a/Gui/Gui40.cpp
+++ b/Gui/Gui40.cpp
@@ -193,7 +193,11 @@ Gui::updateRecentFileActions()
             // split each dir, and find the common part of all dirs.
             std::vector<QStringList> dirParts(dirs.size());
             for (int i = 0; i < dirs.size(); ++i) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+                dirParts[i] = QDir::toNativeSeparators(dirs.at(i)).split(QDir::separator(), Qt::SkipEmptyParts);
+#else
                 dirParts[i] = QDir::toNativeSeparators(dirs.at(i)).split(QDir::separator(), QString::SkipEmptyParts);
+#endif
             }
             int minComps = dirParts[0].size();
             for (int i = 1; i < dirs.size(); ++i) {
@@ -219,7 +223,11 @@ Gui::updateRecentFileActions()
             // remove the n first element to each dirName corresponding to this filename, and recompose
                 for (int i = 0; i < numRecentFiles; ++i) {
                     if (fileNames[i] == it->first) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+                        dirNames[i] = QStringList(QDir::toNativeSeparators(dirNames.at(i)).split(QDir::separator(), Qt::SkipEmptyParts).mid(commonComps)).join(QDir::separator());
+#else
                         dirNames[i] = QStringList(QDir::toNativeSeparators(dirNames.at(i)).split(QDir::separator(), QString::SkipEmptyParts).mid(commonComps)).join(QDir::separator());
+#endif
                     }
                 }
             }


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

`QString::SplitBehaviour` has been [deprecated in Qt 5](https://doc.qt.io/qt-5/qstring-obsolete.html) and `Qt::SplitBehaviour` is recommended instead.

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

Built Natron and used the node graph editor.

**Futher details of this pull request**

N/A.
