### PR TITLE
Fix crash when pasting unexistent nodes

### DIFF
--- a/Gui/NodeGraphPrivate10.cpp
+++ b/Gui/NodeGraphPrivate10.cpp
@@ -114,7 +114,9 @@ NodeGraphPrivate::pasteNodesInternal(const NodeClipBoard & clipboard,
                 const std::string& newScriptName = node->getNode()->getScriptName();
                 oldNewScriptNamesMapping[oldScriptName] = newScriptName;
             }
-            assert( internalNodesClipBoard.size() == newNodes->size() );
+            if (newNodes->size() == 0) {
+                return;
+            }
 
             ///Now that all nodes have been duplicated, try to restore nodes connections
             restoreConnections(internalNodesClipBoard, *newNodes, oldNewScriptNamesMapping);


### PR DESCRIPTION
## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)

**What does this pull request do?**

When I was testing a reported issue I stumbled upon a crash after I've tried to paste a group of nodes that used a plugin that was missing in my test installation.
I've took notice that an assertion failed during copying and pasting that led to the crash.

https://github.com/NatronGitHub/Natron/blob/2b94fdcc1293f82413d1293f477d7c8ea926cc56/Gui/NodeGraphPrivate10.cpp#L114-L120

This PR makes that pasting content that may have missing node plugins only paste those which indeed have their plugin.

**Show a few screenshots (if this is a visual change)**

N/A.

**Have you tested your changes (if applicable)? If so, how?**

By pasting a selection of nodes that have some GIMP ones, which by the way is missing in my test install, in it and seeing that only those nodes were not present.

**Futher details of this pull request**

N/A.
