### PR TITLE
Fix rendering failures caused by not clearing the current context.

### DIFF
--- a/Engine/GPUContextPool.cpp
+++ b/Engine/GPUContextPool.cpp
@@ -168,6 +168,7 @@ GPUContextPool::attachGLContextToRender(bool checkIfGLLoaded)
         if (!_imp->currentOpenGLRendererMaxTexSize) {
             newContext->setContextCurrentNoRender();
             glGetIntegerv(GL_MAX_TEXTURE_SIZE, &_imp->currentOpenGLRendererMaxTexSize);
+            newContext->unsetCurrentContextNoRender();
         }
     }
 

--- a/Engine/OSGLContext.h
+++ b/Engine/OSGLContext.h
@@ -186,6 +186,10 @@ public:
      **/
     static void getGPUInfos(std::list<OpenGLRendererInfo>& renderers);
 
+    /**
+     * @brief Returns true if a context is currently set on the current thread.
+     **/
+    static bool threadHasACurrentContext();
 private:
 
 

--- a/Engine/OSGLContext_mac.cpp
+++ b/Engine/OSGLContext_mac.cpp
@@ -649,6 +649,11 @@ OSGLContext_mac::makeContextCurrent(const OSGLContext_mac* context)
     }
 }
 
+bool
+OSGLContext_mac::threadHasACurrentContext() {
+    return CGLGetCurrentContext() != NULL;
+}
+
 void
 OSGLContext_mac::swapBuffers()
 {

--- a/Engine/OSGLContext_mac.h
+++ b/Engine/OSGLContext_mac.h
@@ -48,6 +48,7 @@ public:
     ~OSGLContext_mac();
 
     static void makeContextCurrent(const OSGLContext_mac* context);
+    static bool threadHasACurrentContext();
     static void getGPUInfos(std::list<OpenGLRendererInfo>& renderers);
 
     void swapBuffers();

--- a/Engine/OSGLContext_wayland.cpp
+++ b/Engine/OSGLContext_wayland.cpp
@@ -576,6 +576,15 @@ OSGLContext_wayland::makeContextCurrent(const OSGLContext_wayland* context)
     }
 }
 
+bool
+OSGLContext_wayland::threadHasACurrentContext() {
+    const OSGLContext_egl_data* eglInfo = appPTR->getEGLData();
+
+    assert(eglInfo);
+
+    return eglInfo != nullptr && eglInfo->_imp->GetCurrentContext() != nullptr;
+}
+
 void
 OSGLContext_wayland::swapBuffers()
 {

--- a/Engine/OSGLContext_wayland.h
+++ b/Engine/OSGLContext_wayland.h
@@ -65,6 +65,7 @@ public:
     static void initEGLData(OSGLContext_egl_data* eglInfo);
     static void destroyEGLData(OSGLContext_egl_data* eglInfo);
     static bool makeContextCurrent(const OSGLContext_wayland* context);
+    static bool threadHasACurrentContext();
     static void getGPUInfos(std::list<OpenGLRendererInfo>& renderers);
 
     void swapBuffers();

--- a/Engine/OSGLContext_win.h
+++ b/Engine/OSGLContext_win.h
@@ -89,6 +89,7 @@ typedef BOOL (WINAPI * WGLDELETECONTEXT_T)(HGLRC);
 typedef PROC (WINAPI * WGLGETPROCADDRESS_T)(LPCSTR);
 typedef BOOL (WINAPI * WGLMAKECURRENT_T)(HDC, HGLRC);
 typedef BOOL (WINAPI * WGLSHARELISTS_T)(HGLRC, HGLRC);
+typedef HGLRC (WINAPI * WGLGETCURRENTCONTEXT_T)();
 
 ////////// https://www.opengl.org/registry/specs/NV/gpu_affinity.txt
 
@@ -154,6 +155,7 @@ struct OSGLContext_wgl_data
     HINSTANCE instance;
     WGLCREATECONTEXT_T CreateContext;
     WGLDELETECONTEXT_T DeleteContext;
+    WGLGETCURRENTCONTEXT_T GetCurrentContext;
     WGLGETPROCADDRESS_T GetProcAddress;
     WGLMAKECURRENT_T MakeCurrent;
     WGLSHARELISTS_T ShareLists;
@@ -206,6 +208,7 @@ public:
     ~OSGLContext_win();
 
     static bool makeContextCurrent(const OSGLContext_win* context);
+    static bool threadHasACurrentContext();
 
     void swapBuffers();
 

--- a/Engine/OSGLContext_x11.cpp
+++ b/Engine/OSGLContext_x11.cpp
@@ -840,6 +840,14 @@ OSGLContext_x11::makeContextCurrent(const OSGLContext_x11* context)
     }
 }
 
+bool
+OSGLContext_x11::threadHasACurrentContext() {
+    const OSGLContext_glx_data* glxInfo = appPTR->getGLXData();
+
+    assert(glxInfo);
+    return glxInfo->_imp->GetCurrentContext() != NULL;
+}
+
 void
 OSGLContext_x11::swapBuffers()
 {

--- a/Engine/OSGLContext_x11.h
+++ b/Engine/OSGLContext_x11.h
@@ -71,6 +71,7 @@ public:
     static void initGLXData(OSGLContext_glx_data* glxInfo);
     static void destroyGLXData(OSGLContext_glx_data* glxInfo);
     static bool makeContextCurrent(const OSGLContext_x11* context);
+    static bool threadHasACurrentContext();
     static void getGPUInfos(std::list<OpenGLRendererInfo>& renderers);
 
     void swapBuffers();

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -25,9 +25,11 @@ set(Tests_SOURCES
     Hash64_Test.cpp
     Image_Test.cpp
     Lut_Test.cpp
+    OSGLContext_Test.cpp
     KnobFile_Test.cpp
     Curve_Test.cpp
     Tracker_Test.cpp
+    OSGLContext_Test.cpp
     wmain.cpp
 )
 add_executable(Tests ${Tests_HEADERS} ${Tests_SOURCES})

--- a/Tests/OSGLContext_Test.cpp
+++ b/Tests/OSGLContext_Test.cpp
@@ -35,13 +35,15 @@ NATRON_NAMESPACE_USING
 
 TEST(OSGLContext, Basic)
 {
-    ASSERT_TRUE(appPTR->isOpenGLLoaded());
+    if (!appPTR->isOpenGLLoaded()) {
+        // TODO: Convert to GTEST_SKIP() when gtest updated.
+        std::cerr << "Skipping test because OpenGL loading failed." << std::endl;
+        return;
+    }
 
     SettingsPtr settings =  appPTR->getCurrentSettings();
-    GLRendererID rendererID;
-    if (settings) {
-        rendererID = settings->getActiveOpenGLRendererID();
-    }
+    ASSERT_NE(settings.get(), nullptr);
+    GLRendererID rendererID = settings->getActiveOpenGLRendererID();
 
     // Verify that we start without a context being set.
     EXPECT_FALSE(OSGLContext::threadHasACurrentContext());
@@ -63,7 +65,11 @@ TEST(OSGLContext, Basic)
 }
 
 TEST(GPUContextPool, Basic) {
-    ASSERT_TRUE(appPTR->isOpenGLLoaded());
+    if (!appPTR->isOpenGLLoaded()) {
+        /// TODO: Convert to GTEST_SKIP() when gtest updated.
+        std::cerr << "Skipping test because OpenGL loading failed." << std::endl;
+        return;
+    }
 
     // Verify that we start without a context being set.
     EXPECT_FALSE(OSGLContext::threadHasACurrentContext());

--- a/Tests/OSGLContext_Test.cpp
+++ b/Tests/OSGLContext_Test.cpp
@@ -1,0 +1,100 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * This file is part of Natron <https://natrongithub.github.io/>,
+ * (C) 2018-2023 The Natron developers
+ * (C) 2013-2018 INRIA and Alexandre Gauthier-Foichat
+ *
+ * Natron is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Natron is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Natron.  If not, see <http://www.gnu.org/licenses/gpl-2.0.html>
+ * ***** END LICENSE BLOCK ***** */
+
+// ***** BEGIN PYTHON BLOCK *****
+// from <https://docs.python.org/3/c-api/intro.html#include-files>:
+// "Since Python may define some pre-processor definitions which affect the standard headers on some systems, you must include Python.h before any standard headers are included."
+#include <Python.h>
+// ***** END PYTHON BLOCK *****
+
+#include "Global/Macros.h"
+
+#include <gtest/gtest.h>
+
+#include "Engine/OSGLContext.h"
+#include "Engine/GPUContextPool.h"
+#include "Engine/Settings.h"
+
+NATRON_NAMESPACE_USING
+
+TEST(OSGLContext, Basic)
+{
+    ASSERT_TRUE(appPTR->isOpenGLLoaded());
+
+    SettingsPtr settings =  appPTR->getCurrentSettings();
+    GLRendererID rendererID;
+    if (settings) {
+        rendererID = settings->getActiveOpenGLRendererID();
+    }
+
+    // Verify that we start without a context being set.
+    EXPECT_FALSE(OSGLContext::threadHasACurrentContext());
+
+    auto newContext = std::make_shared<OSGLContext>( FramebufferConfig(), nullptr, GLVersion.major, GLVersion.minor, rendererID);
+
+    // Verify that creating a context does not set the current context.
+    EXPECT_FALSE(OSGLContext::threadHasACurrentContext());
+
+    newContext->setContextCurrentNoRender();
+
+    // Verify that the current context was actually set.
+    EXPECT_TRUE(OSGLContext::threadHasACurrentContext());
+
+    OSGLContext::unsetCurrentContextNoRender();
+
+    // Verify that it is no longer set.
+    EXPECT_FALSE(OSGLContext::threadHasACurrentContext());
+}
+
+TEST(GPUContextPool, Basic) {
+    ASSERT_TRUE(appPTR->isOpenGLLoaded());
+
+    // Verify that we start without a context being set.
+    EXPECT_FALSE(OSGLContext::threadHasACurrentContext());
+
+    GPUContextPool pool;
+
+    // Verify that creating the pool does not set the current context.
+    EXPECT_FALSE(OSGLContext::threadHasACurrentContext());
+    OSGLContextPtr context = pool.attachGLContextToRender(/* checkIfGLLoaded */ false);
+
+    // Verify that the attach returns a valid pointer to a context, but
+    // this context has not been made current on this thread yet.
+    EXPECT_NE(context.get(), nullptr);
+    EXPECT_FALSE(OSGLContext::threadHasACurrentContext());
+
+    context->setContextCurrentNoRender();
+
+    // Verify that the current context is now set.
+    EXPECT_TRUE(OSGLContext::threadHasACurrentContext());
+
+    OSGLContext::unsetCurrentContextNoRender();
+
+    // Verify that the current context is no longer set.
+    EXPECT_FALSE(OSGLContext::threadHasACurrentContext());
+
+    pool.releaseGLContextFromRender(context);
+
+    // Verify that returing the context does not make it current.
+    EXPECT_FALSE(OSGLContext::threadHasACurrentContext());
+
+    context.reset();
+
+    EXPECT_FALSE(OSGLContext::threadHasACurrentContext());
+}

--- a/Tests/Tests.pro
+++ b/Tests/Tests.pro
@@ -50,6 +50,7 @@ SOURCES += \
     KnobFile_Test.cpp \
     Curve_Test.cpp \
     Tracker_Test.cpp \
+    OSGLContext_Test.cpp \
     wmain.cpp
 
 HEADERS += \


### PR DESCRIPTION

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

This patch fixes 2 bugs where code was leaving a GL context current when it shouldn't have. This was causing rendering failures because code would later try to use a context that was current on one thread to do rendering on another.

This patch contains the following changes:
- Fix GPUContextPool to unset the current context after it has fetched the max texture size.
- Fix OSGLContext_win so it unsets the current context before it returns from analyzeContextWGL().
- Add context clearing in OSGLContext_win for a few exception cases and updated makeContextCurrent(0) to makeContextCurrent(nullptr) for consistency and to make it clear this method takes a pointer.
- Added a unit test that verifies the GPUContextPool and OSGLContext_win::analyzeContextWGL() fixes.


**Have you tested your changes (if applicable)? If so, how?**

Yes. I've verified that this fixes "random" rendering failures I was seeing on Windows. I also created a unit test that verifies the fixes and run them on Windows and Linux. I don't have a Mac dev environment to test with, but the test should detect the same bugs on that platform. I verified the new tests fail without the fixes and pass with them.
