### PR TITLE
Suppress Wnonnull for GCC 11

### DIFF
--- a/Gui/KnobGui.h
+++ b/Gui/KnobGui.h
@@ -203,8 +203,8 @@ public:
             ret = knob->setValue(v, ViewSpec::current(), dimension, reason, newKey);
         }
         if ( (ret > 0) && (ret != KnobHelper::eValueChangedReturnCodeNothingChanged) && (reason == eValueChangedReasonUserEdited) ) {
-            assert(newKey);
-            if (ret == KnobHelper::eValueChangedReturnCodeKeyframeAdded) {
+            assert(newKey != nullptr);
+            if (ret == KnobHelper::eValueChangedReturnCodeKeyframeAdded && newKey != nullptr) {
                 setKeyframeMarkerOnTimeline( newKey->getTime() );
             }
             Q_EMIT keyFrameSet();


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Some parts of the codebase display a `nonnull` warning under GCC 11 even if they were validated. Same happened as reported in Inkscape [issue 2206](https://gitlab.com/inkscape/inkscape/-/issues/2206).

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

Built Natron and used the node graph editor plus the settings menu.

**Futher details of this pull request**

Could be reworked in the future much like Inkscape [MR 2748](https://gitlab.com/inkscape/inkscape/-/merge_requests/2748).
