### PR TITLE
Fix for compilers that use C++17 by default.

### DIFF
--- a/Global/MathUtils.h
+++ b/Global/MathUtils.h
@@ -41,7 +41,7 @@ template<class T>
 constexpr const T&
 clamp(const T& v, const T& lo, const T& hi)
 {
-    return clamp(v, lo, hi, std::less<T>{});
+    return MathUtils::clamp(v, lo, hi, std::less<T>{});
 }
 
 } // namespace MathUtils


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Specifying the MathUtils namespace to resolve the ambiguity caused by the addition of std::clamp() in C++17.

This fixes a build error on Windows with a freshly installed MSYS2 where g++ uses c++17 by default.

**Have you tested your changes (if applicable)? If so, how?**

Yes. The code that uses MathUtils::clamp() properly builds after this change.
