### PR TITLE
Clear current GLX context before destroying the current context

### DIFF
--- a/Engine/OSGLContext_x11.cpp
+++ b/Engine/OSGLContext_x11.cpp
@@ -111,6 +111,7 @@ typedef Bool (*PFNGLXQUERYEXTENSIONPROC)(Display*, int*, int*);
 typedef Bool (*PFNGLXQUERYVERSIONPROC)(Display*, int*, int*);
 typedef void (*PFNGLXDESTROYCONTEXTPROC)(Display*, GLXContext);
 typedef Bool (*PFNGLXMAKECURRENTPROC)(Display*, GLXDrawable, GLXContext);
+typedef GLXContext (*PFNGLXGETCURRENTCONTEXTPROC)();
 typedef void (*PFNGLXSWAPBUFFERSPROC)(Display*, GLXDrawable);
 typedef const char* (*PFNGLXQUERYEXTENSIONSSTRINGPROC)(Display*, int);
 typedef GLXFBConfig* (*PFNGLXGETFBCONFIGSPROC)(Display*, int, int*);
@@ -167,6 +168,7 @@ struct OSGLContext_glx_dataPrivate
     PFNGLXQUERYVERSIONPROC QueryVersion;
     PFNGLXDESTROYCONTEXTPROC DestroyContext;
     PFNGLXMAKECURRENTPROC MakeCurrent;
+    PFNGLXGETCURRENTCONTEXTPROC GetCurrentContext;
     PFNGLXSWAPBUFFERSPROC SwapBuffers;
     PFNGLXQUERYEXTENSIONSSTRINGPROC QueryExtensionsString;
     PFNGLXCREATENEWCONTEXTPROC CreateNewContext;
@@ -316,6 +318,7 @@ OSGLContext_x11::initGLXData(OSGLContext_glx_data* glxInfo)
     glxInfo->_imp->QueryVersion = (PFNGLXQUERYVERSIONPROC)dlsym(glxInfo->_imp->handle, "glXQueryVersion");
     glxInfo->_imp->DestroyContext = (PFNGLXDESTROYCONTEXTPROC)dlsym(glxInfo->_imp->handle, "glXDestroyContext");
     glxInfo->_imp->MakeCurrent = (PFNGLXMAKECURRENTPROC)dlsym(glxInfo->_imp->handle, "glXMakeCurrent");
+    glxInfo->_imp->GetCurrentContext = (PFNGLXGETCURRENTCONTEXTPROC)dlsym(glxInfo->_imp->handle, "glXGetCurrentContext");
     glxInfo->_imp->SwapBuffers = (PFNGLXSWAPBUFFERSPROC)dlsym(glxInfo->_imp->handle, "glXSwapBuffers");
     glxInfo->_imp->QueryExtensionsString = (PFNGLXQUERYEXTENSIONSSTRINGPROC)dlsym(glxInfo->_imp->handle, "glXQueryExtensionsString");
     glxInfo->_imp->CreateNewContext = (PFNGLXCREATENEWCONTEXTPROC)dlsym(glxInfo->_imp->handle, "glXCreateNewContext");
@@ -810,6 +813,10 @@ OSGLContext_x11::~OSGLContext_x11()
         _imp->glxWindowHandle = 0;
     }
     if (_imp->glxContextHandle) {
+
+        if (glxInfo->_imp->GetCurrentContext() == _imp->glxContextHandle) {
+            glxInfo->_imp->MakeCurrent(glxInfo->_imp->x11.display, None, NULL);
+        }
         glxInfo->_imp->DestroyContext(glxInfo->_imp->x11.display, _imp->glxContextHandle);
         _imp->glxContextHandle = 0;
     }


### PR DESCRIPTION
- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

On Linux systems using GLX, it clears the current GLX context before destroying the current context, which fixes a crash-on-startup on my system (Arch Linux, Qt 5.15.8, using an NVIDIA GPU with vendor drivers).

**Have you tested your changes (if applicable)? If so, how?**

I only tested it as far as that Natron doesn't crash right away anymore. Since I don't know how to use Natron yet, not having gotten to the point where I can try it before having fixed this, I haven't really performed more testing. Since I found others being affected by the same bug (#863) I wanted to share my potential fix rather sooner than later.

**Futher details of this pull request**

Without this, on my system, Qt somehow ends up using a GLX context that Natron already destroyed, causing a GLXBadContext crash on startup. That much I verified using GDB. I have no idea how Qt ends up using that context at all and how it ends up using it at that point. I assume it just uses the current context and somehow ends up getting a destroyed context when querying the current context, but that's just a guess based on this fix working for me.

I have no clue who of Natron, Qt or NVIDIA's GLX implementation are at really at fault, nor have I tested this beyond verifying that Natron doesn't crash on startup anymore.

