### PR TITLE
Substitute QGL classes with QOpenGL

### DIFF
--- a/Gui/CurveGui.cpp
+++ b/Gui/CurveGui.cpp
@@ -45,6 +45,10 @@
 #include "Gui/CurveWidgetPrivate.h"
 #include "Gui/KnobGui.h"
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QOpenGLContext>
+#endif
+
 NATRON_NAMESPACE_ENTER
 
 CurveGui::CurveGui(CurveWidget *curveWidget,
@@ -299,7 +303,7 @@ CurveGui::drawCurve(int curveIndex,
         return;
     }
 
-    assert( QGLContext::currentContext() == _curveWidget->context() );
+    assert( QOpenGLContext::currentContext() == _curveWidget->context() );
 
     std::vector<float> vertices, exprVertices;
     double x1 = 0;

--- a/Gui/CurveWidget.cpp
+++ b/Gui/CurveWidget.cpp
@@ -70,6 +70,10 @@ GCC_DIAG_UNUSED_PRIVATE_FIELD_ON
 #include "Gui/TabWidget.h"
 #include "Gui/ViewerGL.h"
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QOpenGLContext>
+#endif
+
 NATRON_NAMESPACE_ENTER
 
 /*****************************CURVE WIDGET***********************************************/
@@ -116,8 +120,12 @@ CurveWidget::CurveWidget(Gui* gui,
                          CurveSelection* selection,
                          TimeLinePtr timeline,
                          QWidget* parent,
-                         const QGLWidget* shareWidget)
-    : QGLWidget(parent, shareWidget)
+                         const QOpenGLWidget* shareWidget)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    : QOpenGLWidget(parent)
+#else
+    : QOpenGLWidget(parent, shareWidget)
+#endif
     , _imp( new CurveWidgetPrivate(gui, selection, timeline, this) )
 {
     // always running in the main thread
@@ -435,7 +443,11 @@ CurveWidget::swapOpenGLBuffers()
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    update();
+#else
     swapBuffers();
+#endif
 }
 
 /**
@@ -486,7 +498,7 @@ CurveWidget::getScreenPixelRatio() const
     assert( qApp && qApp->thread() == QThread::currentThread() );
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-    return windowHandle()->devicePixelRatio();
+    return devicePixelRatio();
 #else
     return _imp->_gui ? _imp->_gui->devicePixelRatio() : 1.;
 #endif
@@ -579,7 +591,7 @@ CurveWidget::resizeGL(int width,
 {
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );
-    assert( QGLContext::currentContext() == context() );
+    assert( QOpenGLContext::currentContext() == context() );
 
     if ( !appPTR->isOpenGLLoaded() ) {
         return;
@@ -620,7 +632,7 @@ CurveWidget::paintGL()
 {
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );
-    assert( QGLContext::currentContext() == context() );
+    assert( QOpenGLContext::currentContext() == context() );
 
     if ( !appPTR->isOpenGLLoaded() ) {
         return;
@@ -735,7 +747,7 @@ CurveWidget::renderText(double x,
 {
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );
-    assert( QGLContext::currentContext() == context() );
+    assert( QOpenGLContext::currentContext() == context() );
 
     if ( text.isEmpty() ) {
         return;
@@ -1241,7 +1253,7 @@ CurveWidget::mouseMoveEvent(QMouseEvent* e)
 
     if (_imp->_state == eEventStateNone) {
         // nothing else to do
-        QGLWidget::mouseMoveEvent(e);
+        QOpenGLWidget::mouseMoveEvent(e);
 
         return;
     }
@@ -1364,7 +1376,7 @@ CurveWidget::mouseMoveEvent(QMouseEvent* e)
     if (mustUpdate) {
         update();
     }
-    QGLWidget::mouseMoveEvent(e);
+    QOpenGLWidget::mouseMoveEvent(e);
 } // mouseMoveEvent
 
 void
@@ -1622,7 +1634,7 @@ CurveWidget::keyPressEvent(QKeyEvent* e)
         if (ce) {
             ce->handleUnCaughtKeyPressEvent(e);
         }
-        QGLWidget::keyPressEvent(e);
+        QOpenGLWidget::keyPressEvent(e);
     }
 } // keyPressEvent
 
@@ -1630,7 +1642,7 @@ void
 CurveWidget::enterEvent(QEvent* e)
 {
     setFocus();
-    QGLWidget::enterEvent(e);
+    QOpenGLWidget::enterEvent(e);
 }
 
 void
@@ -2128,7 +2140,7 @@ CurveWidget::onUpdateOnPenUpActionTriggered()
 void
 CurveWidget::focusInEvent(QFocusEvent* e)
 {
-    QGLWidget::focusInEvent(e);
+    QOpenGLWidget::focusInEvent(e);
 }
 
 void

--- a/Gui/CurveWidget.h
+++ b/Gui/CurveWidget.h
@@ -39,13 +39,18 @@
 
 CLANG_DIAG_OFF(deprecated)
 CLANG_DIAG_OFF(uninitialized)
-#include <QtOpenGL/QGLWidget>
 #include <QtCore/QMetaType>
 #include <QtCore/QSize>
 #include <QDialog>
 #include <QtCore/QByteArray>
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QOpenGLWidget>
+#else
+#include "Gui/QGLWidgetCompat.h"
+#endif
 
 #include "Global/GlobalDefines.h"
 
@@ -60,7 +65,7 @@ NATRON_NAMESPACE_ENTER
 class CurveWidgetPrivate;
 
 class CurveWidget
-    : public QGLWidget, public OverlaySupport
+    : public QOpenGLWidget, public OverlaySupport
 {
     friend class CurveGui;
     friend class CurveWidgetPrivate;
@@ -76,7 +81,7 @@ public:
                 CurveSelection* selection,
                 TimeLinePtr timeline = TimeLinePtr(),
                 QWidget* parent = NULL,
-                const QGLWidget* shareWidget = NULL);
+                const QOpenGLWidget* shareWidget = NULL);
 
     virtual ~CurveWidget() OVERRIDE;
 

--- a/Gui/CurveWidgetPrivate.cpp
+++ b/Gui/CurveWidgetPrivate.cpp
@@ -51,6 +51,10 @@
 #include "Gui/Menu.h"
 #include "Gui/ticks.h"
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QOpenGLContext>
+#endif
+
 #define CLICK_DISTANCE_FROM_CURVE_ACCEPTANCE 5 //maximum distance from a curve that accepts a mouse click
 // (in widget pixels)
 #define CURSOR_WIDTH 15
@@ -289,7 +293,7 @@ CurveWidgetPrivate::drawSelectionRectangle(double screenPixelRatio)
 {
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );
-    assert( QGLContext::currentContext() == _widget->context() );
+    assert( QOpenGLContext::currentContext() == _widget->context() );
     {
         GLProtectAttrib a(GL_HINT_BIT | GL_ENABLE_BIT | GL_LINE_BIT | GL_COLOR_BUFFER_BIT | GL_CURRENT_BIT);
 
@@ -363,7 +367,7 @@ CurveWidgetPrivate::drawTimelineMarkers(double screenPixelRatio)
 {
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );
-    assert( QGLContext::currentContext() == _widget->context() );
+    assert( QOpenGLContext::currentContext() == _widget->context() );
     glCheckError();
 
     refreshTimelinePositions();
@@ -426,7 +430,7 @@ CurveWidgetPrivate::drawCurves(double screenPixelRatio)
 {
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );
-    assert( QGLContext::currentContext() == _widget->context() );
+    assert( QOpenGLContext::currentContext() == _widget->context() );
 
     //now draw each curve
     std::vector<CurveGuiPtr> visibleCurves;
@@ -444,7 +448,7 @@ CurveWidgetPrivate::drawScale(double screenPixelRatio)
     glCheckError();
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );
-    assert( QGLContext::currentContext() == _widget->context() );
+    assert( QOpenGLContext::currentContext() == _widget->context() );
 
     QPointF btmLeft = zoomCtx.toZoomCoordinates(0, _widget->height() - 1);
     QPointF topRight = zoomCtx.toZoomCoordinates(_widget->width() - 1, 0);
@@ -568,7 +572,7 @@ CurveWidgetPrivate::drawSelectedKeyFramesBbox(double screenPixelRatio)
 {
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );
-    assert( QGLContext::currentContext() == _widget->context() );
+    assert( QOpenGLContext::currentContext() == _widget->context() );
 
     {
         GLProtectAttrib a(GL_HINT_BIT | GL_ENABLE_BIT | GL_LINE_BIT | GL_COLOR_BUFFER_BIT | GL_CURRENT_BIT);

--- a/Gui/CustomParamInteract.cpp
+++ b/Gui/CustomParamInteract.cpp
@@ -47,6 +47,10 @@
 #include "Engine/AppInstance.h"
 #include "Engine/TimeLine.h"
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QOpenGLContext>
+#endif
+
 
 NATRON_NAMESPACE_ENTER
 
@@ -85,7 +89,7 @@ CustomParamInteract::CustomParamInteract(const KnobGuiPtr& knob,
                                          void* ofxParamHandle,
                                          const OfxParamOverlayInteractPtr & entryPoint,
                                          QWidget* parent)
-    : QGLWidget(parent)
+    : QOpenGLWidget(parent)
     , _imp( new CustomParamInteractPrivate(knob, ofxParamHandle, entryPoint) )
 {
     double minW, minH;
@@ -103,7 +107,7 @@ CustomParamInteract::paintGL()
 {
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );
-    assert( QGLContext::currentContext() == context() );
+    assert( QOpenGLContext::currentContext() == context() );
 
     if ( !appPTR->isOpenGLLoaded() ) {
         return;
@@ -149,7 +153,7 @@ CustomParamInteract::resizeGL(int w,
 {
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );
-    assert( QGLContext::currentContext() == context() );
+    assert( QOpenGLContext::currentContext() == context() );
 
     if ( !appPTR->isOpenGLLoaded() ) {
         return;
@@ -171,7 +175,11 @@ CustomParamInteract::sizeHint() const
 void
 CustomParamInteract::swapOpenGLBuffers()
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    update();
+#else
     swapBuffers();
+#endif
 }
 
 void
@@ -201,7 +209,7 @@ double
 CustomParamInteract::getScreenPixelRatio() const
 {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-    return windowHandle()->devicePixelRatio();
+    return devicePixelRatio();
 #else
     KnobGuiPtr k = _imp->knob.lock();
     return (k && k->getGui()) ? k->getGui()->devicePixelRatio() : 1.;

--- a/Gui/CustomParamInteract.h
+++ b/Gui/CustomParamInteract.h
@@ -36,11 +36,11 @@
 #include "Global/GLIncludes.h" //!<must be included before QGlWidget because of gl.h and glew.h
 #include "Global/GlobalDefines.h"
 
-CLANG_DIAG_OFF(deprecated)
-CLANG_DIAG_OFF(uninitialized)
-#include <QGLWidget>
-CLANG_DIAG_ON(deprecated)
-CLANG_DIAG_ON(uninitialized)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QOpenGLWidget>
+#else
+#include "Gui/QGLWidgetCompat.h"
+#endif
 
 #include "Engine/OverlaySupport.h"
 
@@ -50,7 +50,7 @@ NATRON_NAMESPACE_ENTER
 
 struct CustomParamInteractPrivate;
 class CustomParamInteract
-    : public QGLWidget, public OverlaySupport
+    : public QOpenGLWidget, public OverlaySupport
 {
 public:
     CustomParamInteract(const KnobGuiPtr& knob,

--- a/Gui/DopeSheetView.cpp
+++ b/Gui/DopeSheetView.cpp
@@ -76,6 +76,10 @@
 #include "Gui/ZoomContext.h"
 #include "Gui/TabWidget.h"
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QOpenGLContext>
+#endif
+
 #define NATRON_DOPESHEET_MIN_RANGE_FIT 10
 
 NATRON_NAMESPACE_ENTER
@@ -110,14 +114,14 @@ running_in_main_thread()
 }
 
 void
-running_in_main_context(const QGLWidget *glWidget)
+running_in_main_context(const QOpenGLWidget *glWidget)
 {
-    assert( glWidget->context() == QGLContext::currentContext() );
+    assert( glWidget->context() == QOpenGLContext::currentContext() );
     Q_UNUSED(glWidget);
 }
 
 void
-running_in_main_thread_and_context(const QGLWidget *glWidget)
+running_in_main_thread_and_context(const QOpenGLWidget *glWidget)
 {
     running_in_main_thread();
     running_in_main_context(glWidget);
@@ -809,7 +813,10 @@ DopeSheetViewPrivate::generateKeyframeTextures()
         if (std::max( kfTexturesImages[i].width(), kfTexturesImages[i].height() ) != KF_PIXMAP_SIZE) {
             kfTexturesImages[i] = kfTexturesImages[i].scaled(KF_PIXMAP_SIZE, KF_PIXMAP_SIZE, Qt::KeepAspectRatio, Qt::SmoothTransformation);
         }
-        kfTexturesImages[i] = QGLWidget::convertToGLFormat(kfTexturesImages[i]);
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 4, 0)
+        kfTexturesImages[i] = QOpenGLWidget::convertToGLFormat(kfTexturesImages[i]);
+#endif
         glBindTexture(GL_TEXTURE_2D, kfTexturesIDs[i]);
 
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
@@ -2562,7 +2569,7 @@ DopeSheetView::DopeSheetView(DopeSheet *model,
                              Gui *gui,
                              const TimeLinePtr &timeline,
                              QWidget *parent)
-    : QGLWidget(parent)
+    : QOpenGLWidget(parent)
     , _imp( new DopeSheetViewPrivate(this) )
 {
     _imp->model = model;
@@ -2683,7 +2690,12 @@ DopeSheetView::swapOpenGLBuffers()
 {
     running_in_main_thread();
 
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    update();
+#else
     swapBuffers();
+#endif
 }
 
 /**
@@ -2734,7 +2746,7 @@ double
 DopeSheetView::getScreenPixelRatio() const
 {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-    return windowHandle()->devicePixelRatio();
+    return devicePixelRatio();
 #else
     return _imp->gui ? _imp->gui->devicePixelRatio() : 1.;
 #endif
@@ -3707,7 +3719,7 @@ DopeSheetView::wheelEvent(QWheelEvent *e)
 void
 DopeSheetView::focusInEvent(QFocusEvent *e)
 {
-    QGLWidget::focusInEvent(e);
+    QOpenGLWidget::focusInEvent(e);
 }
 
 NATRON_NAMESPACE_EXIT

--- a/Gui/DopeSheetView.h
+++ b/Gui/DopeSheetView.h
@@ -36,18 +36,13 @@
 #include "Global/GLIncludes.h" //!<must be included before QGlWidget because of gl.h and glew.h
 #include "Global/GlobalDefines.h"
 
-CLANG_DIAG_OFF(deprecated)
-CLANG_DIAG_OFF(uninitialized)
+#include <QTreeWidget>
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-#include <QtWidgets/QTreeWidget>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QOpenGLWidget>
 #else
-#include <QtGui/QTreeWidget>
+#include "Gui/QGLWidgetCompat.h"
 #endif
-
-#include <QtOpenGL/QGLWidget>
-CLANG_DIAG_ON(deprecated)
-CLANG_DIAG_ON(uninitialized)
 
 #include "Engine/OverlaySupport.h"
 #include "Engine/ViewIdx.h"
@@ -81,7 +76,7 @@ class DopeSheetViewPrivate;
  * /!\ This class should depends less of the hierarchy view.
  */
 class DopeSheetView
-    : public QGLWidget, public OverlaySupport
+    : public QOpenGLWidget, public OverlaySupport
 {
 GCC_DIAG_SUGGEST_OVERRIDE_OFF
     Q_OBJECT

--- a/Gui/Gui.pro
+++ b/Gui/Gui.pro
@@ -25,7 +25,7 @@ CONFIG += boost opengl qt cairo python shiboken pyside
 QT += gui core network
 
 greaterThan(QT_MAJOR_VERSION, 4) {
-    QT += concurrent
+    QT += concurrent widgets
 } else {
     QT += opengl
 }

--- a/Gui/Gui.pro
+++ b/Gui/Gui.pro
@@ -22,8 +22,13 @@ TEMPLATE = lib
 CONFIG += staticlib
 CONFIG += moc rcc
 CONFIG += boost opengl qt cairo python shiboken pyside 
-QT += gui core opengl network
-greaterThan(QT_MAJOR_VERSION, 4): QT += concurrent
+QT += gui core network
+
+greaterThan(QT_MAJOR_VERSION, 4) {
+    QT += concurrent
+} else {
+    QT += opengl
+}
 
 GUI_WRAPPER_DIR = Qt$${QT_MAJOR_VERSION}/NatronGui
 ENGINE_WRAPPER_DIR = Qt$${QT_MAJOR_VERSION}/NatronEngine

--- a/Gui/GuiFwd.h
+++ b/Gui/GuiFwd.h
@@ -49,7 +49,6 @@ class QFont;
 class QFontComboBox;
 class QFontMetrics;
 class QFrame;
-class QOpenGLShaderProgram;
 class QGraphicsLineItem;
 class QGraphicsPolygonItem;
 class QGraphicsScene;
@@ -94,6 +93,10 @@ class QVBoxLayout;
 class QWheelEvent;
 class QWidget;
 typedef boost::shared_ptr<QUndoStack> QUndoStackPtr;
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+class QOpenGLShaderProgram;
+#endif
 
 // Natron Gui
 NATRON_NAMESPACE_ENTER

--- a/Gui/GuiFwd.h
+++ b/Gui/GuiFwd.h
@@ -49,7 +49,7 @@ class QFont;
 class QFontComboBox;
 class QFontMetrics;
 class QFrame;
-class QGLShaderProgram;
+class QOpenGLShaderProgram;
 class QGraphicsLineItem;
 class QGraphicsPolygonItem;
 class QGraphicsScene;

--- a/Gui/Histogram.h
+++ b/Gui/Histogram.h
@@ -35,12 +35,15 @@
 
 #include "Global/GLIncludes.h" //!<must be included before QGlWidget because of gl.h and glew.h
 
-CLANG_DIAG_OFF(deprecated)
 CLANG_DIAG_OFF(uninitialized)
 #include <QtCore/QSize>
-#include <QtOpenGL/QGLWidget>
-CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QOpenGLWidget>
+#else
+#include "Gui/QGLWidgetCompat.h"
+#endif
 
 #include "Gui/PanelWidget.h"
 #include "Gui/GuiFwd.h"
@@ -52,7 +55,7 @@ NATRON_NAMESPACE_ENTER
  **/
 struct HistogramPrivate;
 class Histogram
-    : public QGLWidget
+    : public QOpenGLWidget
       , public PanelWidget
 {
 GCC_DIAG_SUGGEST_OVERRIDE_OFF
@@ -72,7 +75,7 @@ public:
     };
 
     Histogram(Gui* gui,
-              const QGLWidget* shareWidget = NULL);
+              const QOpenGLWidget* shareWidget = NULL);
 
     virtual ~Histogram();
 

--- a/Gui/HostOverlay.cpp
+++ b/Gui/HostOverlay.cpp
@@ -49,15 +49,18 @@
 #include "Global/KeySymbols.h"
 
 #include "Global/GLIncludes.h" //!<must be included before QGlWidget because of gl.h and glew.h
-CLANG_DIAG_OFF(deprecated)
-#include <QtOpenGL/QGLWidget>
-CLANG_DIAG_ON(deprecated)
 #include <QtCore/QDebug>
 #include <QtCore/QPointF>
 #include <QtCore/QThread>
 #include <QFont>
 #include <QColor>
 #include <QApplication>
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QOpenGLWidget>
+#else
+#include "Gui/QGLWidgetCompat.h"
+#endif
 
 
 #ifndef M_PI

--- a/Gui/QGLExtrasCompat.h
+++ b/Gui/QGLExtrasCompat.h
@@ -1,0 +1,30 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * This file is part of Natron <https://natrongithub.github.io/>,
+ * (C) 2018-2022 The Natron developers
+ * (C) 2013-2018 INRIA and Alexandre Gauthier-Foichat
+ *
+ * Natron is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Natron is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Natron.  If not, see <http://www.gnu.org/licenses/gpl-2.0.html>
+ * ***** END LICENSE BLOCK ***** */
+
+#ifndef NATRON_GUI_QGLEXTRASCOMPAT_H
+#define NATRON_GUI_QGLEXTRASCOMPAT_H
+
+#include <QGLShaderProgram>
+#include <QGLShader>
+
+typedef QGLShaderProgram QOpenGLShaderProgram;
+typedef QSharedPointer<QGLShaderProgram> QOpenGLShaderProgramPtr;
+typedef QGLShader QOpenGLShader;
+
+#endif // NATRON_GUI_QGLEXTRASCOMPAT_H

--- a/Gui/QGLExtrasCompat.h
+++ b/Gui/QGLExtrasCompat.h
@@ -17,11 +17,23 @@
  * along with Natron.  If not, see <http://www.gnu.org/licenses/gpl-2.0.html>
  * ***** END LICENSE BLOCK ***** */
 
+// This is a header that provides type declarations that map a subset of the newer QOpenGL
+// classes used by Natron with their older QGL counterparts
+
 #ifndef NATRON_GUI_QGLEXTRASCOMPAT_H
 #define NATRON_GUI_QGLEXTRASCOMPAT_H
 
-#include <QGLShaderProgram>
-#include <QGLShader>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#error "This file must not be included while using Qt >= 5.4.0"
+#endif
+
+#include "Global/Macros.h"
+
+// QGL was deprecated in macOS
+CLANG_DIAG_OFF(deprecated)
+#include <QtOpenGL/QGLShaderProgram>
+#include <QtOpenGL/QGLShader>
+CLANG_DIAG_ON(deprecated)
 
 typedef QGLShaderProgram QOpenGLShaderProgram;
 typedef QSharedPointer<QGLShaderProgram> QOpenGLShaderProgramPtr;

--- a/Gui/QGLWidgetCompat.h
+++ b/Gui/QGLWidgetCompat.h
@@ -17,10 +17,21 @@
  * along with Natron.  If not, see <http://www.gnu.org/licenses/gpl-2.0.html>
  * ***** END LICENSE BLOCK ***** */
 
+// This is a header that provides type declarations that map a subset of the newer QOpenGL
+// classes used by Natron with their older QGL counterparts
+
 #ifndef NATRON_GUI_QGLWIDGETCOMPAT_H
 #define NATRON_GUI_QGLWIDGETCOMPAT_H
 
-#include <QGLWidget>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#error "This file must not be included while using Qt >= 5.4.0"
+#endif
+
+#include "Global/Macros.h"
+
+CLANG_DIAG_OFF(deprecated)
+#include <QtOpenGL/QGLWidget>
+CLANG_DIAG_ON(deprecated)
 
 typedef QGLWidget QOpenGLWidget;
 typedef QGLContext QOpenGLContext;

--- a/Gui/QGLWidgetCompat.h
+++ b/Gui/QGLWidgetCompat.h
@@ -1,0 +1,28 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * This file is part of Natron <https://natrongithub.github.io/>,
+ * (C) 2018-2022 The Natron developers
+ * (C) 2013-2018 INRIA and Alexandre Gauthier-Foichat
+ *
+ * Natron is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Natron is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Natron.  If not, see <http://www.gnu.org/licenses/gpl-2.0.html>
+ * ***** END LICENSE BLOCK ***** */
+
+#ifndef NATRON_GUI_QGLWIDGETCOMPAT_H
+#define NATRON_GUI_QGLWIDGETCOMPAT_H
+
+#include <QGLWidget>
+
+typedef QGLWidget QOpenGLWidget;
+typedef QGLContext QOpenGLContext;
+
+#endif // NATRON_GUI_QGLWIDGETCOMPAT_H

--- a/Gui/TextRenderer.cpp
+++ b/Gui/TextRenderer.cpp
@@ -345,19 +345,15 @@ TextRenderer::renderText(float x,
             }
             glCheckError();
 #if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
-            glBegin(GL_TRIANGLES);
+            glBegin(GL_QUADS);
             glTexCoord2f(c->xTexCoords[0], c->yTexCoords[1]);
             glVertex2f(0, 0);
             glTexCoord2f(c->xTexCoords[1], c->yTexCoords[1]);
             glVertex2f(c->w * scalex, 0);
             glTexCoord2f(c->xTexCoords[1], c->yTexCoords[0]);
             glVertex2f(c->w * scalex, c->h * scaley);
-            glTexCoord2f(c->xTexCoords[1], c->yTexCoords[0]);
-            glVertex2f(c->w * scalex, c->h * scaley);
             glTexCoord2f(c->xTexCoords[0], c->yTexCoords[0]);
             glVertex2f(0, c->h * scaley);
-            glTexCoord2f(c->xTexCoords[0], c->yTexCoords[1]);
-            glVertex2f(0, 0);
 #else
             glBegin(GL_QUADS);
             glTexCoord2f(c->xTexCoords[0], c->yTexCoords[0]);

--- a/Gui/TextRenderer.cpp
+++ b/Gui/TextRenderer.cpp
@@ -39,9 +39,13 @@ CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
 #include "Global/GLIncludes.h" //!<must be included before QGlWidget because of gl.h and glew.h
-CLANG_DIAG_OFF(deprecated)
-#include <QtOpenGL/QGLWidget>
-CLANG_DIAG_ON(deprecated)
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QPainter>
+#include <QOpenGLWidget>
+#else
+#include "Gui/QGLWidgetCompat.h"
+#endif
 
 NATRON_NAMESPACE_ENTER
 
@@ -148,7 +152,9 @@ TextRendererPrivate::newTransparentTexture()
 
     QImage image(TEXTURE_SIZE, TEXTURE_SIZE, QImage::Format_ARGB32);
     image.fill(Qt::transparent);
-    image = QGLWidget::convertToGLFormat(image);
+#if QT_VERSION < QT_VERSION_CHECK(5, 4, 0)
+    image = QOpenGLWidget::convertToGLFormat(image);
+#endif
     glTexImage2D( GL_TEXTURE_2D, 0, GL_RGBA8, TEXTURE_SIZE, TEXTURE_SIZE,
                   0, GL_RGBA, GL_UNSIGNED_BYTE, image.bits() );
 
@@ -196,7 +202,9 @@ TextRendererPrivate::createCharacter(QChar c)
 
 
     // fill the texture with the QImage
-    image = QGLWidget::convertToGLFormat(image);
+#if QT_VERSION < QT_VERSION_CHECK(5, 4, 0)
+    image = QOpenGLWidget::convertToGLFormat(image);
+#endif
     glCheckError();
 
     GLuint savedTexture;
@@ -278,7 +286,7 @@ TextRenderer::renderText(float x,
     TextRendererPrivatePtr p;
     FontRenderers::iterator it = _imp->renderers.find(font);
     if ( it != _imp->renderers.end() ) {
-        p  = (*it).second;
+        p = it->second;
     } else {
         p = TextRendererPrivatePtr( new TextRendererPrivate(font) );
         _imp->renderers[font] = p;
@@ -336,6 +344,21 @@ TextRenderer::renderText(float x,
                 assert( glIsTexture(texture) );
             }
             glCheckError();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+            glBegin(GL_TRIANGLES);
+            glTexCoord2f(c->xTexCoords[0], c->yTexCoords[1]);
+            glVertex2f(0, 0);
+            glTexCoord2f(c->xTexCoords[1], c->yTexCoords[1]);
+            glVertex2f(c->w * scalex, 0);
+            glTexCoord2f(c->xTexCoords[1], c->yTexCoords[0]);
+            glVertex2f(c->w * scalex, c->h * scaley);
+            glTexCoord2f(c->xTexCoords[1], c->yTexCoords[0]);
+            glVertex2f(c->w * scalex, c->h * scaley);
+            glTexCoord2f(c->xTexCoords[0], c->yTexCoords[0]);
+            glVertex2f(0, c->h * scaley);
+            glTexCoord2f(c->xTexCoords[0], c->yTexCoords[1]);
+            glVertex2f(0, 0);
+#else
             glBegin(GL_QUADS);
             glTexCoord2f(c->xTexCoords[0], c->yTexCoords[0]);
             glVertex2f(0, 0);
@@ -345,6 +368,7 @@ TextRenderer::renderText(float x,
             glVertex2f(c->w * scalex, c->h * scaley);
             glTexCoord2f(c->xTexCoords[0], c->yTexCoords[1]);
             glVertex2f(0, c->h * scaley);
+#endif
             glEnd();
             glCheckErrorIgnoreOSXBug();
             glTranslatef(c->w * scalex, 0, 0);

--- a/Gui/TimeLineGui.cpp
+++ b/Gui/TimeLineGui.cpp
@@ -62,6 +62,10 @@ GCC_DIAG_UNUSED_PRIVATE_FIELD_ON
 #include "Gui/ViewerTab.h"
 #include "Gui/ticks.h"
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QOpenGLContext>
+#endif
+
 NATRON_NAMESPACE_ENTER
 
 #define TICK_HEIGHT 7
@@ -235,7 +239,7 @@ TimeLineGui::TimeLineGui(ViewerInstance* viewer,
                          TimeLinePtr timeline,
                          Gui* gui,
                          ViewerTab* viewerTab)
-    : QGLWidget(viewerTab)
+    : QOpenGLWidget(viewerTab)
     , _imp( new TimelineGuiPrivate(this, viewer, gui, viewerTab) )
 {
     setTimeline(timeline);
@@ -856,7 +860,7 @@ TimeLineGui::renderText(double x,
                         const QFont & font,
                         int flags) const
 {
-    assert( QGLContext::currentContext() == context() );
+    assert( QOpenGLContext::currentContext() == context() );
 
     glCheckError();
     if ( text.isEmpty() ) {
@@ -1017,7 +1021,7 @@ TimeLineGui::enterEvent(QEvent* e)
 {
     _imp->alphaCursor = true;
     update();
-    QGLWidget::enterEvent(e);
+    QOpenGLWidget::enterEvent(e);
 }
 
 void
@@ -1025,7 +1029,7 @@ TimeLineGui::leaveEvent(QEvent* e)
 {
     _imp->alphaCursor = false;
     update();
-    QGLWidget::leaveEvent(e);
+    QOpenGLWidget::leaveEvent(e);
 }
 
 void
@@ -1083,7 +1087,7 @@ TimeLineGui::mouseReleaseEvent(QMouseEvent* e)
     }
 
     _imp->state = eTimelineStateIdle;
-    QGLWidget::mouseReleaseEvent(e);
+    QOpenGLWidget::mouseReleaseEvent(e);
 } // TimeLineGui::mouseReleaseEvent
 
 void

--- a/Gui/TimeLineGui.h
+++ b/Gui/TimeLineGui.h
@@ -38,12 +38,17 @@
 CLANG_DIAG_OFF(deprecated)
 CLANG_DIAG_OFF(uninitialized)
 #include "Global/GLIncludes.h" //!<must be included before QGlWidget because of gl.h and glew.h
-#include <QtOpenGL/QGLWidget>
 #include <QtCore/QList>
 #include <QtCore/QPointF>
 #include <QtCore/QSize>
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QOpenGLWidget>
+#else
+#include "Gui/QGLWidgetCompat.h"
+#endif
 
 #include "Global/GlobalDefines.h"
 
@@ -54,7 +59,7 @@ NATRON_NAMESPACE_ENTER
 struct TimelineGuiPrivate;
 
 class TimeLineGui
-    : public QGLWidget
+    : public QOpenGLWidget
 {
 GCC_DIAG_SUGGEST_OVERRIDE_OFF
     Q_OBJECT

--- a/Gui/ViewerGL.cpp
+++ b/Gui/ViewerGL.cpp
@@ -3632,6 +3632,7 @@ ViewerGL::swapOpenGLBuffers()
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );
 #if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    // calls glSwapBuffers in the widget stack as described in https://doc.qt.io/qt-5/qopenglwidget.html#threading
     update();
 #else
     swapBuffers();

--- a/Gui/ViewerGL.h
+++ b/Gui/ViewerGL.h
@@ -37,11 +37,12 @@
 #include "Global/GLIncludes.h" //!<must be included before QGlWidget because of gl.h and glew.h
 
 #include <QtCore/QSize>
-CLANG_DIAG_OFF(deprecated)
-CLANG_DIAG_OFF(uninitialized)
-#include <QtOpenGL/QGLWidget>
-CLANG_DIAG_ON(deprecated)
-CLANG_DIAG_ON(uninitialized)
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QOpenGLWidget>
+#else
+#include "Gui/QGLWidgetCompat.h"
+#endif
 
 #include "Engine/OpenGLViewerI.h"
 #include "Engine/ViewIdx.h"
@@ -58,7 +59,7 @@ NATRON_NAMESPACE_ENTER
  * OpenGL related code as well as user events.
  **/
 class ViewerGL
-    : public QGLWidget, public OpenGLViewerI
+    : public QOpenGLWidget, public OpenGLViewerI
 {
 GCC_DIAG_SUGGEST_OVERRIDE_OFF
     Q_OBJECT
@@ -72,7 +73,7 @@ public:
        can pass a pointer to the 1st viewer you created. It allows the viewers to share the same OpenGL context.
      */
     explicit ViewerGL(ViewerTab* parent,
-                      const QGLWidget* shareWidget = NULL);
+                      const QOpenGLWidget* shareWidget = NULL);
 
 
     virtual ~ViewerGL() OVERRIDE;
@@ -107,7 +108,7 @@ public:
 
     /**
      *@brief Hack to allow the resizeEvent to be publicly used elsewhere.
-     * It calls QGLWidget::resizeEvent(QResizeEvent*).
+     * It calls QOpenGLWidget::resizeEvent(QResizeEvent*).
      **/
     virtual void resizeEvent(QResizeEvent* e) OVERRIDE FINAL;
 

--- a/Gui/ViewerGLPrivate.cpp
+++ b/Gui/ViewerGLPrivate.cpp
@@ -33,7 +33,12 @@
 
 #include "Global/GLIncludes.h" //!<must be included before QGlWidget because of gl.h and glew.h
 #include <QApplication> // qApp
-#include <QtOpenGL/QGLShaderProgram>
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QOpenGLShaderProgram>
+#else
+#include "Gui/QGLExtrasCompat.h"
+#endif
 
 #include "Engine/Lut.h" // Color
 #include "Engine/Settings.h"
@@ -43,6 +48,10 @@
 #include "Gui/GuiApplicationManager.h" // appFont
 #include "Gui/Menu.h"
 #include "Gui/ViewerTab.h"
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QOpenGLContext>
+#endif
 
 #ifndef M_PI
 #define M_PI        3.14159265358979323846264338327950288   /* pi             */
@@ -228,7 +237,7 @@ ViewerGL::Implementation::drawRenderingVAO(unsigned int mipMapLevel,
 {
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );
-    assert( QGLContext::currentContext() == _this->context() );
+    assert( QOpenGLContext::currentContext() == _this->context() );
 
     bool useShader = _this->getBitDepth() != eImageBitDepthByte;
 
@@ -472,8 +481,8 @@ ViewerGL::Implementation::initAndCheckGlExtensions()
 {
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );
-    assert( QGLContext::currentContext() == _this->context() );
-    assert( QGLShaderProgram::hasOpenGLShaderPrograms( _this->context() ) );
+    assert( QOpenGLContext::currentContext() == _this->context() );
+    assert( QOpenGLShaderProgram::hasOpenGLShaderPrograms( _this->context() ) );
 
     return true;
 }

--- a/Gui/ViewerGLPrivate.h
+++ b/Gui/ViewerGLPrivate.h
@@ -159,8 +159,8 @@ struct ViewerGL::Implementation
     GLuint iboTriangleStripId; /*!< IBOs holding vertices indexes for triangle strip sets*/
     TextureInfo displayTextures[2]; /*!< A pointer to the textures that would be used if A and B are displayed*/
     std::vector<TextureInfo> partialUpdateTextures; /*!< Pointer to the partial rectangle textures overlayed onto the displayed texture when tracking*/
-    boost::scoped_ptr<QGLShaderProgram> shaderRGB; /*!< The shader program used to render RGB data*/
-    boost::scoped_ptr<QGLShaderProgram> shaderBlack; /*!< The shader program used when the viewer is disconnected.*/
+    boost::scoped_ptr<QOpenGLShaderProgram> shaderRGB; /*!< The shader program used to render RGB data*/
+    boost::scoped_ptr<QOpenGLShaderProgram> shaderBlack; /*!< The shader program used when the viewer is disconnected.*/
     bool shaderLoaded; /*!< Flag to check whether the shaders have already been loaded.*/
     InfoViewerWidget* infoViewer[2]; /*!< Pointer to the info bar below the viewer holding pixel/mouse/format related info*/
     ViewerTab* const viewerTab; /*!< Pointer to the viewer tab GUI*/

--- a/Gui/ViewerGLPrivate.h
+++ b/Gui/ViewerGLPrivate.h
@@ -42,6 +42,10 @@ CLANG_DIAG_ON(uninitialized)
 #include "Gui/ZoomContext.h"
 #include "Gui/GuiFwd.h"
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 4, 0)
+#include "Gui/QGLExtrasCompat.h"
+#endif
+
 
 #define WIPE_MIX_HANDLE_LENGTH 50.
 #define WIPE_ROTATE_HANDLE_LENGTH 100.


### PR DESCRIPTION
## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)

**What does this pull request do?**

Given that the Qt OpenGL module was [deprecated in Qt 5.4.0](https://doc.qt.io/qt-5/qtopengl-index.html), removed in Qt 6 and most importantly was not functioning under a Wayland session (e.g. alpha output in KDE KWin or corrupted images in Sway), I've replaced its usage with the newer [OpenGL integration from Qt Gui](https://doc.qt.io/qt-5/qtgui-index.html#opengl-and-opengl-es-integration) and used both type definitions plus preprocessor conditionals for backwards compatibility with Qt 4.

**Show a few screenshots (if this is a visual change)**

![2022-01-30_19-37](https://user-images.githubusercontent.com/39890836/151720983-4ed215c3-af7b-4250-9bc5-4d6ce5b0eec7.png)

**Have you tested your changes (if applicable)? If so, how?**

By building Natron and using the viewer, the dope sheet editor, the curve editor and the histogram.

**Futher details of this pull request**

Will post support for Wayland offscreen (`OSGLContext`) soon.
