### PR TITLE
Index model children with QAbstractItemModel

### DIFF
--- a/Gui/DopeSheetHierarchyView.cpp
+++ b/Gui/DopeSheetHierarchyView.cpp
@@ -130,7 +130,11 @@ HierarchyViewSelectionModel::selectChildren(const QModelIndex &index,
                                             QItemSelection *selection) const
 {
     int row = 0;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    QModelIndex childIndex = index.model()->index(row, 0);
+#else
     QModelIndex childIndex = index.child(row, 0);
+#endif
 
     while ( childIndex.isValid() ) {
         if ( !selection->contains(childIndex) ) {
@@ -143,7 +147,11 @@ HierarchyViewSelectionModel::selectChildren(const QModelIndex &index,
         }
 
         ++row;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+        childIndex = index.model()->index(row, 0);
+#else
         childIndex = index.child(row, 0);
+#endif
     }
 }
 
@@ -187,7 +195,11 @@ HierarchyViewSelectionModel::checkParentsSelectedStates(const QModelIndex &index
         QModelIndex index = (*it);
         bool selectParent = true;
         int row = 0;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+        QModelIndex childIndexIt = index.model()->index(row, 0);
+#else
         QModelIndex childIndexIt = index.child(row, 0);
+#endif
 
         while ( childIndexIt.isValid() ) {
             if ( childIndexIt.data(QT_ROLE_CONTEXT_IS_ANIMATED).toBool() ) {
@@ -199,7 +211,11 @@ HierarchyViewSelectionModel::checkParentsSelectedStates(const QModelIndex &index
             }
 
             ++row;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+            childIndexIt = index.model()->index(row, 0);
+#else
             childIndexIt = index.child(row, 0);
+#endif
         }
 
         if ( (flags & QItemSelectionModel::Select && selectParent) ) {
@@ -798,7 +814,11 @@ HierarchyView::drawRow(QPainter *painter,
         painter->fillRect(itemRect.adjusted(-1, 0, 0, 0), fillColor);
 
         // Draw the item text
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+        QStyleOptionViewItem newOpt = viewOptions();
+#else
         QStyleOptionViewItemV4 newOpt = viewOptions();
+#endif
         newOpt.rect = itemRect;
 
         if ( selectionModel()->isSelected(index) ) {
@@ -848,7 +868,11 @@ HierarchyView::drawBranches(QPainter *painter,
         painter->fillRect(rectForDull, nodeColorDull);
 
         // Draw the branch indicator
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+        QStyleOptionViewItem option = viewOptions();
+#else
         QStyleOptionViewItemV4 option = viewOptions();
+#endif
         option.rect = _imp->getParentArrowRect(item, rect);
         option.displayAlignment = Qt::AlignCenter;
 


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

`QModelIndex::child` has been [deprecated in Qt 5](https://doc.qt.io/qt-5/qmodelindex-obsolete.html) and `QAbstractItemModel::index` is recommended instead.

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

Built Natron and used the node graph editor in conjunction with the dopesheet viewer.

**Futher details of this pull request**

N/A.
