### PR TITLE
Fix OpenGL support handling for plugins with dynamic GL support.

### DIFF
--- a/Engine/EffectInstance.h
+++ b/Engine/EffectInstance.h
@@ -1322,11 +1322,6 @@ public:
         return ePluginOpenGLRenderSupportNone;
     }
 
-    virtual void onEnableOpenGLKnobValueChanged(bool /*activated*/)
-    {
-
-    }
-
     /**
      * @brief If this effect is a writer then the file path corresponding to the output images path will be fed
      * with the content of pattern.

--- a/Engine/Node.cpp
+++ b/Engine/Node.cpp
@@ -5017,18 +5017,7 @@ Node::onEffectKnobValueChanged(KnobI* what,
         ssinfo << "</font>";
         _imp->nodeInfos.lock()->setValue( ssinfo.str() );
     } else if ( what == _imp->openglRenderingEnabledKnob.lock().get() ) {
-        bool enabled = true;
-        int thisKnobIndex = _imp->openglRenderingEnabledKnob.lock()->getValue();
-        if (thisKnobIndex == 1 || (thisKnobIndex == 2 && getApp()->isBackground())) {
-            enabled = false;
-        }
-        if (enabled) {
-            // Check value on project now
-            if (!getApp()->getProject()->isOpenGLRenderActivated()) {
-                enabled = false;
-            }
-        }
-        _imp->effect->onEnableOpenGLKnobValueChanged(enabled);
+         // Do nothing. Knob value will be checked in getCurrentOpenGLRenderSupport() calls.
     } else if (what == _imp->processAllLayersKnob.lock().get() ) {
 
         std::map<int, ChannelSelector>::iterator foundOutput = _imp->channelsSelectors.find(-1);
@@ -5098,23 +5087,14 @@ Node::onEffectKnobValueChanged(KnobI* what,
 void
 Node::onOpenGLEnabledKnobChangedOnProject(bool activated)
 {
-    bool enabled = activated;
     KnobChoicePtr k = _imp->openglRenderingEnabledKnob.lock();
-    if (enabled) {
-        if (k) {
-            k->setAllDimensionsEnabled(true);
-            int thisKnobIndex = k->getValue();
-            if (thisKnobIndex == 1 || (thisKnobIndex == 2 && getApp()->isBackground())) {
-                enabled = false;
-            }
-        }
-    } else {
-        if (k) {
-            k->setAllDimensionsEnabled(true);
-        }
+    if (k) {
+        // Make the enable state for the node knob match the
+        // state of the project level GPU rendering state.
+        // This makes it so you can't change node level GPU
+        // rendering state if the project has GPU rendering disabled.
+        k->setAllDimensionsEnabled(activated);
     }
-    _imp->effect->onEnableOpenGLKnobValueChanged(enabled);
-
 }
 
 bool

--- a/Engine/NodeMain.cpp
+++ b/Engine/NodeMain.cpp
@@ -186,7 +186,7 @@ Node::load(const CreateNodeArgs& args)
        Set modifiable props
      */
     refreshDynamicProperties();
-    onOpenGLEnabledKnobChangedOnProject(getApp()->getProject()->isOpenGLRenderActivated());
+    onOpenGLEnabledKnobChangedOnProject(getApp()->getProject()->isGPURenderingEnabledInProject());
 
     if ( isTrackerNodePlugin() ) {
         _imp->isMultiInstance = true;

--- a/Engine/OfxEffectInstance.cpp
+++ b/Engine/OfxEffectInstance.cpp
@@ -2756,20 +2756,6 @@ OfxEffectInstance::supportsOpenGLRender() const
     }
 }
 
-void
-OfxEffectInstance::onEnableOpenGLKnobValueChanged(bool activated)
-{
-    const Plugin* p = getNode()->getPlugin();
-    if (p->getPluginOpenGLRenderSupport() == ePluginOpenGLRenderSupportYes) {
-        // The property may only change if the plug-in has the property set to yes on the descriptor
-        if (activated) {
-            effectInstance()->getProps().setStringProperty(kOfxImageEffectPropOpenGLRenderSupported, "true");
-        } else {
-            effectInstance()->getProps().setStringProperty(kOfxImageEffectPropOpenGLRenderSupported, "false");
-        }
-    }
-}
-
 bool
 OfxEffectInstance::supportsMultiResolution() const
 {

--- a/Engine/OfxEffectInstance.h
+++ b/Engine/OfxEffectInstance.h
@@ -284,7 +284,6 @@ public:
                                     Transform::Matrix3x3* transform) OVERRIDE FINAL WARN_UNUSED_RETURN;
     virtual bool isHostMaskingEnabled() const OVERRIDE FINAL WARN_UNUSED_RETURN;
     virtual bool isHostMixingEnabled() const OVERRIDE FINAL WARN_UNUSED_RETURN;
-    virtual void onEnableOpenGLKnobValueChanged(bool activated) OVERRIDE FINAL;
 
     /********OVERRIDDEN FROM EFFECT INSTANCE: END*************/
     OfxClipInstance* getClipCorrespondingToInput(int inputNo) const;

--- a/Engine/Project.cpp
+++ b/Engine/Project.cpp
@@ -933,9 +933,7 @@ Project::initializeKnobs()
     _imp->gpuSupport->setAnimationEnabled(false);
     _imp->gpuSupport->setHintToolTip( tr("Select when to activate GPU rendering for plug-ins. Note that if the OpenGL Rendering parameter in the Preferences/GPU Rendering is set to disabled then GPU rendering will not be activated regardless of that value.") );
     _imp->gpuSupport->setEvaluateOnChange(false);
-    if (!appPTR->getCurrentSettings()->isOpenGLRenderingEnabled()) {
-        _imp->gpuSupport->setAllDimensionsEnabled(false);
-    }
+    _imp->gpuSupport->setAllDimensionsEnabled(appPTR->getCurrentSettings()->isOpenGLRenderingEnabled());
     page->addKnob(_imp->gpuSupport);
 
     KnobPagePtr viewsPage = AppManager::createKnob<KnobPage>( this, tr("Views") );
@@ -1208,16 +1206,6 @@ Project::getProjectFormatAtIndex(int index,
     QMutexLocker l(&_imp->formatMutex);
 
     return _imp->findFormat(index, f);
-}
-
-bool
-Project::isOpenGLRenderActivated() const
-{
-    if (!appPTR->getCurrentSettings()->isOpenGLRenderingEnabled()) {
-        return false;
-    }
-    int index =  _imp->gpuSupport->getValue();
-    return index == 0 || (index == 2 && !getApp()->isBackground());
 }
 
 int
@@ -1740,14 +1728,9 @@ Project::onKnobValueChanged(KnobI* knob,
 void
 Project::refreshOpenGLRenderingFlagOnNodes()
 {
-    bool activated = appPTR->getCurrentSettings()->isOpenGLRenderingEnabled();
-    if (!activated) {
-        _imp->gpuSupport->setAllDimensionsEnabled(false);
-    } else {
-        _imp->gpuSupport->setAllDimensionsEnabled(true);
-        int index =  _imp->gpuSupport->getValue();
-        activated = index == 0 || (index == 2 && !getApp()->isBackground());
-    }
+    _imp->gpuSupport->setAllDimensionsEnabled(appPTR->getCurrentSettings()->isOpenGLRenderingEnabled());
+
+    const bool activated = isGPURenderingEnabledInProject();
     NodesList allNodes;
     getNodes_recursive(allNodes, false);
     for (NodesList::iterator it = allNodes.begin(); it!=allNodes.end(); ++it) {

--- a/Engine/Project.h
+++ b/Engine/Project.h
@@ -299,8 +299,6 @@ public:
      **/
     bool quitAnyProcessingForAllNodes(AfterQuitProcessingI* receiver, const GenericWatcherCallerArgsPtr& args);
 
-    bool isOpenGLRenderActivated() const;
-
     void refreshOpenGLRenderingFlagOnNodes();
 
 private:


### PR DESCRIPTION

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

OfxEffectInstance::onEnableOpenGLKnobValueChange() breaks rendering for plugins that change their OpenGL support based on the value of their parameters (e.g. OCIODisplay and friends). This method can cause "OpenGL enabled" render calls to be made on plugins that have explicitly stated they do not support OpenGL with their current parameter values. This function also violates the contract between host and plugin because it blindly changes the value of an instance property without the plugin having any way to know it happened or stop it. This logic is also not even needed because other logic in Node::getCurrentOpenGLRenderSupport() actually properly handles all the project, node, and plugin level overrides.

The following changes are include in this change:
- Removed OfxEffectInstance::onEnableOpenGLKnobValueChanged() and related declarations in the EffectInstace base class.
- Removed Project::isOpenGLRenderActivated() because it is basically identical to Project::isGPURenderingEnabledInProject().
- Clean up logic in callers that used to call onEnableOpenGLKnobValueChanged().
- Fixed a bug(?) where node "GPU render" knobs were not getting disabled when the project level knob caused GPU rendering to be disabled.
- Minor cleanups to make code simpler and more consistent

**Have you tested your changes (if applicable)? If so, how?**

Yes. I verified that this change causes Natron to stop requesting GL renders from plugins, like OCIODisplay, that explicitly
state that they do not support GL requests given their current parameter values. I also verified that GL render calls are
made when the plugin signals that the parameter combination does allow GL support.

**Futher details of this pull request**

The following changes to the OCIO plugins also helped detect and verify these changes worked properly.
https://github.com/NatronGitHub/openfx-io/pull/28
https://github.com/NatronGitHub/openfx-io/pull/29
