### PR TITLE
Replace width with horizontal advance for font metrics

### DIFF
--- a/Gui/ComboBox.cpp
+++ b/Gui/ComboBox.cpp
@@ -137,7 +137,11 @@ ComboBox::sizeForWidth(int w) const
     int hextra = DROP_DOWN_ICON_SIZE * 2, vextra = 0;
 
     ///Indent of 1 character
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    int indent = fm.horizontalAdvance( QLatin1Char('x') );
+#else
     int indent = fm.width( QLatin1Char('x') );
+#endif
 
     if (indent > 0) {
         if ( (align & Qt::AlignLeft) || (align & Qt::AlignRight) ) {
@@ -237,7 +241,11 @@ ComboBox::layoutRect() const
 {
     QRect cr = contentsRect();
     Qt::Alignment align = QStyle::visualAlignment( Qt::LeftToRight, QFlag(_align) );
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    int indent = fontMetrics().horizontalAdvance( QLatin1Char('x') ) / 2;
+#else
     int indent = fontMetrics().width( QLatin1Char('x') ) / 2;
+#endif
 
     if (indent > 0) {
         if (align & Qt::AlignLeft) {
@@ -723,7 +731,11 @@ ComboBox::setCurrentText_internal(const QString & text)
     }
 
     if (_sizePolicy.horizontalPolicy() != QSizePolicy::Fixed) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        int w = m.horizontalAdvance(str) + 2 * DROP_DOWN_ICON_SIZE;
+#else
         int w = m.width(str) + 2 * DROP_DOWN_ICON_SIZE;
+#endif
         setMinimumWidth(w);
     }
 
@@ -743,7 +755,11 @@ ComboBox::setMaximumWidthFromText(const QString & str)
     if (_sizePolicy.horizontalPolicy() == QSizePolicy::Fixed) {
         return;
     }
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    int w = fontMetrics().horizontalAdvance(str);
+#else
     int w = fontMetrics().width(str);
+#endif
     setMaximumWidth(w + DROP_DOWN_ICON_SIZE * 2);
 }
 
@@ -753,7 +769,11 @@ ComboBox::growMaximumWidthFromText(const QString & str)
     if (_sizePolicy.horizontalPolicy() == QSizePolicy::Fixed) {
         return;
     }
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    int w = fontMetrics().horizontalAdvance(str) + 2 * DROP_DOWN_ICON_SIZE;
+#else
     int w = fontMetrics().width(str) + 2 * DROP_DOWN_ICON_SIZE;
+#endif
 
     if ( w > maximumWidth() ) {
         setMaximumWidth(w);
@@ -843,7 +863,11 @@ ComboBox::setCurrentIndex_internal(int index)
 
     if (_sizePolicy.horizontalPolicy() != QSizePolicy::Fixed) {
         QFontMetrics m = fontMetrics();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        int w = m.horizontalAdvance(str) + 2 * DROP_DOWN_ICON_SIZE;
+#else
         int w = m.width(str) + 2 * DROP_DOWN_ICON_SIZE;
+#endif
         setMinimumWidth(w);
     }
 

--- a/Gui/CurveWidget.cpp
+++ b/Gui/CurveWidget.cpp
@@ -1535,7 +1535,11 @@ CurveWidget::getWidgetFontHeight() const
 int
 CurveWidget::getStringWidthForCurrentFont(const std::string& string) const
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    return fontMetrics().horizontalAdvance( QString::fromUtf8( string.c_str() ) );
+#else
     return fontMetrics().width( QString::fromUtf8( string.c_str() ) );
+#endif
 }
 
 QSize

--- a/Gui/CurveWidgetPrivate.cpp
+++ b/Gui/CurveWidgetPrivate.cpp
@@ -492,7 +492,11 @@ CurveWidgetPrivate::drawScale(double screenPixelRatio)
             ticks_fill(half_tick, ticks_max, m1, m2, &ticks);
             const double smallestTickSize = range * smallestTickSizePixel / rangePixel;
             const double largestTickSize = range * largestTickSizePixel / rangePixel;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+            const double minTickSizeTextPixel = ( (axis == 0) ? fm.horizontalAdvance( QLatin1String("00") ) : fm.height() ) / _screenPixelRatio;
+#else
             const double minTickSizeTextPixel = ( (axis == 0) ? fm.width( QLatin1String("00") ) : fm.height() ) / _screenPixelRatio; // AXIS-SPECIFIC
+#endif
             const double minTickSizeText = range * minTickSizeTextPixel / rangePixel;
             for (int i = m1; i <= m2; ++i) {
                 double value = i * smallTickSize + offset;
@@ -517,7 +521,11 @@ CurveWidgetPrivate::drawScale(double screenPixelRatio)
                 if (tickSize > minTickSizeText) {
                     const int tickSizePixel = rangePixel * tickSize / range;
                     const QString s = QString::number(value);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+                    const double sSizePixel = ( (axis == 0) ? fm.horizontalAdvance(s) : fm.height() ) / _screenPixelRatio; // AXIS-SPECIFIC
+#else
                     const double sSizePixel = ( (axis == 0) ? fm.width(s) : fm.height() ) / _screenPixelRatio; // AXIS-SPECIFIC
+#endif
                     if (tickSizePixel > sSizePixel) {
                         const double sSizeFullPixel = sSizePixel + minTickSizeTextPixel;
                         double alphaText = 1.0; //alpha;
@@ -771,7 +779,11 @@ CurveWidgetPrivate::isNearbyKeyFrameText(const QPoint& pt) const
                 topLeftWidget.ry() += yOffset;
 
                 QString coordStr =  QString::fromUtf8("x: %1, y: %2").arg( (*it2)->key.getTime() ).arg( (*it2)->key.getValue() );
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+                QPointF btmRightWidget( topLeftWidget.x() + fm.horizontalAdvance(coordStr) / _screenPixelRatio, topLeftWidget.y() + fm.height() / _screenPixelRatio );
+#else
                 QPointF btmRightWidget( topLeftWidget.x() + fm.width(coordStr) / _screenPixelRatio, topLeftWidget.y() + fm.height() / _screenPixelRatio );
+#endif
 
                 if ( (pt.x() >= topLeftWidget.x() - CLICK_DISTANCE_FROM_CURVE_ACCEPTANCE) && (pt.x() <= btmRightWidget.x() + CLICK_DISTANCE_FROM_CURVE_ACCEPTANCE) &&
                      ( pt.y() >= topLeftWidget.y() - CLICK_DISTANCE_FROM_CURVE_ACCEPTANCE) && ( pt.y() <= btmRightWidget.y() + CLICK_DISTANCE_FROM_CURVE_ACCEPTANCE) ) {
@@ -836,8 +848,13 @@ CurveWidgetPrivate::isNearbySelectedTangentText(const QPoint & pt) const
 
                 QString leftCoordStr =  QString( tr("l: %1") ).arg(std::floor( ( (*it2)->key.getLeftDerivative() * rounding ) + 0.5 ) / rounding);
                 QString rightCoordStr =  QString( tr("r: %1") ).arg(std::floor( ( (*it2)->key.getRightDerivative() * rounding ) + 0.5 ) / rounding);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+                QPointF btmRight_LeftTanWidget( topLeft_LeftTanWidget.x() + fm.horizontalAdvance(leftCoordStr) / _screenPixelRatio, topLeft_LeftTanWidget.y() + fm.height() / _screenPixelRatio );
+                QPointF btmRight_RightTanWidget( topLeft_RightTanWidget.x() + fm.horizontalAdvance(rightCoordStr) / _screenPixelRatio, topLeft_RightTanWidget.y() + fm.height() / _screenPixelRatio );
+#else
                 QPointF btmRight_LeftTanWidget( topLeft_LeftTanWidget.x() + fm.width(leftCoordStr) / _screenPixelRatio, topLeft_LeftTanWidget.y() + fm.height() / _screenPixelRatio );
                 QPointF btmRight_RightTanWidget( topLeft_RightTanWidget.x() + fm.width(rightCoordStr) / _screenPixelRatio, topLeft_RightTanWidget.y() + fm.height() / _screenPixelRatio );
+#endif
 
                 if ( (pt.x() >= topLeft_LeftTanWidget.x() - CLICK_DISTANCE_FROM_CURVE_ACCEPTANCE) && (pt.x() <= btmRight_LeftTanWidget.x() + CLICK_DISTANCE_FROM_CURVE_ACCEPTANCE) &&
                      ( pt.y() >= topLeft_LeftTanWidget.y() - CLICK_DISTANCE_FROM_CURVE_ACCEPTANCE) && ( pt.y() <= btmRight_LeftTanWidget.y() + CLICK_DISTANCE_FROM_CURVE_ACCEPTANCE) ) {

--- a/Gui/CustomParamInteract.cpp
+++ b/Gui/CustomParamInteract.cpp
@@ -291,7 +291,11 @@ CustomParamInteract::getWidgetFontHeight() const
 int
 CustomParamInteract::getStringWidthForCurrentFont(const std::string& string) const
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    return fontMetrics().horizontalAdvance( QString::fromUtf8( string.c_str() ) );
+#else
     return fontMetrics().width( QString::fromUtf8( string.c_str() ) );
+#endif
 }
 
 RectD

--- a/Gui/DopeSheetView.cpp
+++ b/Gui/DopeSheetView.cpp
@@ -423,7 +423,11 @@ DopeSheetView::getWidgetFontHeight() const
 int
 DopeSheetView::getStringWidthForCurrentFont(const std::string& string) const
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    return fontMetrics().horizontalAdvance( QString::fromUtf8( string.c_str() ) );
+#else
     return fontMetrics().width( QString::fromUtf8( string.c_str() ) );
+#endif
 }
 
 /*
@@ -922,7 +926,11 @@ DopeSheetViewPrivate::drawScale() const
 
         const double smallestTickSize = range * smallestTickSizePixel / rangePixel;
         const double largestTickSize = range * largestTickSizePixel / rangePixel;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        const double minTickSizeTextPixel = fm.horizontalAdvance( QString::fromUtf8("00") ) / _screenPixelRatio;
+#else
         const double minTickSizeTextPixel = fm.width( QString::fromUtf8("00") ) / _screenPixelRatio;
+#endif
         const double minTickSizeText = range * minTickSizeTextPixel / rangePixel;
 
         glCheckError();
@@ -947,7 +955,11 @@ DopeSheetViewPrivate::drawScale() const
             if (tickSize > minTickSizeText) {
                 const int tickSizePixel = rangePixel * tickSize / range;
                 const QString s = QString::number(value);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+                const int sSizePixel = fm.horizontalAdvance(s) / _screenPixelRatio;
+#else
                 const int sSizePixel = fm.width(s) / _screenPixelRatio;
+#endif
 
                 if (tickSizePixel > sSizePixel) {
                     const int sSizeFullPixel = sSizePixel + minTickSizeTextPixel;
@@ -1237,7 +1249,11 @@ DopeSheetViewPrivate::drawRange(const DSNodePtr &dsNode) const
             double fontHeight = fm.height() / _screenPixelRatio;
             QString leftText = QString::number(range.first);
             QString rightText = QString::number(range.second - 1);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+            double rightTextW = fm.horizontalAdvance(rightText) / _screenPixelRatio;
+#else
             double rightTextW = fm.width(rightText) / _screenPixelRatio;
+#endif
             QPointF textLeftPos( zoomContext.toZoomCoordinates(zoomContext.toWidgetCoordinates(range.first, 0).x() + 3, 0).x(),
                                  zoomContext.toZoomCoordinates(0, zoomContext.toWidgetCoordinates(0, clipRectCenterY).y() + fontHeight / 2.).y() );
 

--- a/Gui/Edge.cpp
+++ b/Gui/Edge.cpp
@@ -536,7 +536,11 @@ Edge::initLine()
                 _imp->label->setPos(pos);
                 QFontMetrics fm( _imp->label->font() );
                 int fontHeight = fm.height();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+                double txtWidth = fm.horizontalAdvance( _imp->label->text() );
+#else
                 double txtWidth = fm.width( _imp->label->text() );
+#endif
                 if ( (visibleLength < fontHeight * 2) || (visibleLength < txtWidth) ) {
                     _imp->label->hide();
                     _imp->enoughSpaceToShowLabel = false;
@@ -579,7 +583,11 @@ Edge::initLine()
                 double cosinus = std::cos(_imp->angle);
                 int yOffset = 0;
                 if (cosinus < 0) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+                    yOffset = -fm.horizontalAdvance( _imp->label->text() );
+#else
                     yOffset = -fm.width( _imp->label->text() );
+#endif
                 } else if ( (cosinus >= -0.01) && (cosinus <= 0.01) ) {
                     yOffset = +5;
                 } else {

--- a/Gui/Histogram.cpp
+++ b/Gui/Histogram.cpp
@@ -1629,7 +1629,11 @@ HistogramPrivate::drawScale()
             ticks_fill(half_tick, ticks_max, m1, m2, &ticks);
             const double smallestTickSize = range * smallestTickSizePixel / rangePixel;
             const double largestTickSize = range * largestTickSizePixel / rangePixel;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+            const double minTickSizeTextPixel = ( (axis == 0) ? fm.horizontalAdvance( QLatin1String("00") ) : fm.height() ) / _screenPixelRatio;
+#else
             const double minTickSizeTextPixel = ( (axis == 0) ? fm.width( QLatin1String("00") ) : fm.height() ) / _screenPixelRatio; // AXIS-SPECIFIC
+#endif
             const double minTickSizeText = range * minTickSizeTextPixel / rangePixel;
             for (int i = m1; i <= m2; ++i) {
                 double value = i * smallTickSize + offset;
@@ -1653,7 +1657,11 @@ HistogramPrivate::drawScale()
                 if (tickSize > minTickSizeText) {
                     const int tickSizePixel = rangePixel * tickSize / range;
                     const QString s = QString::number(value);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+                    const double sSizePixel = ( (axis == 0) ? fm.horizontalAdvance(s) : fm.height() ) / _screenPixelRatio; // AXIS-SPECIFIC
+#else
                     const double sSizePixel = ( (axis == 0) ? fm.width(s) : fm.height() ) / _screenPixelRatio; // AXIS-SPECIFIC
+#endif
                     if (tickSizePixel > sSizePixel) {
                         const double sSizeFullPixel = sSizePixel + minTickSizeTextPixel;
                         double alphaText = 1.0; //alpha;
@@ -1688,7 +1696,11 @@ HistogramPrivate::drawWarnings()
     if (mipMapLevel > 0) {
         QFontMetrics fm(*_textFont);
         QString str( tr("Image downscaled") );
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        double strWidth = fm.horizontalAdvance(str) / _screenPixelRatio;
+#else
         double strWidth = fm.width(str) / _screenPixelRatio;
+#endif
         double strHeight = fm.height() / _screenPixelRatio;
         QPointF pos = zoomCtx.toZoomCoordinates(widget->width() - strWidth - 10, 5 * strHeight + 30);
         glCheckError();
@@ -1720,7 +1732,11 @@ HistogramPrivate::drawMissingImage()
     }
     QString txt( tr("Missing image") );
     QFontMetrics fm(*_textFont);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    int strWidth = fm.horizontalAdvance(txt) / _screenPixelRatio;
+#else
     int strWidth = fm.width(txt) / _screenPixelRatio;
+#endif
     QPointF pos = zoomCtx.toZoomCoordinates(widget->width() / 2. - strWidth / 2., fm.height() / _screenPixelRatio + 10);
 
     glCheckError();
@@ -1818,7 +1834,11 @@ HistogramPrivate::drawPicker()
 
     glCheckError();
     QFontMetrics fm(*_textFont, 0);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    double strWidth = std::max( std::max( std::max( fm.horizontalAdvance(rValueStr), fm.horizontalAdvance(gValueStr) ), fm.horizontalAdvance(bValueStr) ), fm.horizontalAdvance(xCoordinateStr) ) / _screenPixelRatio;
+#else
     double strWidth = std::max( std::max( std::max( fm.width(rValueStr), fm.width(gValueStr) ), fm.width(bValueStr) ), fm.width(xCoordinateStr) ) / _screenPixelRatio;
+#endif
     double strHeight = fm.height() / _screenPixelRatio;
     QPointF xPos = zoomCtx.toZoomCoordinates(widget->width() - strWidth - 10, strHeight + 10);
     QPointF rPos = zoomCtx.toZoomCoordinates(widget->width() - strWidth - 10, 2 * strHeight + 15);

--- a/Gui/InfoViewerWidget.cpp
+++ b/Gui/InfoViewerWidget.cpp
@@ -98,20 +98,32 @@ InfoViewerWidget::InfoViewerWidget(const QString & description,
         descriptionText.append( QString::fromUtf8("</font>") );
         descriptionLabel->setText(descriptionText);
         QFontMetrics fm = descriptionLabel->fontMetrics();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        int width = fm.horizontalAdvance( QString::fromUtf8("A:") );
+#else
         int width = fm.width( QString::fromUtf8("A:") );
+#endif
         descriptionLabel->setMinimumWidth(width);
     }
     imageFormat = new Label(this);
     {
         QFontMetrics fm = imageFormat->fontMetrics();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        int width = fm.horizontalAdvance( QString::fromUtf8("backward.motion32f") );
+#else
         int width = fm.width( QString::fromUtf8("backward.motion32f") );
+#endif
         imageFormat->setMinimumWidth(width);
     }
 
     resolution = new Label(this);
     {
         QFontMetrics fm = resolution->fontMetrics();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        int width = fm.horizontalAdvance( QString::fromUtf8("2K_Super_35(full-ap) 00000x00000:0.00") );
+#else
         int width = fm.width( QString::fromUtf8("2K_Super_35(full-ap) 00000x00000:0.00") );
+#endif
         resolution->setMinimumWidth(width);
     }
 
@@ -119,7 +131,11 @@ InfoViewerWidget::InfoViewerWidget(const QString & description,
     coordDispWindow = new Label(this);
     {
         QFontMetrics fm = coordDispWindow->fontMetrics();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        int width = fm.horizontalAdvance( QString::fromUtf8("RoD: 000 000 0000 0000") );
+#else
         int width = fm.width( QString::fromUtf8("RoD: 000 000 0000 0000") );
+#endif
         coordDispWindow->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
         coordDispWindow->setMinimumWidth(width);
     }
@@ -127,7 +143,11 @@ InfoViewerWidget::InfoViewerWidget(const QString & description,
     _fpsLabel = new Label(this);
     {
         QFontMetrics fm = _fpsLabel->fontMetrics();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        int width = fm.horizontalAdvance( QString::fromUtf8("100 fps") );
+#else
         int width = fm.width( QString::fromUtf8("100 fps") );
+#endif
         _fpsLabel->setMinimumWidth(width);
         _fpsLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
         _fpsLabel->hide();
@@ -136,14 +156,22 @@ InfoViewerWidget::InfoViewerWidget(const QString & description,
     coordMouse = new Label(this);
     {
         QFontMetrics fm = coordMouse->fontMetrics();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        int width = fm.horizontalAdvance( QString::fromUtf8("x=00000 y=00000") );
+#else
         int width = fm.width( QString::fromUtf8("x=00000 y=00000") );
+#endif
         coordMouse->setMinimumWidth(width);
     }
 
     rgbaValues = new Label(this);
     {
         QFontMetrics fm = rgbaValues->fontMetrics();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        int width = fm.horizontalAdvance( QString::fromUtf8("0.00000 0.00000 0.00000 ~ ") );
+#else
         int width = fm.width( QString::fromUtf8("0.00000 0.00000 0.00000 ~ ") );
+#endif
         rgbaValues->setMinimumWidth(width);
     }
 
@@ -153,7 +181,11 @@ InfoViewerWidget::InfoViewerWidget(const QString & description,
     hvl_lastOption = new Label(this);
     {
         QFontMetrics fm = hvl_lastOption->fontMetrics();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        int width = fm.horizontalAdvance( QString::fromUtf8("H:000 S:0.00 V:0.00 L:0.00000") );
+#else
         int width = fm.width( QString::fromUtf8("H:000 S:0.00 V:0.00 L:0.00000") );
+#endif
         hvl_lastOption->setMinimumWidth(width);
     }
 

--- a/Gui/KnobGui20.cpp
+++ b/Gui/KnobGui20.cpp
@@ -578,7 +578,11 @@ KnobGui::getStringWidthForCurrentFont(const std::string& string) const
         return _imp->customInteract->getStringWidthForCurrentFont(string);
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    return getGui()->fontMetrics().horizontalAdvance( QString::fromUtf8( string.c_str() ) );
+#else
     return getGui()->fontMetrics().width( QString::fromUtf8( string.c_str() ) );
+#endif
 }
 
 void

--- a/Gui/KnobWidgetDnD.cpp
+++ b/Gui/KnobWidgetDnD.cpp
@@ -285,7 +285,11 @@ KnobWidgetDnD::startDrag()
         textThirdLine = tr("Drag it to a dimension of another parameter of the same type");
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    int textWidth = std::max( std::max( fmetrics.horizontalAdvance(textFirstLine), fmetrics.horizontalAdvance(knobLine) ), fmetrics.horizontalAdvance(textThirdLine) );
+#else
     int textWidth = std::max( std::max( fmetrics.width(textFirstLine), fmetrics.width(knobLine) ), fmetrics.width(textThirdLine) );
+#endif
     QImage dragImg(textWidth, (fmetrics.height() + 5) * 3, QImage::Format_ARGB32);
     dragImg.fill( QColor(0, 0, 0, 200) );
     QPainter p(&dragImg);

--- a/Gui/NodeGui.cpp
+++ b/Gui/NodeGui.cpp
@@ -985,7 +985,11 @@ NodeGui::resize(int width,
     QString persistentMessage = _persistentMessage->text();
     f.setPixelSize(25);
     metrics = QFontMetrics(f, 0);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    int pMWidth = metrics.horizontalAdvance(persistentMessage);
+#else
     int pMWidth = metrics.width(persistentMessage);
+#endif
     int midNodeX = topLeft.x() + iconWidth + (width - iconWidth) / 2;
     QPointF bitDepthPos(midNodeX, 0);
     _streamIssuesWarning->refreshPosition(bitDepthPos);

--- a/Gui/PreferencesPanel.cpp
+++ b/Gui/PreferencesPanel.cpp
@@ -769,7 +769,11 @@ PreferencesPanel::createGui()
             uiTabTreeItem = _imp->tabs[i].treeItem;
         }
         QString label = QString::fromUtf8( pageKnob->getLabel().c_str() );
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        int w = fm.horizontalAdvance(label);
+#else
         int w = fm.width(label);
+#endif
         maxLength = std::max(w, maxLength);
     }
     assert(pluginsFrameLayout);

--- a/Gui/ScaleSliderQWidget.cpp
+++ b/Gui/ScaleSliderQWidget.cpp
@@ -516,7 +516,11 @@ ScaleSliderQWidget::paintEvent(QPaintEvent* /*e*/)
     ticks_fill(half_tick, ticks_max, m1, m2, &ticks);
     const double smallestTickSize = range * smallestTickSizePixel / rangePixel;
     const double largestTickSize = range * largestTickSizePixel / rangePixel;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    const double minTickSizeTextPixel = fontM.horizontalAdvance( QLatin1String("00") ); // AXIS-SPECIFIC
+#else
     const double minTickSizeTextPixel = fontM.width( QLatin1String("00") ); // AXIS-SPECIFIC
+#endif
     const double minTickSizeText = range * minTickSizeTextPixel / rangePixel;
     for (int i = m1; i <= m2; ++i) {
         double value = i * smallTickSize + offset;
@@ -543,7 +547,11 @@ ScaleSliderQWidget::paintEvent(QPaintEvent* /*e*/)
         if ( renderFloating && (tickSize > minTickSizeText) ) {
             const int tickSizePixel = rangePixel * tickSize / range;
             const QString s = QString::number(value);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+            const int sSizePixel =  fontM.horizontalAdvance(s);
+#else
             const int sSizePixel =  fontM.width(s);
+#endif
             if (tickSizePixel > sSizePixel) {
                 const int sSizeFullPixel = sSizePixel + minTickSizeTextPixel;
                 double alphaText = 1.0; //alpha;
@@ -560,7 +568,11 @@ ScaleSliderQWidget::paintEvent(QPaintEvent* /*e*/)
 
                 QPointF textPos = _imp->zoomCtx.toWidgetCoordinates( value, btmLeft.y() );
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+                int textWidth = fontM.horizontalAdvance(s);
+#else
                 int textWidth = fontM.width(s);
+#endif
                 int textX = std::floor(textPos.x() + 0.5);
                 int textY = std::floor(textPos.y() + 0.5);
                 // center the text, and make sure it fits

--- a/Gui/ScriptTextEdit.cpp
+++ b/Gui/ScriptTextEdit.cpp
@@ -340,7 +340,11 @@ InputScriptTextEdit::getLineNumberAreaWidth()
         ++digits;
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    return 3 + fontMetrics().horizontalAdvance( QLatin1Char('9') ) * digits;
+#else
     return 3 + fontMetrics().width( QLatin1Char('9') ) * digits;
+#endif
 }
 
 void

--- a/Gui/SequenceFileDialog.cpp
+++ b/Gui/SequenceFileDialog.cpp
@@ -1327,7 +1327,11 @@ SequenceItemDelegate::sizeHint(const QStyleOptionViewItem & option,
     QString str =  index.data(FileSystemModel::FilePathRole).toString();
     QFontMetrics metric(option.font);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    return QSize( metric.horizontalAdvance(str), metric.height() );
+#else
     return QSize( metric.width(str), metric.height() );
+#endif
 }
 
 void
@@ -2670,7 +2674,11 @@ FileDialogComboBox::sizeHint() const
     if ( (index >= 0) && ( index < count() ) ) {
         QFontMetrics fm = fontMetrics();
         QString txt = itemText(index);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        int w = fm.horizontalAdvance(txt);
+#else
         int w = fm.width(txt);
+#endif
 
         return QSize(w + 10, fm.height() * 1.5);
     }

--- a/Gui/SplashScreen.cpp
+++ b/Gui/SplashScreen.cpp
@@ -209,7 +209,11 @@ LoadProjectSplashScreen::paintEvent(QPaintEvent* /*e*/)
     QString loadString( tr("Loading ") );
     QFontMetrics fm = p.fontMetrics();
     QPointF loadStrPos(300 * _scale, _pixmap.height() / 2.);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    p.drawText(QPointF(loadStrPos.x() + (fm.horizontalAdvance(loadString) + 5) * _scale, _pixmap.height() / 2.), _projectName);
+#else
     p.drawText(QPointF(loadStrPos.x() + (fm.width(loadString) + 5) * _scale, _pixmap.height() / 2.), _projectName);
+#endif
     p.setPen( QColor(243, 137, 0) );
     p.drawText(loadStrPos, loadString);
 }

--- a/Gui/TableModelView.cpp
+++ b/Gui/TableModelView.cpp
@@ -950,7 +950,11 @@ ExpandingLineEdit::resizeToContents()
     }
     if ( QWidget * parent = parentWidget() ) {
         QPoint position = pos();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        int hintWidth = minimumWidth() + fontMetrics().horizontalAdvance( displayText() );
+#else
         int hintWidth = minimumWidth() + fontMetrics().width( displayText() );
+#endif
         int parentWidth = parent->width();
         int maxWidth = isRightToLeft() ? position.x() + oldWidth : parentWidth - position.x();
         int newWidth = qBound(originalWidth, hintWidth, maxWidth);

--- a/Gui/TextRenderer.cpp
+++ b/Gui/TextRenderer.cpp
@@ -174,7 +174,11 @@ TextRendererPrivate::createCharacter(QChar c)
     }
 
     GLuint texture = _usedTextures.back();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    GLsizei width = _fontMetrics.horizontalAdvance(c);
+#else
     GLsizei width = _fontMetrics.width(c);
+#endif
     GLsizei height = _fontMetrics.height();
 
     // render into a new transparent pixmap using QPainter
@@ -284,7 +288,11 @@ TextRenderer::renderText(float x,
     if (flags & Qt::AlignHCenter || flags & Qt::AlignRight) {
         int width = 0;
         for (int i = 0; i < text.length(); ++i) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+            width += p->_fontMetrics.horizontalAdvance(text[i]);
+#else
             width += p->_fontMetrics.width(text[i]);
+#endif
         }
         if (flags & Qt::AlignHCenter) {
             x -= width/2. * scalex;

--- a/Gui/TimeLineGui.cpp
+++ b/Gui/TimeLineGui.cpp
@@ -542,7 +542,11 @@ TimeLineGui::paintGL()
         ticks_fill(half_tick, ticks_max, m1, m2, &ticks);
         const double smallestTickSize = range * smallestTickSizePixel / rangePixel;
         const double largestTickSize = range * largestTickSizePixel / rangePixel;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        const double minTickSizeTextPixel = ( _imp->isTimeFormatFrames ? fm.horizontalAdvance( QLatin1String("00000") ) : fm.horizontalAdvance( QLatin1String("00:00:00:00") ) ) / _imp->_screenPixelRatio;
+#else
         const double minTickSizeTextPixel = ( _imp->isTimeFormatFrames ? fm.width( QLatin1String("00000") ) : fm.width( QLatin1String("00:00:00:00") ) ) / _imp->_screenPixelRatio; // AXIS-SPECIFIC
+#endif
         const double minTickSizeText = range * minTickSizeTextPixel / rangePixel;
         for (int i = m1; i <= m2; ++i) {
             double value = i * smallTickSize + offset;
@@ -566,7 +570,11 @@ TimeLineGui::paintGL()
             if (tickSize > minTickSizeText) {
                 const int tickSizePixel = rangePixel * tickSize / range;
                 const QString s = _imp->isTimeFormatFrames ? QString::number(value) : timecodeString(value, fps);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+                const int sSizePixel =  fm.horizontalAdvance(s) / _imp->_screenPixelRatio;
+#else
                 const int sSizePixel =  fm.width(s) / _imp->_screenPixelRatio;
+#endif
                 if (tickSizePixel > sSizePixel) {
                     const int sSizeFullPixel = sSizePixel + minTickSizeTextPixel;
                     double alphaText = 1.0; //alpha;

--- a/Gui/ViewerGL.cpp
+++ b/Gui/ViewerGL.cpp
@@ -1115,7 +1115,11 @@ wordWrap(const QFontMetrics& fm,
 
     for (int i = 0; i < words.size(); ++i) {
         QString word = words[i];
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        int wordPixels = fm.horizontalAdvance(word);
+#else
         int wordPixels = fm.width(word);
+#endif
 
         // If adding the new word to the current line would be too long,
         // then put it on a new line (and split it up if it's too long).
@@ -1142,7 +1146,11 @@ wordWrap(const QFontMetrics& fm,
                     stringL.push_back(curString);
                     curString.clear();
                 }
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+                wordPixels = fm.horizontalAdvance(word);
+#else
                 wordPixels = fm.width(word);
+#endif
                 //tmp.append('\n');
             }
 
@@ -3699,7 +3707,11 @@ ViewerGL::getWidgetFontHeight() const
 int
 ViewerGL::getStringWidthForCurrentFont(const std::string& string) const
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    return fontMetrics().horizontalAdvance( QString::fromUtf8( string.c_str() ) );
+#else
     return fontMetrics().width( QString::fromUtf8( string.c_str() ) );
+#endif
 }
 
 void

--- a/Gui/ViewerTab.cpp
+++ b/Gui/ViewerTab.cpp
@@ -146,7 +146,11 @@ ViewerTab::ViewerTab(const std::list<NodeGuiPtr> & existingNodesContext,
                                         "The channels of the layer will be mapped to the RGBA channels of the viewer according to "
                                         "its number of channels. (e.g: UV would be mapped to RG)") + QString::fromUtf8("</p>") );
     QObject::connect( _imp->layerChoice, SIGNAL(currentIndexChanged(int)), this, SLOT(onLayerComboChanged(int)) );
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    _imp->layerChoice->setFixedWidth( fm.horizontalAdvance( QString::fromUtf8("Color.Toto.RGBA") ) + 3 * TO_DPIX(DROP_DOWN_ICON_SIZE) );
+#else
     _imp->layerChoice->setFixedWidth( fm.width( QString::fromUtf8("Color.Toto.RGBA") ) + 3 * TO_DPIX(DROP_DOWN_ICON_SIZE) );
+#endif
     _imp->layerChoice->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     _imp->firstRowLayout->addWidget(_imp->layerChoice);
 
@@ -154,7 +158,11 @@ ViewerTab::ViewerTab(const std::list<NodeGuiPtr> & existingNodesContext,
     _imp->alphaChannelChoice->setToolTip( QString::fromUtf8("<p><b>") + tr("Alpha channel:") + QString::fromUtf8("</b></p><p>")
                                           + tr("Select here a channel of any layer that will be used when displaying the "
                                                "alpha channel with the <b>Channels</b> choice on the right.") + QString::fromUtf8("</p>") );
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    _imp->alphaChannelChoice->setFixedWidth( fm.horizontalAdvance( QString::fromUtf8("Color.alpha") ) + 3 * TO_DPIX(DROP_DOWN_ICON_SIZE) );
+#else
     _imp->alphaChannelChoice->setFixedWidth( fm.width( QString::fromUtf8("Color.alpha") ) + 3 * TO_DPIX(DROP_DOWN_ICON_SIZE) );
+#endif
     _imp->alphaChannelChoice->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     QObject::connect( _imp->alphaChannelChoice, SIGNAL(currentIndexChanged(int)), this, SLOT(onAlphaChannelComboChanged(int)) );
     _imp->firstRowLayout->addWidget(_imp->alphaChannelChoice);
@@ -163,7 +171,11 @@ ViewerTab::ViewerTab(const std::list<NodeGuiPtr> & existingNodesContext,
     _imp->viewerChannels->setToolTip( QString::fromUtf8("<p><b>") + tr("Display Channels:") + QString::fromUtf8("</b></p><p>")
                                       + tr("The channels to display on the viewer.") + QString::fromUtf8("</p>") );
     _imp->firstRowLayout->addWidget(_imp->viewerChannels);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    _imp->viewerChannels->setFixedWidth( fm.horizontalAdvance( QString::fromUtf8("Luminance") ) + 3 * TO_DPIX(DROP_DOWN_ICON_SIZE) );
+#else
     _imp->viewerChannels->setFixedWidth( fm.width( QString::fromUtf8("Luminance") ) + 3 * TO_DPIX(DROP_DOWN_ICON_SIZE) );
+#endif
     _imp->viewerChannels->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
     addSpacer(_imp->firstRowLayout);
@@ -360,7 +372,11 @@ ViewerTab::ViewerTab(const std::list<NodeGuiPtr> & existingNodesContext,
 
     _imp->firstInputImage = new ComboBox(_imp->firstSettingsRow);
     _imp->firstInputImage->setToolTip( _imp->firstInputLabel->toolTip() );
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    _imp->firstInputImage->setFixedWidth(fm.horizontalAdvance( QString::fromUtf8("ColorCorrect1") ) + 3 * DROP_DOWN_ICON_SIZE);
+#else
     _imp->firstInputImage->setFixedWidth(fm.width( QString::fromUtf8("ColorCorrect1") ) + 3 * DROP_DOWN_ICON_SIZE);
+#endif
     _imp->firstInputImage->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     _imp->firstInputImage->addItem( QString::fromUtf8(" - ") );
     QObject::connect( _imp->firstInputImage, SIGNAL(currentIndexChanged(QString)), this, SLOT(onFirstInputNameChanged(QString)) );
@@ -376,7 +392,11 @@ ViewerTab::ViewerTab(const std::list<NodeGuiPtr> & existingNodesContext,
 
     _imp->compositingOperator = new ComboBox(_imp->firstSettingsRow);
     QObject::connect( _imp->compositingOperator, SIGNAL(currentIndexChanged(int)), this, SLOT(onCompositingOperatorIndexChanged(int)) );
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    _imp->compositingOperator->setFixedWidth(fm.horizontalAdvance( QString::fromUtf8("W-OnionSkin") ) + 3 * DROP_DOWN_ICON_SIZE);
+#else
     _imp->compositingOperator->setFixedWidth(fm.width( QString::fromUtf8("W-OnionSkin") ) + 3 * DROP_DOWN_ICON_SIZE);
+#endif
     _imp->compositingOperator->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     _imp->compositingOperator->setToolTip( _imp->compositingOperatorLabel->toolTip() );
     _imp->compositingOperator->addItem( tr(" - "), QIcon(), QKeySequence(), tr("No wipe or composite: A") );
@@ -399,7 +419,11 @@ ViewerTab::ViewerTab(const std::list<NodeGuiPtr> & existingNodesContext,
 
     _imp->secondInputImage = new ComboBox(_imp->firstSettingsRow);
     _imp->secondInputImage->setToolTip( _imp->secondInputLabel->toolTip() );
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    _imp->secondInputImage->setFixedWidth(fm.horizontalAdvance( QString::fromUtf8("ColorCorrect1") )  + 3 * DROP_DOWN_ICON_SIZE);
+#else
     _imp->secondInputImage->setFixedWidth(fm.width( QString::fromUtf8("ColorCorrect1") )  + 3 * DROP_DOWN_ICON_SIZE);
+#endif
     _imp->secondInputImage->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
     _imp->secondInputImage->addItem( QString::fromUtf8(" - ") );
     QObject::connect( _imp->secondInputImage, SIGNAL(currentIndexChanged(QString)), this, SLOT(onSecondInputNameChanged(QString)) );


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

`QFontMetrics::width` has been [deprecated in Qt 5](https://doc.qt.io/qt-5/qfontmetrics-obsolete.html) and `QLineEdit::horizontalAdvance` is recommended instead.

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

Built Natron and used the node graph editor plus the settings menu.

**Futher details of this pull request**

N/A.
