### PR TITLE
Engine/CLArgs.cpp: allow dot in writer name

### DIFF
--- a/Engine/CLArgs.cpp
+++ b/Engine/CLArgs.cpp
@@ -1080,7 +1080,7 @@ CLArgsPrivate::parse()
 
 
         //Check that the name is conform to a Python acceptable script name
-        std::string pythonConform = NATRON_PYTHON_NAMESPACE::makeNameScriptFriendly( it->toStdString() );
+        std::string pythonConform = NATRON_PYTHON_NAMESPACE::makeNameScriptFriendlyWithDots( it->toStdString() );
         if (it->toStdString() != pythonConform) {
             std::cout << tr("The name of the Write node specified is not valid: it cannot contain non alpha-numerical "
                             "characters and must not start with a digit.").toStdString() << std::endl;


### PR DESCRIPTION
Allow access to writers in a group, see https://discuss.pixls.us/t/rendering-nested-write-nodes/33225

Tested on Windows 11 (``NatronRenderer project.ntp -w Group1.Write1``).