### PR TITLE
Copy node or group background and overlay color

### DIFF
--- a/Gui/NodeGui.cpp
+++ b/Gui/NodeGui.cpp
@@ -2275,6 +2275,13 @@ NodeGui::restoreInternal(const NodeGuiPtr& thisShared,
 void
 NodeGui::copyFrom(const NodeGuiSerialization & obj)
 {
+    float r, g, b;
+    double overlayR, overlayB, overlayG;
+    obj.getColor(&r, &g, &b);
+    setCurrentColor( QColor::fromRgbF(r, g, b) );
+    if (obj.getOverlayColor(&overlayR, &overlayG, &overlayB)) {
+        setOverlayColor( QColor::fromRgbF(overlayR, overlayB, overlayG) );
+    }
     setPos_mt_safe( QPointF( obj.getX(), obj.getY() ) );
     NodePtr node = getNode();
     assert(node);


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)

**What does this pull request do?**

When nodes are copied these preserve their labels too, plus a suffix, but their colors are not. This PR fixes that for both current and overlay colors.

**Show a few screenshots (if this is a visual change)**

N/A yet.

**Have you tested your changes (if applicable)? If so, how?**

By copying and pasting nodes in the viewer.

**Futher details of this pull request**

Fixes #813.
