### PR TITLE
Fix pthread related build busters in glog code.

### DIFF
--- a/libs/glog/glog-Natron.patch
+++ b/libs/glog/glog-Natron.patch
@@ -1,19 +1,20 @@
 diff -ur /Users/devernay/Development/blender/extern/glog/src/windows/port.h ./src/windows/port.h
 --- /Users/devernay/Development/blender/extern/glog/src/windows/port.h	2016-03-21 18:40:14.000000000 +0100
 +++ ./src/windows/port.h	2016-05-20 11:55:42.000000000 +0200
-@@ -136,17 +136,22 @@
+@@ -136,17 +136,23 @@
  #endif  // _MSC_VER
  
  // ----------------------------------- THREADS
-+#ifndef __MINGW32__ // MingW
++#if defined(HAVE_PTHREAD)
++# include <pthread.h>
++#else // no PTHREAD
  typedef DWORD pthread_t;
  typedef DWORD pthread_key_t;
  typedef LONG pthread_once_t;
  enum { PTHREAD_ONCE_INIT = 0 };   // important that this be 0! for SpinLock
-+#else
  #define pthread_self  GetCurrentThreadId
  #define pthread_equal(pthread_t_1, pthread_t_2)  ((pthread_t_1)==(pthread_t_2))
-+#endif
++#endif // HAVE_PTHREAD
  
 +#ifndef __MINGW32__ // MingW
  inline struct tm* localtime_r(const time_t* timep, struct tm* result) {

--- a/libs/glog/src/windows/port.h
+++ b/libs/glog/src/windows/port.h
@@ -136,15 +136,16 @@ typedef int pid_t;
 #endif  // _MSC_VER
 
 // ----------------------------------- THREADS
-#ifndef __MINGW32__ // MingW
+#if defined(HAVE_PTHREAD)
+# include <pthread.h>
+#else // no PTHREAD
 typedef DWORD pthread_t;
 typedef DWORD pthread_key_t;
 typedef LONG pthread_once_t;
 enum { PTHREAD_ONCE_INIT = 0 };   // important that this be 0! for SpinLock
-#else
 #define pthread_self  GetCurrentThreadId
 #define pthread_equal(pthread_t_1, pthread_t_2)  ((pthread_t_1)==(pthread_t_2))
-#endif
+#endif // HAVE_PTHREAD
 
 #ifndef __MINGW32__ // MingW
 inline struct tm* localtime_r(const time_t* timep, struct tm* result) {


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Fixes port.h to more closely match upstream glog code which also fixes build issues related to pthreads on MSYS2 builds.

The build issues are ultimately caused by different headers in the glog code including different config.h files. Some headers
like libs/glog/src/windows/port.h include the config.h that are in the same directory, but files like libs/glog/src/base/mutex.h
do not have a config.h in the same directory. This causes the compiler to fallback to searching the include paths. When this
happens, the gflags directories are scanned before the glog directories because glog depends on gflags. This results in the
gflags config.h being used sometimes.  The gflag config.h defines HAVE_PTHREADS which in turn causes glogs' mutex.h to include pthread.h. The inclusion of pthread.h then causes issues with the thread related function declarations in port.h. 

Without this change the build fails because we get "multiple definition" errors for the thread related definitions in port.h. This
change fixes this issue by allowing the code to just use the pthread header if HAVE_PTHREADS is defined and fallback on the alternate definitions if it is not. It also causes the code to be a closer match to upstream glog which could facilitate
unforking glog if that ever becomes desirable in the future.

**Have you tested your changes (if applicable)? If so, how?**

Yes. The glog code builds fine on a fresh MSYS2 install with this change.
