### PR TITLE
Only display the overlays for nodes that are in the viewer render path and have their properties panel maximized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Allow creating a node with the same name that was just deleted. #732
 - Natron can now keep up to 32 project backups (see Preferences/General/Save versions). #562
-- Only display the overlays for nodes that are in the viewer render path and have their properties panel maximized. #744
+- Only display the overlays for nodes that are in the viewer render path and have their properties panel maximized. Can be disabled in Preferences/Viewer. #744
 
 
 ## Version 2.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Allow creating a node with the same name that was just deleted. #732
 - Natron can now keep up to 32 project backups (see Preferences/General/Save versions). #562
+- Only display the overlays for nodes that are in the viewer render path and have their properties panel maximized. #744
 
 
 ## Version 2.4.2

--- a/Engine/Settings.cpp
+++ b/Engine/Settings.cpp
@@ -1140,15 +1140,23 @@ Settings::initializeKnobsViewers()
     _maximumNodeViewerUIOpened->setHintToolTip( tr("Controls the maximum amount of nodes that can have their interface showing up at the same time in the viewer") );
     _viewersTab->addKnob(_maximumNodeViewerUIOpened);
 
-    _viewerKeys = AppManager::createKnob<KnobBool>( this, tr("Use number keys for the viewer") );
-    _viewerKeys->setName("viewerNumberKeys");
-    _viewerKeys->setHintToolTip( tr("When enabled, the row of number keys on the keyboard "
+    _viewerNumberKeys = AppManager::createKnob<KnobBool>( this, tr("Use number keys for the viewer") );
+    _viewerNumberKeys->setName("viewerNumberKeys");
+    _viewerNumberKeys->setHintToolTip( tr("When enabled, the row of number keys on the keyboard "
                                     "is used for switching input (<key> connects input to A side, "
                                     "<shift-key> connects input to B side), even if the corresponding "
                                     "character in the current keyboard layout is not a number.\n"
                                     "This may have to be disabled when using a remote display connection "
                                     "to Linux from a different OS.") );
-    _viewersTab->addKnob(_viewerKeys);
+    _viewersTab->addKnob(_viewerNumberKeys);
+
+    _viewerOverlaysPath = AppManager::createKnob<KnobBool>( this, tr("Only display overlays for the viewer render path") );
+    _viewerOverlaysPath->setName("viewerOverlaysPath");
+    _viewerOverlaysPath->setHintToolTip( tr("When disabled, overlays for all the non-minimized open "
+                                            "properties panels are displayed. When enabled, overlays are "
+                                            "displayed only for the render path for the current viewer "
+                                            "inputs.") );
+    _viewersTab->addKnob(_viewerOverlaysPath);
 } // Settings::initializeKnobsViewers
 
 void
@@ -1546,7 +1554,8 @@ Settings::setDefaultValues()
     _autoProxyWhenScrubbingTimeline->setDefaultValue(true);
     _autoProxyLevel->setDefaultValue(1);
     _maximumNodeViewerUIOpened->setDefaultValue(2);
-    _viewerKeys->setDefaultValue(true);
+    _viewerNumberKeys->setDefaultValue(true);
+    _viewerOverlaysPath->setDefaultValue(true);
 
     // Nodegraph
     _autoScroll->setDefaultValue(false);
@@ -2493,9 +2502,15 @@ Settings::getMaxOpenedNodesViewerContext() const
 }
 
 bool
-Settings::isViewerKeysEnabled() const
+Settings::viewerNumberKeys() const
 {
-    return _viewerKeys->getValue();
+    return _viewerNumberKeys->getValue();
+}
+
+bool
+Settings::viewerOverlaysPath() const
+{
+    return _viewerOverlaysPath->getValue();
 }
 
 ///////////////////////////////////////////////////////

--- a/Engine/Settings.h
+++ b/Engine/Settings.h
@@ -254,7 +254,8 @@ public:
     bool isAutoProxyEnabled() const;
     unsigned int getAutoProxyMipMapLevel() const;
     int getMaxOpenedNodesViewerContext() const;
-    bool isViewerKeysEnabled() const;
+    bool viewerNumberKeys() const;
+    bool viewerOverlaysPath() const;
     ///////////////////////////////////////////////////////
 
     bool areRGBPixelComponentsSupported() const;
@@ -536,7 +537,8 @@ private:
     KnobBoolPtr _autoProxyWhenScrubbingTimeline;
     KnobChoicePtr _autoProxyLevel;
     KnobIntPtr _maximumNodeViewerUIOpened;
-    KnobBoolPtr _viewerKeys;
+    KnobBoolPtr _viewerNumberKeys;
+    KnobBoolPtr _viewerOverlaysPath;
 
     // Nodegraph
     KnobPagePtr _nodegraphTab;

--- a/Gui/Gui50.cpp
+++ b/Gui/Gui50.cpp
@@ -365,7 +365,7 @@ Gui::handleNativeKeys(int key,
                       quint32 nativeVirtualKey)
 {
     //qDebug() << "scancode=" << nativeScanCode << "virtualkey=" << nativeVirtualKey;
-    if ( !appPTR->getCurrentSettings()->isViewerKeysEnabled() ) {
+    if ( !appPTR->getCurrentSettings()->viewerNumberKeys() ) {
         return key;
     }
 

--- a/Gui/ViewerTab20.cpp
+++ b/Gui/ViewerTab20.cpp
@@ -114,7 +114,7 @@ ViewerTab::drawOverlays(double time,
         }
         double transformedTime;
         bool ok = _imp->getTimeTransform(time, view, *it, getInternalNode(), &transformedTime);
-        if (!ok) {
+        if (!ok && appPTR->getCurrentSettings()->viewerOverlaysPath()) {
             // overlay is not visible in current viewer, even though its parameter panel is open.
             continue;
         }
@@ -265,7 +265,7 @@ ViewerTab::notifyOverlaysPenDown(const RenderScale & renderScale,
     for (NodesList::const_iterator it = nodes.begin(); it != nodes.end(); ++it) {
         double transformedTime;
         bool ok = _imp->getTimeTransform(timestamp, view, *it, getInternalNode(), &transformedTime);
-        if (!ok) {
+        if (!ok && appPTR->getCurrentSettings()->viewerOverlaysPath()) {
             // overlay is not visible in current viewer, even though its parameter panel is open.
             continue;
         }
@@ -304,7 +304,7 @@ ViewerTab::notifyOverlaysPenDoubleClick(const RenderScale & renderScale,
 #else
         double transformedTime;
         bool ok = _imp->getTimeTransform(time, view, *it, getInternalNode(), &transformedTime);
-        if (!ok) {
+        if (!ok && appPTR->getCurrentSettings()->viewerOverlaysPath()) {
             // overlay is not visible in current viewer, even though its parameter panel is open.
             continue;
         }
@@ -369,7 +369,7 @@ ViewerTab::notifyOverlaysPenMotion_internal(const NodePtr& node,
 #else
     double transformedTime;
     bool ok = _imp->getTimeTransform(time, view, node, getInternalNode(), &transformedTime);
-    if (!ok) {
+    if (!ok && appPTR->getCurrentSettings()->viewerOverlaysPath()) {
         // overlay is not visible in current viewer, even though its parameter panel is open.
         return false;
     }
@@ -522,7 +522,7 @@ ViewerTab::notifyOverlaysPenUp(const RenderScale & renderScale,
 #else
         double transformedTime;
         bool ok = _imp->getTimeTransform(time, view, *it, getInternalNode(), &transformedTime);
-        if (!ok) {
+        if (!ok && appPTR->getCurrentSettings()->viewerOverlaysPath()) {
             // overlay is not visible in current viewer, even though its parameter panel is open.
             continue;
         }
@@ -661,7 +661,7 @@ ViewerTab::notifyOverlaysKeyDown_internal(const NodePtr& node,
 #ifdef NATRON_TRANSFORM_AFFECTS_OVERLAYS
     double transformedTime;
     bool ok = _imp->getTimeTransform(time, ViewIdx(0), node, getInternalNode(), &transformedTime);
-    if (!ok) {
+    if (!ok && appPTR->getCurrentSettings()->viewerOverlaysPath()) {
         // overlay is not visible in current viewer, even though its parameter panel is open.
         return false;
     }
@@ -771,7 +771,7 @@ ViewerTab::notifyOverlaysKeyUp(const RenderScale & renderScale,
 #ifdef NATRON_TRANSFORM_AFFECTS_OVERLAYS
         double transformedTime;
         bool ok = _imp->getTimeTransform(time, ViewIdx(0), *it, getInternalNode(), &transformedTime);
-        if (!ok) {
+        if (!ok && appPTR->getCurrentSettings()->viewerOverlaysPath()) {
             // overlay is not visible in current viewer, even though its parameter panel is open.
             continue;
         }
@@ -832,7 +832,7 @@ ViewerTab::notifyOverlaysKeyRepeat_internal(const NodePtr& node,
 #ifdef NATRON_TRANSFORM_AFFECTS_OVERLAYS
     double transformedTime;
     bool ok = _imp->getTimeTransform(time, ViewIdx(0), node, getInternalNode(), &transformedTime);
-    if (!ok) {
+    if (!ok && appPTR->getCurrentSettings()->viewerOverlaysPath()) {
         // overlay is not visible in current viewer, even though its parameter panel is open.
         return false;
     }
@@ -932,7 +932,7 @@ ViewerTab::notifyOverlaysFocusGained(const RenderScale & renderScale)
 #ifdef NATRON_TRANSFORM_AFFECTS_OVERLAYS
         double transformedTime;
         bool ok = _imp->getTimeTransform(time, ViewIdx(0), *it, getInternalNode(), &transformedTime);
-        if (!ok) {
+        if (!ok && appPTR->getCurrentSettings()->viewerOverlaysPath()) {
             // overlay is not visible in current viewer, even though its parameter panel is open.
             continue;
         }
@@ -986,7 +986,7 @@ ViewerTab::notifyOverlaysFocusLost(const RenderScale & renderScale)
 #ifdef NATRON_TRANSFORM_AFFECTS_OVERLAYS
         double transformedTime;
         bool ok = _imp->getTimeTransform(time, ViewIdx(0), *it, getInternalNode(), &transformedTime);
-        if (!ok) {
+        if (!ok && appPTR->getCurrentSettings()->viewerOverlaysPath()) {
             // overlay is not visible in current viewer, even though its parameter panel is open.
             continue;
         }

--- a/Gui/ViewerTab20.cpp
+++ b/Gui/ViewerTab20.cpp
@@ -109,9 +109,13 @@ ViewerTab::drawOverlays(double time,
     for (NodesList::reverse_iterator it = nodes.rbegin(); it != nodes.rend(); ++it) {
         NodeGuiPtr nodeUi = boost::dynamic_pointer_cast<NodeGui>( (*it)->getNodeGui() );
 #ifdef NATRON_TRANSFORM_AFFECTS_OVERLAYS
+        if (!nodeUi) {
+            continue;
+        }
         double transformedTime;
         bool ok = _imp->getTimeTransform(time, view, *it, getInternalNode(), &transformedTime);
-        if (!nodeUi) {
+        if (!ok) {
+            // overlay is not visible in current viewer, even though its parameter panel is open.
             continue;
         }
         bool overlayDeemed = false;
@@ -257,8 +261,15 @@ ViewerTab::notifyOverlaysPenDown(const RenderScale & renderScale,
     NodesList nodes;
     getGui()->getNodesEntitledForOverlays(nodes);
 
+    ViewIdx view = getCurrentView();
     for (NodesList::const_iterator it = nodes.begin(); it != nodes.end(); ++it) {
-        if ( notifyOverlaysPenDown_internal(*it, renderScale, pen, viewportPos, pos, pressure, timestamp) ) {
+        double transformedTime;
+        bool ok = _imp->getTimeTransform(timestamp, view, *it, getInternalNode(), &transformedTime);
+        if (!ok) {
+            // overlay is not visible in current viewer, even though its parameter panel is open.
+            continue;
+        }
+        if ( notifyOverlaysPenDown_internal(*it, renderScale, pen, viewportPos, pos, pressure, transformedTime) ) {
             return true;
         }
     }
@@ -284,18 +295,20 @@ ViewerTab::notifyOverlaysPenDoubleClick(const RenderScale & renderScale,
     getGui()->getNodesEntitledForOverlays(nodes);
 
 
+    ViewIdx view = getCurrentView();
     for (NodesList::const_iterator it = nodes.begin(); it != nodes.end(); ++it) {
         QPointF transformPos;
         double time = getGui()->getApp()->getTimeLine()->currentFrame();
 #ifndef NATRON_TRANSFORM_AFFECTS_OVERLAYS
         transformPos = pos;
 #else
-        ViewIdx view = getCurrentView();
         double transformedTime;
         bool ok = _imp->getTimeTransform(time, view, *it, getInternalNode(), &transformedTime);
-        if (ok) {
-            time = transformedTime;
+        if (!ok) {
+            // overlay is not visible in current viewer, even though its parameter panel is open.
+            continue;
         }
+        time = transformedTime;
 
         Transform::Matrix3x3 mat(1, 0, 0, 0, 1, 0, 0, 0, 1);
         ok = _imp->getOverlayTransform(time, view, *it, getInternalNode(), &mat);
@@ -356,6 +369,10 @@ ViewerTab::notifyOverlaysPenMotion_internal(const NodePtr& node,
 #else
     double transformedTime;
     bool ok = _imp->getTimeTransform(time, view, node, getInternalNode(), &transformedTime);
+    if (!ok) {
+        // overlay is not visible in current viewer, even though its parameter panel is open.
+        return false;
+    }
     if (ok) {
         /*
          * Do not allow interaction with retimed interacts otherwise the user may end up modifying keyframes at unexpected
@@ -505,6 +522,10 @@ ViewerTab::notifyOverlaysPenUp(const RenderScale & renderScale,
 #else
         double transformedTime;
         bool ok = _imp->getTimeTransform(time, view, *it, getInternalNode(), &transformedTime);
+        if (!ok) {
+            // overlay is not visible in current viewer, even though its parameter panel is open.
+            continue;
+        }
         if (ok) {
             /*
              * Do not allow interaction with retimed interacts otherwise the user may end up modifying keyframes at unexpected
@@ -640,6 +661,10 @@ ViewerTab::notifyOverlaysKeyDown_internal(const NodePtr& node,
 #ifdef NATRON_TRANSFORM_AFFECTS_OVERLAYS
     double transformedTime;
     bool ok = _imp->getTimeTransform(time, ViewIdx(0), node, getInternalNode(), &transformedTime);
+    if (!ok) {
+        // overlay is not visible in current viewer, even though its parameter panel is open.
+        return false;
+    }
     if (ok) {
         /*
          * Do not allow interaction with retimed interacts otherwise the user may end up modifying keyframes at unexpected
@@ -746,6 +771,10 @@ ViewerTab::notifyOverlaysKeyUp(const RenderScale & renderScale,
 #ifdef NATRON_TRANSFORM_AFFECTS_OVERLAYS
         double transformedTime;
         bool ok = _imp->getTimeTransform(time, ViewIdx(0), *it, getInternalNode(), &transformedTime);
+        if (!ok) {
+            // overlay is not visible in current viewer, even though its parameter panel is open.
+            continue;
+        }
         if (ok) {
             /*
              * Do not allow interaction with retimed interacts otherwise the user may end up modifying keyframes at unexpected
@@ -803,6 +832,10 @@ ViewerTab::notifyOverlaysKeyRepeat_internal(const NodePtr& node,
 #ifdef NATRON_TRANSFORM_AFFECTS_OVERLAYS
     double transformedTime;
     bool ok = _imp->getTimeTransform(time, ViewIdx(0), node, getInternalNode(), &transformedTime);
+    if (!ok) {
+        // overlay is not visible in current viewer, even though its parameter panel is open.
+        return false;
+    }
     if (ok) {
         /*
          * Do not allow interaction with retimed interacts otherwise the user may end up modifying keyframes at unexpected
@@ -899,6 +932,10 @@ ViewerTab::notifyOverlaysFocusGained(const RenderScale & renderScale)
 #ifdef NATRON_TRANSFORM_AFFECTS_OVERLAYS
         double transformedTime;
         bool ok = _imp->getTimeTransform(time, ViewIdx(0), *it, getInternalNode(), &transformedTime);
+        if (!ok) {
+            // overlay is not visible in current viewer, even though its parameter panel is open.
+            continue;
+        }
         if (ok) {
             time = transformedTime;
         }
@@ -949,6 +986,10 @@ ViewerTab::notifyOverlaysFocusLost(const RenderScale & renderScale)
 #ifdef NATRON_TRANSFORM_AFFECTS_OVERLAYS
         double transformedTime;
         bool ok = _imp->getTimeTransform(time, ViewIdx(0), *it, getInternalNode(), &transformedTime);
+        if (!ok) {
+            // overlay is not visible in current viewer, even though its parameter panel is open.
+            continue;
+        }
         if (ok) {
             time = transformedTime;
         }


### PR DESCRIPTION
…h and have their properties panel maximized

fixes #744
