### PR TITLE
Partially revert Shiboken generation in QMake for Python bindings

### DIFF
--- a/Gui/Gui.pro
+++ b/Gui/Gui.pro
@@ -227,6 +227,7 @@ SOURCES += \
     ViewerTabPrivate.cpp \
     ViewerToolButton.cpp \
     ticks.cpp \
+    $${GUI_WRAPPER_DIR}/natrongui_module_wrapper.cpp \
 
 HEADERS += \
     AboutWindow.h \
@@ -383,9 +384,7 @@ HEADERS += \
     ../libs/OpenFX/include/nuke/fnPublicOfxExtensions.h \
     ../libs/OpenFX/include/tuttle/ofxReadWrite.h \
     ../libs/OpenFX_extensions/ofxhParametricParam.h \
-
-GENERATED_SOURCES += $${GUI_WRAPPER_DIR}/natrongui_module_wrapper.cpp
-GENERATED_HEADERS += $${GUI_WRAPPER_DIR}/natrongui_python.h
+    $${GUI_WRAPPER_DIR}/natrongui_python.h \
 
 GUI_GENERATED_SOURCES = \
     guiapp_wrapper \
@@ -396,8 +395,8 @@ GUI_GENERATED_SOURCES = \
     pyviewer_wrapper
 
 for(name, GUI_GENERATED_SOURCES) {
-    GENERATED_SOURCES += $${GUI_WRAPPER_DIR}/$${name}.cpp
-    GENERATED_HEADERS += $${GUI_WRAPPER_DIR}/$${name}.h
+    SOURCES += $${GUI_WRAPPER_DIR}/$${name}.cpp
+    HEADERS += $${GUI_WRAPPER_DIR}/$${name}.h
 }
 
 RESOURCES += \
@@ -420,48 +419,6 @@ OTHER_FILES += \
     Resources/Images/prevUserKey.png \
     Resources/Images/searchSize.png \
     Resources/Images/splashscreen.svg
-
-defineReplace(shibokenGui) {
-    SOURCES += $$GENERATED_SOURCES
-    HEADERS += $$GENERATED_HEADERS
-    return("%_wrapper.cpp")
-}
-
-QT_INCLUDEPATH = $$PYTHON_INCLUDEPATH $$PYSIDE_INCLUDEDIR
-for(dep, QT) {
-    QT_INCLUDEPATH += $$eval(QT.$${dep}.includes)
-    QT_INCLUDEPATH += $$absolute_path($$eval(QT.$${dep}.name), $$PYSIDE_INCLUDEDIR)
-}
-
-equals(QT_MAJOR_VERSION, 5) {
-    PYGUI_HEADER = PySide2_Gui_Python.h
-    POST_SHIBOKEN = bash $$shell_path($$PWD/../tools/utils/runPostShiboken2.sh)
-} else:equals(QT_MAJOR_VERSION, 4) {
-    PYGUI_HEADER = Pyside_Gui_Python.h
-    POST_SHIBOKEN = bash $$shell_path($$PWD/../tools/utils/runPostShiboken.sh)
-}
-
-
-SRC_PATH = $$relative_path($$PWD, $$OUT_PWD)/
-DEP_GROUP = $$PYGUI_HEADER typesystem_natronGui.xml $$HEADERS
-guisbk.input = $$PYGUI_HEADER typesystem_natronGui.xml
-guisbk.depends = $$eval($$list($$join(DEP_GROUP, " "$$SRC_PATH, $$SRC_PATH)))
-guisbk.target = guisbk
-guisbk.commands = cd $$PWD && $$SHIBOKEN \
-    --enable-parent-ctor-heuristic --use-isnull-as-nb_nonzero \
-    --avoid-protected-hack --enable-pyside-extensions \
-    -I.:..:../Global:../Engine:../libs/OpenFX/include:$$PYTHON_SITE_PACKAGES/PySide2/include:$$[QT_INSTALL_PREFIX]/include \
-    $$join(INCLUDEPATH, ":", "-I") \
-    $$join(QT_INCLUDEPATH, ":", "-I") \
-    -T../Engine:$$TYPESYSTEMPATH --output-directory=$$OUT_PWD/Qt$$QT_MAJOR_VERSION \
-    $$PYGUI_HEADER typesystem_natronGui.xml && \
-    $$POST_SHIBOKEN $$OUT_PWD/Qt$$QT_MAJOR_VERSION/NatronGui natrongui
-pygui.depends = guisbk
-pygui.target = $$shell_path($$GUI_WRAPPER_DIR/%_wrapper.cpp)
-pygui.output_function = shibokenGui
-pygui.commands = bash -c 'true'
-
-QMAKE_EXTRA_TARGETS += guisbk pygui
 
 macx {
 HEADERS += TaskBarMac.h

--- a/global.pri
+++ b/global.pri
@@ -33,8 +33,6 @@ DEFINES += OFX_SUPPORTS_DIALOG
 #for QString(const char*) assumes ASCII strings, we may run into troubles
 DEFINES += QT_NO_CAST_FROM_ASCII
 
-greaterThan(QT_MAJOR_VERSION, 4): CONFIG += python3
-
 # To run Natron without Python functionnalities (for debug purposes)
 run-without-python {
     message("Natron will run (not build) without Python")
@@ -404,21 +402,17 @@ win32-g++ {
     cairo:     PKGCONFIG += cairo fontconfig
     equals(QT_MAJOR_VERSION, 5) {
       shiboken:  INCLUDEPATH += $$PYTHON_SITE_PACKAGES/PySide2/include/shiboken2
-      shiboken:  SHIBOKEN = $$system(pkg-config --variable=generator_location shiboken2)
     	pyside:    INCLUDEPATH += $$PYTHON_SITE_PACKAGES/PySide2/include/PySide2
       pyside:    INCLUDEPATH += $$PYTHON_SITE_PACKAGES/PySide2/include/PySide2/QtCore
       pyside:    INCLUDEPATH += $$PYTHON_SITE_PACKAGES/PySide2/include/PySide2/QtGui
       pyside:    INCLUDEPATH += $$PYTHON_SITE_PACKAGES/PySide2/include/PySide2/QtWidgets
-      pyside:    TYPESYSTEMPATH *= $$system(pkg-config --variable=typesystemdir pyside2)
     }
     equals(QT_MAJOR_VERSION, 4) {
       shiboken:  PKGCONFIG += shiboken-py$$PYV
-      shiboken:  SHIBOKEN = $$system(pkg-config --variable=generator_location shiboken)
     	pyside:    PKGCONFIG += pyside-py$$PYV
       PYSIDE_INCLUDEDIR = $$system(pkg-config --variable=includedir pyside-py$$PYV)
    	  pyside:    INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtCore
       pyside:    INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtGui
-      pyside:    TYPESYSTEMPATH *= $$system(pkg-config --variable=typesystemdir pyside)
     }
     python:    PKGCONFIG += python-$$PYVER$$PY_PKG_SUFFIX
     boost:     LIBS += -lboost_serialization-mt
@@ -460,14 +454,12 @@ unix {
     equals(QT_MAJOR_VERSION, 5) {
         system(pkg-config --exists pyside2) {
             shiboken: PKGCONFIG += shiboken2
-            shiboken: SHIBOKEN = $$system(pkg-config --variable=generator_location shiboken2)
             pyside:   PKGCONFIG += pyside2
             # add QtCore to includes
             PYSIDE_INCLUDEDIR = $$system(pkg-config --variable=includedir pyside2)
             pyside:   INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtCore
             pyside:   INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtGui
             pyside:   INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtWidgets
-            pyside:   TYPESYSTEMPATH *= $$system(pkg-config --variable=typesystemdir pyside2)
         }
     }
 
@@ -477,9 +469,7 @@ unix {
          # See for example tools/travis/install_dependencies.sh for a solution that works on Linux,
          # using a custom config.pri
          shiboken: PKGCONFIG += shiboken
-         shiboken: SHIBOKEN = $$system(pkg-config --variable=generator_location shiboken)
          pyside:   PKGCONFIG += pyside
-         pyside:   TYPESYSTEMPATH *= $$system(pkg-config --variable=typesystemdir pyside)
          # The following hack also works with Homebrew if pyside is installed with option --with-python3
          macx {
            QMAKE_LFLAGS += '-Wl,-rpath,\'@loader_path/../Frameworks\''


### PR DESCRIPTION
## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)

**What does this pull request do?**

This PR reverts #803 partially due to the many issues introduced by it, but the install instructions, build configurations and generator cleanup scripts were conserved.

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

N/A yet.

**Futher details of this pull request**

The documentation will be updated to point users out to use the proper build system when using a Qt version.
