### PR TITLE
Fix freeze in Tracker when not in viewer path

### DIFF
--- a/Engine/TrackerNode.cpp
+++ b/Engine/TrackerNode.cpp
@@ -569,6 +569,11 @@ TrackerNode::knobChanged(KnobI* k,
     }
 
     ctx->onKnobsLoaded();
+
+    OverlaySupport* overlay = getCurrentViewportForOverlays();
+    if (!overlay || !overlay->getInternalViewerNode()) {
+        return false;
+    }
     
     bool ret = true;
     if ( k == _imp->ui->trackRangeDialogOkButton.lock().get() ) {
@@ -593,7 +598,6 @@ TrackerNode::knobChanged(KnobI* k,
             return false;
         }
 
-        OverlaySupport* overlay = getCurrentViewportForOverlays();
         ctx->trackSelectedMarkers( startFrame, lastFrame, step,  overlay);
         _imp->ui->trackRangeDialogGroup.lock()->setValue(false);
     } else if ( k == _imp->ui->trackRangeDialogCancelButton.lock().get() ) {


### PR DESCRIPTION
## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)

**What does this pull request do?**

When a tracker node outside of the viewer has one of its button clicked Natron might freeze due to some knobs request a viewport that the node doesn't have because its not connected to any. This PR fixes this by checking if an overlay is available and proceed with the knobs, ignores the action otherwise.

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

By adding a tracker node outside of a viewer path and 

**Futher details of this pull request**

Fixes #299.
