### PR TITLE
Color selector palette

### DIFF
--- a/Gui/ColorSelectorWidget.cpp
+++ b/Gui/ColorSelectorWidget.cpp
@@ -133,7 +133,7 @@ ColorSelectorPaletteButton::updateColor(bool signal)
                 .arg(_g)
                 .arg(_b)
                 .arg(_a)
-                .arg( tr("Clear current color with right-click.") ) );
+                .arg( tr("Clear color with right-click.") ) );
 
     if (signal) {
         Q_EMIT colorChanged(_r, _g, _b, _a);
@@ -145,10 +145,10 @@ ColorSelectorPaletteButton::initButton()
 {
     setIconSize( QSize(COLOR_SELECTOR_PALETTE_ICON_SIZE,
                        COLOR_SELECTOR_PALETTE_ICON_SIZE) );
-    setStyleSheet( QString::fromUtf8("border: 0; background-color: transparent;") );
+    setStyleSheet( QString::fromUtf8("QPushButton { border: 0; background-color: transparent; }") );
 
-    QObject::connect( this, SIGNAL(clicked()),
-                      this, SLOT(buttonClicked()) );
+    QObject::connect( this, SIGNAL( clicked() ),
+                      this, SLOT( buttonClicked() ) );
 
     updateColor(false);
 }

--- a/Gui/ColorSelectorWidget.h
+++ b/Gui/ColorSelectorWidget.h
@@ -38,7 +38,60 @@ CLANG_DIAG_ON(uninitialized)
 #include "Gui/LineEdit.h"
 #include "Gui/Button.h"
 
+#define COLOR_SELECTOR_PALETTE_DEFAULT_COLOR 0.0
+#define COLOR_SELECTOR_PALETTE_SETTINGS "ColorSelectorPalette"
+#define COLOR_SELECTOR_PALETTE_ROWS 2
+#define COLOR_SELECTOR_PALETTE_COLS 12
+#define COLOR_SELECTOR_PALETTE_ICON_SIZE 18
+
 NATRON_NAMESPACE_ENTER
+
+class ColorSelectorPaletteButton : public Button
+{
+    Q_OBJECT
+
+public:
+
+    explicit ColorSelectorPaletteButton(QWidget *parent = NULL);
+    explicit ColorSelectorPaletteButton(float r = COLOR_SELECTOR_PALETTE_DEFAULT_COLOR,
+                                        float g = COLOR_SELECTOR_PALETTE_DEFAULT_COLOR,
+                                        float b = COLOR_SELECTOR_PALETTE_DEFAULT_COLOR,
+                                        float a = 1.0,
+                                        QWidget *parent = NULL);
+
+    bool isModified();
+    void clearModified();
+
+    void getColor(float *r, float *g, float *b, float *a);
+
+Q_SIGNALS:
+
+    void colorChanged(float r, float g, float b, float a);
+    void colorPicked(float r, float g, float b, float a);
+
+public Q_SLOTS:
+
+    void clearColor();
+    void setColor(float r, float g, float b, float a);
+
+private:
+
+    float _r;
+    float _g;
+    float _b;
+    float _a;
+    bool _modified;
+
+    void updateColor(bool signal = true);
+
+    void initButton();
+
+private Q_SLOTS:
+
+    void buttonClicked();
+
+    void mouseReleaseEvent(QMouseEvent *e) override;
+};
 
 class ColorSelectorWidget : public QWidget
 {
@@ -57,6 +110,7 @@ Q_SIGNALS:
 public Q_SLOTS:
 
     void setColor(float r, float g, float b, float a);
+    void setColorFromPalette(float r, float g, float b, float a);
 
 private:
 
@@ -84,6 +138,8 @@ private:
 
     QStackedWidget *_stack;
 
+    QVector<ColorSelectorPaletteButton*> _paletteButtons;
+
     void setRedChannel(float value);
     void setGreenChannel(float value);
     void setBlueChannel(float value);
@@ -97,6 +153,13 @@ private:
     void announceColorChange();
 
     void setTriangleSize();
+
+    void initPaletteButtons(QWidget *widget = NULL,
+                            int rows = COLOR_SELECTOR_PALETTE_ROWS,
+                            int cols = COLOR_SELECTOR_PALETTE_COLS);
+    void updatePaletteButtons();
+    void savePaletteButton(int id);
+    void savePaletteButtons();
 
 private Q_SLOTS:
 
@@ -130,12 +193,16 @@ private Q_SLOTS:
 
     void handleButtonClicked(bool checked);
 
+    void setPaletteButtonColor(bool clicked = true);
+    void clearPaletteButtons(bool clicked = true);
+
     // workaround for QToolButton+QWidgetAction
     // triggered signal(s) are never emitted!?
     bool event(QEvent*e) override
     {
         if (e->type() == QEvent::Show) {
             Q_EMIT updateColor();
+            updatePaletteButtons();
         }
         return QWidget::event(e);
     }

--- a/Gui/ColorSelectorWidget.h
+++ b/Gui/ColorSelectorWidget.h
@@ -30,6 +30,7 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QMouseEvent>
 #include <QEvent>
 #include <QStackedWidget>
+#include <QButtonGroup>
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
@@ -134,7 +135,7 @@ private:
 
     LineEdit *_hex;
 
-    Button *_button;
+    QButtonGroup *_buttonColorGroup;
 
     QStackedWidget *_stack;
 
@@ -191,7 +192,7 @@ private Q_SLOTS:
     void setSliderSColor();
     void setSliderVColor();
 
-    void handleButtonClicked(bool checked);
+    void handleButtonColorClicked(int id);
 
     void setPaletteButtonColor(bool clicked = true);
     void clearPaletteButtons(bool clicked = true);


### PR DESCRIPTION
- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Adds supports for palette in the color selector and some ui changes/fixes in the widget.

The palette is stored in the Natron settings.

* Right-click a palette color to clear/reset
* Shift+A to add current color to palette
* Shift+C to clear the palette

**Show a few screenshots (if this is a visual change)**

![palette-macos](https://user-images.githubusercontent.com/34516798/149637051-655aeac6-985d-4a21-97ec-2474124acc35.png)
![palette-winlin](https://user-images.githubusercontent.com/34516798/149637055-02402f54-a7c1-4b79-901b-c912002bd053.png)

**Have you tested your changes (if applicable)? If so, how?**

* macOS 10.13
* Ubuntu 20.04
* Windows 10 20H2

**Futher details of this pull request**

See #688