### PR TITLE
Fix build with python3.6

### DIFF
--- a/global.pri
+++ b/global.pri
@@ -43,8 +43,8 @@ run-without-python {
     CONFIG += python
     python3 {
       PYV=3
-      PY_PKG_SUFFIX=-embed
-      PYTHON_CONFIG_FLAGS=--embed
+      PY_PKG_SUFFIX=
+      PYTHON_CONFIG_FLAGS=
     } else {
       PYV=2
       PY_PKG_SUFFIX=


### PR DESCRIPTION
My python3-config doesn't know the `--embed` option, causing all python-related build variables to be invalid, making `#include <Python.h>` fail. It looks like this option is only present since python 3.8: https://github.com/python/cpython/issues/80902.
Perhaps it would be possible to selectively add `--embed` for python >= 3.8?

The error messages were rather cryptic so it took me quite some time to track this down. Would be nice if something could be done about it on behalf of other users who might run into the same problem.