### PR TITLE
Enable OpenGL rendering by default in Engine

### DIFF
--- a/Engine/Settings.cpp
+++ b/Engine/Settings.cpp
@@ -1493,7 +1493,7 @@ Settings::setDefaultValues()
 #if NATRON_VERSION_MAJOR < 2 || (NATRON_VERSION_MAJOR == 2 && NATRON_VERSION_MINOR < 2)
     _enableOpenGL->setDefaultValue((int)eEnableOpenGLDisabled);
 #else
-    _enableOpenGL->setDefaultValue((int)eEnableOpenGLDisabledIfBackground);
+    _enableOpenGL->setDefaultValue((int)eEnableOpenGLEnabled);
 #endif
 
     // General/Projects setup


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Breaking change (fix or feature that would cause existing functionality to change)

**What does this pull request do?**

Currently Natron by default disables GPU rendering if running in background, i.e. NatronRenderer, this results in effects not being able to use it and in cases that OpenGL is required the plugin may throw an exception or crash (see [this issue comment](https://github.com/NatronGitHub/Natron/issues/779#issuecomment-1147568655) for more details).
A way to fix this is to enable it by default so environments that load OpenGL in a suitable way for Natron can make use of it, even if Natron isn't windowed.
In case there's a much better solution out there then this PR could be superseded by another one.

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

By rendering a project that uses the Shadertoy plugin with both Natron and NatronRenderer.

**Futher details of this pull request**

Attempts to fix #779.
