### PR TITLE
Use QMargins for table model view

### DIFF
--- a/Gui/TableModelView.cpp
+++ b/Gui/TableModelView.cpp
@@ -918,12 +918,21 @@ ExpandingLineEdit::updateMinimumWidth()
 {
     int left, right;
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    QMargins textMargin = textMargins();
+    int width = textMargin.left() + textMargin.right() + 4;
+    QMargins contentMargin = contentsMargins();
+    width += contentMargin.left() + contentMargin.right();
+
+    QStyleOptionFrame opt;
+#else
     getTextMargins(&left, 0, &right, 0);
     int width = left + right + 4 /*horizontalMargin in qlineedit.cpp*/;
     getContentsMargins(&left, 0, &right, 0);
     width += left + right;
 
     QStyleOptionFrameV2 opt;
+#endif
     initStyleOption(&opt);
 
     int minWidth = style()->sizeFromContents(QStyle::CT_LineEdit, &opt, QSize(width, 0).


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

`QLineEdit::getTextMargins`/`QLineEdit::getContentMargins` has been [deprecated in Qt 5](https://doc.qt.io/qt-5/qlineedit-obsolete.html) and `QLineEdit::contentMargins`/`QLineEdit::textMargins` is recommended instead.

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

Built Natron and used the node graph editor plus the settings menu.

**Futher details of this pull request**

N/A.
