### PR TITLE
Query site packages path using the Python site module

### DIFF
--- a/global.pri
+++ b/global.pri
@@ -56,7 +56,7 @@ run-without-python {
     # PYTHON_VERSION contains major.minor.micro
     PYTHON_VERSION=$$system(python$$PYV -c \"import platform; print(platform.python_version())\")
     # PYTHON_SITE_PACKAGES contains the location of the site-packages directory
-    PYTHON_SITE_PACKAGES=$$system(python$$PYV -c \"from distutils.sysconfig import get_python_lib; print(get_python_lib())\")
+    PYTHON_SITE_PACKAGES=$$system(python$$PYV -c \"import site; print(site.getsitepackages()[0])\")
     # User may specify an alternate python2-config from the command-line,
     # as in "qmake PYTHON_CONFIG=python2.7-config"
     isEmpty(PYTHON_CONFIG) {


### PR DESCRIPTION
## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)

**What does this pull request do?**

Running QMake to generate the Makefiles displays various `DeprecationWarning`s under Python 3.10 due to the usage of `distutils`, which is indeed deprecated. Replacing the usage of the module with `site` maintains [compatibility with Python 2.7](https://docs.python.org/2/library/site.html#site.getsitepackages).

**Show a few screenshots (if this is a visual change)**

```python
>>> from distutils.sysconfig import get_python_lib
<string>:1: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
<string>:1: DeprecationWarning: The distutils.sysconfig module is deprecated, use sysconfig instead
>>> print(get_python_lib())
/usr/lib/python3.10/site-packages
>>> # Although ``site`` fits the bill
>>> import site
>>> print(site.getsitepackages()[0])
/usr/lib/python3.10/site-packages
```

**Have you tested your changes (if applicable)? If so, how?**

By building Natron.

**Futher details of this pull request**

I'm planning to do the same for the initialization process by using both `site` and `sysconfig`.
