### PR TITLE
Hide viewer buttons when roto/tracker properties panel is minimized

### DIFF
--- a/Documentation/source/conf.py
+++ b/Documentation/source/conf.py
@@ -53,7 +53,7 @@ version_21 = '2.1.10'
 version_22 = '2.2.10'
 version_23 = '2.3.16'
 version_24 = '2.4.3'
-version_24 = '2.5.0'
+version_25 = '2.5.0'
 version_30 = '3.0.0'
 
 # The version for this branch

--- a/Gui/NodeGui.cpp
+++ b/Gui/NodeGui.cpp
@@ -2130,23 +2130,23 @@ NodeGui::setVisibleSettingsPanel(bool b, bool m, bool h)
     }
     if (_settingsPanel) {
         _settingsPanel->setClosed(!b);
+        if (b) {
+            // also maximize (but don't minimize when closing)
+            _settingsPanel->minimizeOrMaximize(false);
+        }
     }
 }
 
 bool
 NodeGui::isSettingsPanelVisible() const
 {
-    if (_settingsPanel) {
-        return !_settingsPanel->isClosed();
-    } else {
-        return false;
-    }
+    return _settingsPanel && !_settingsPanel->isClosed() && !_settingsPanel->isMinimized();
 }
 
 bool
 NodeGui::isSettingsPanelMinimized() const
 {
-    return _settingsPanel ? _settingsPanel->isMinimized() : false;
+    return _settingsPanel && _settingsPanel->isMinimized();
 }
 
 void

--- a/Gui/NodeGui.cpp
+++ b/Gui/NodeGui.cpp
@@ -434,6 +434,8 @@ NodeGui::ensurePanelCreated(bool minimized, bool hideUnmodified)
     if (_settingsPanel) {
         QObject::connect( _settingsPanel, SIGNAL(nameChanged(QString)), this, SLOT(setName(QString)) );
         QObject::connect( _settingsPanel, SIGNAL(closeChanged(bool)), this, SLOT(onSettingsPanelClosed(bool)) );
+        QObject::connect( _settingsPanel, SIGNAL(minimized()), this, SLOT(onSettingsPanelMinimized()) );
+        QObject::connect( _settingsPanel, SIGNAL(maximized()), this, SLOT(onSettingsPanelMaximized()) );
         QObject::connect( _settingsPanel, SIGNAL(colorChanged(QColor)), this, SLOT(onSettingsPanelColorChanged(QColor)) );
 
         _graph->getGui()->setNodeViewerInterface(thisShared);
@@ -495,6 +497,32 @@ NodeGui::onSettingsPanelClosed(bool closed)
         }
     }
     Q_EMIT settingsPanelClosed(closed);
+}
+
+void
+NodeGui::onSettingsPanelMinimized()
+{
+    NodePtr internalNode = getNode();
+    if (internalNode && internalNode->hasAnyPersistentMessage()) {
+        const std::list<ViewerTab*>& viewers = getDagGui()->getGui()->getViewersList();
+        for (std::list<ViewerTab*>::const_iterator it = viewers.begin(); it != viewers.end(); ++it) {
+            (*it)->getViewer()->updatePersistentMessage();
+        }
+    }
+    Q_EMIT settingsPanelMinimized();
+}
+
+void
+NodeGui::onSettingsPanelMaximized()
+{
+    NodePtr internalNode = getNode();
+    if (internalNode && internalNode->hasAnyPersistentMessage()) {
+        const std::list<ViewerTab*>& viewers = getDagGui()->getGui()->getViewersList();
+        for (std::list<ViewerTab*>::const_iterator it = viewers.begin(); it != viewers.end(); ++it) {
+            (*it)->getViewer()->updatePersistentMessage();
+        }
+    }
+    Q_EMIT settingsPanelMaximized();
 }
 
 NodeSettingsPanel*

--- a/Gui/NodeGui.h
+++ b/Gui/NodeGui.h
@@ -453,6 +453,10 @@ public Q_SLOTS:
 
     void onSettingsPanelClosed(bool closed);
 
+    void onSettingsPanelMinimized();
+
+    void onSettingsPanelMaximized();
+
     void onSettingsPanelColorChanged(const QColor & color);
 
     void togglePreview();
@@ -542,6 +546,10 @@ Q_SIGNALS:
     void positionChanged(int x, int y);
 
     void settingsPanelClosed(bool b);
+
+    void settingsPanelMinimized();
+
+    void settingsPanelMaximized();
 
     void previewImageComputed();
 

--- a/Gui/NodeSettingsPanel.cpp
+++ b/Gui/NodeSettingsPanel.cpp
@@ -88,6 +88,8 @@ NodeSettingsPanel::NodeSettingsPanel(const MultiInstancePanelPtr & multiPanel,
 
 
     QObject::connect( this, SIGNAL(closeChanged(bool)), NodeUi.get(), SLOT(onSettingsPanelClosedChanged(bool)) );
+    QObject::connect( this, SIGNAL(minimized()), NodeUi.get(), SLOT(onSettingsPanelMinimized(bool)) );
+    QObject::connect( this, SIGNAL(maximized()), NodeUi.get(), SLOT(onSettingsPanelMaximized(bool)) );
     const QSize mediumBSize( TO_DPIX(NATRON_MEDIUM_BUTTON_SIZE), TO_DPIY(NATRON_MEDIUM_BUTTON_SIZE) );
     const QSize mediumIconSize( TO_DPIX(NATRON_MEDIUM_BUTTON_ICON_SIZE), TO_DPIY(NATRON_MEDIUM_BUTTON_ICON_SIZE) );
     QPixmap pixSettings;

--- a/Gui/NodeSettingsPanel.cpp
+++ b/Gui/NodeSettingsPanel.cpp
@@ -88,8 +88,6 @@ NodeSettingsPanel::NodeSettingsPanel(const MultiInstancePanelPtr & multiPanel,
 
 
     QObject::connect( this, SIGNAL(closeChanged(bool)), NodeUi.get(), SLOT(onSettingsPanelClosedChanged(bool)) );
-    QObject::connect( this, SIGNAL(minimized()), NodeUi.get(), SLOT(onSettingsPanelMinimized(bool)) );
-    QObject::connect( this, SIGNAL(maximized()), NodeUi.get(), SLOT(onSettingsPanelMaximized(bool)) );
     const QSize mediumBSize( TO_DPIX(NATRON_MEDIUM_BUTTON_SIZE), TO_DPIY(NATRON_MEDIUM_BUTTON_SIZE) );
     const QSize mediumIconSize( TO_DPIX(NATRON_MEDIUM_BUTTON_ICON_SIZE), TO_DPIY(NATRON_MEDIUM_BUTTON_ICON_SIZE) );
     QPixmap pixSettings;

--- a/Gui/NodeViewerContext.cpp
+++ b/Gui/NodeViewerContext.cpp
@@ -159,6 +159,8 @@ NodeViewerContext::createGui()
     QObject::connect( _imp->viewer, SIGNAL(selectionCleared()), this, SLOT(onViewerSelectionCleared()), Qt::UniqueConnection );
     NodeGuiPtr node = _imp->getNode();
     QObject::connect( node.get(), SIGNAL(settingsPanelClosed(bool)), this, SLOT(onNodeSettingsPanelClosed(bool)), Qt::UniqueConnection );
+    QObject::connect( node.get(), SIGNAL(settingsPanelMinimized()), this, SLOT(onNodeSettingsPanelMinimized()), Qt::UniqueConnection );
+    QObject::connect( node.get(), SIGNAL(settingsPanelMaximized()), this, SLOT(onNodeSettingsPanelMaximized()), Qt::UniqueConnection );
     KnobsVec knobsOrdered = node->getNode()->getEffectInstance()->getViewerUIKnobs();
 
 
@@ -266,6 +268,18 @@ NodeViewerContext::onNodeSettingsPanelClosed(bool closed)
         // Set the viewer interface for this plug-in to be the one of this node
         _imp->viewerTab->setPluginViewerInterface(node);
     }
+}
+
+void
+NodeViewerContext::onNodeSettingsPanelMinimized()
+{
+    return onNodeSettingsPanelClosed(true);
+}
+
+void
+NodeViewerContext::onNodeSettingsPanelMaximized()
+{
+    return onNodeSettingsPanelClosed(false);
 }
 
 int

--- a/Gui/NodeViewerContext.h
+++ b/Gui/NodeViewerContext.h
@@ -138,6 +138,10 @@ public Q_SLOTS:
 
     void onNodeSettingsPanelClosed(bool closed);
 
+    void onNodeSettingsPanelMinimized();
+
+    void onNodeSettingsPanelMaximized();
+
 private:
 
     boost::scoped_ptr<NodeViewerContextPrivate> _imp;


### PR DESCRIPTION
**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)

**What does this pull request do?**

- addresses issue commented in [#745 (review)](https://github.com/NatronGitHub/Natron/pull/745#pullrequestreview-847945375)
- when panel is maximized, buttons are displayed even if viewer is not in render path (see #744 for an explanation of that feature). This is not 100% satisfactory, but better than before IMHO
- do not show the viewer buttons if a node is selected in the nodegraph but has its properties panel minimized
- maximize properties panel when double-clicking a node in the nodegraph
- minimized() and maximized() were originally two separate signals (in NodeSettingsPanel), so I kept it that way, but we could have simpler definitions of NodeGui::onSettingsPanelMinimized() and NodeGui::onSettingsPanelMaximized() that simply call NodeGui::onSettingsPanelClosed(true) or NodeGui::onSettingsPanelClosed(false).

**Show a few screenshots (if this is a visual change)**

N/A

**Have you tested your changes (if applicable)? If so, how?**

- create a rotopaint node, connect to the viewer
- create a rotopaint shape
- minimize the rotopaint panel, the buttons in the Viewer should be removed [FIXED IN THIS PR]
- create a tracker node, its buttons should appear in the viewer
- select the rotopaint node in the nodegraph, its viewer buttons should not appear [FIXED IN THIS PR]
- double-click the rotopaint node in the nodegraph, it will be maximized [FIXED IN THIS PR] and its viewer buttons replace those of the tracker node