### PR TITLE
Fixes to get Qt5 working on Windows.

### DIFF
--- a/Gui/FileTypeMainWindow_win.cpp
+++ b/Gui/FileTypeMainWindow_win.cpp
@@ -92,11 +92,6 @@ bool
 DocumentWindow::nativeEvent(const QByteArray& eventType, void* message, long* result)
 {
     MSG* msg = static_cast<MSG*>(message);
-#else
-bool
-DocumentWindow::winEvent(MSG* msg,  long *result)
-{
-#endif
     switch (msg->message) {
     case WM_DDE_INITIATE:
 
@@ -112,12 +107,30 @@ DocumentWindow::winEvent(MSG* msg,  long *result)
         break;
     }
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
     return QMainWindow::nativeEvent(eventType, message, result);
-#else
-    return QMainWindow::winEvent(msg, result);
-#endif
 }
+#else
+bool
+DocumentWindow::winEvent(MSG* msg,  long *result)
+{
+    switch (msg->message) {
+    case WM_DDE_INITIATE:
+
+        return ddeInitiate(msg, result);
+        break;
+    case WM_DDE_EXECUTE:
+
+        return ddeExecute(msg, result);
+        break;
+    case WM_DDE_TERMINATE:
+
+        return ddeTerminate(msg, result);
+        break;
+    }
+
+    return QMainWindow::winEvent(msg, result);
+}
+#endif
 
 void
 DocumentWindow::ddeOpenFile(const QString&)

--- a/Gui/FileTypeMainWindow_win.cpp
+++ b/Gui/FileTypeMainWindow_win.cpp
@@ -87,26 +87,36 @@ DocumentWindow::~DocumentWindow()
 // —— public slots ——————————————————————————
 // —— protected slots —————————————————————————
 // —— events ————————————————————————————
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 bool
-DocumentWindow::winEvent(MSG *message,
-                         long *result)
+DocumentWindow::nativeEvent(const QByteArray& eventType, void* message, long* result)
 {
-    switch (message->message) {
+    MSG* msg = static_cast<MSG*>(message);
+#else
+bool
+DocumentWindow::winEvent(MSG* msg,  long *result)
+{
+#endif
+    switch (msg->message) {
     case WM_DDE_INITIATE:
 
-        return ddeInitiate(message, result);
+        return ddeInitiate(msg, result);
         break;
     case WM_DDE_EXECUTE:
 
-        return ddeExecute(message, result);
+        return ddeExecute(msg, result);
         break;
     case WM_DDE_TERMINATE:
 
-        return ddeTerminate(message, result);
+        return ddeTerminate(msg, result);
         break;
     }
 
-    return QMainWindow::winEvent(message, result);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    return QMainWindow::nativeEvent(eventType, message, result);
+#else
+    return QMainWindow::winEvent(msg, result);
+#endif
 }
 
 void

--- a/Gui/FileTypeMainWindow_win.h
+++ b/Gui/FileTypeMainWindow_win.h
@@ -138,7 +138,11 @@ protected:
     /**
      * reimpl as DDE events come as windows events and are not translated by Qt.
      */
-    virtual bool winEvent(MSG *message, long *result);
+    #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    virtual bool nativeEvent(const QByteArray& eventType, void* message, long* result);
+    #else
+    virtual bool winEvent(MSG *msg, long *result);
+    #endif
 
     // —— helpers for the file registration ——————————————————
     /**

--- a/Gui/Pyside_Gui_Python.h
+++ b/Gui/Pyside_Gui_Python.h
@@ -37,6 +37,9 @@
 #include <pyside_global.h>
 #endif
 
+#include <QSize>
+#include <QObject>
+
 #include <QtGui/qpytextobject.h>
 
 //Global

--- a/Gui/PythonPanels.h
+++ b/Gui/PythonPanels.h
@@ -30,6 +30,8 @@
 
 CLANG_DIAG_OFF(deprecated)
 CLANG_DIAG_OFF(uninitialized)
+// Include order matters here to keep shiboken happy.
+#include <QWidget>
 #include <QDialog>
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)

--- a/Gui/TaskBar.cpp
+++ b/Gui/TaskBar.cpp
@@ -39,7 +39,8 @@ TaskBar::TaskBar(QWidget *parent)
     , _state(NoProgress)
 {
 #ifdef Q_OS_WIN
-    _wid = parent->window()->winId();
+    // QT4 typedefs WId as an HWND, but QT5 typdefs it as a quintptr, so a cast is needed.
+    _hwnd = reinterpret_cast<HWND>(parent->window()->winId());
     CoInitialize(NULL);
     HRESULT hres = CoCreateInstance(CLSID_TaskbarList,
                                     NULL,
@@ -112,7 +113,7 @@ TaskBar::setProgressValue(double value)
     if (!_wtask) {
         return;
     }
-    if (_wtask->SetProgressValue(_wid, currentVal, totalVal) == S_OK) {
+    if (_wtask->SetProgressValue(_hwnd, currentVal, totalVal) == S_OK) {
         _val = value;
     }
 #elif defined(Q_OS_DARWIN)
@@ -153,7 +154,7 @@ TaskBar::setProgressState(TaskBar::ProgressState state)
         flag = TBPF_NORMAL;
         break;
     }
-    if (_wtask->SetProgressState(_wid, flag) == S_OK) {
+    if (_wtask->SetProgressState(_hwnd, flag) == S_OK) {
         _state = state;
     }
 #elif defined(Q_OS_DARWIN)

--- a/Gui/TaskBar.h
+++ b/Gui/TaskBar.h
@@ -71,7 +71,7 @@ private:
 
 #ifdef Q_OS_WIN
     ITaskbarList3 *_wtask;
-    WId _wid;
+    HWND _hwnd;
 #elif defined(Q_OS_DARWIN)
     TaskBarMac *_mtask;
 #endif

--- a/global.pri
+++ b/global.pri
@@ -419,11 +419,14 @@ win32-g++ {
     expat:     PKGCONFIG += expat
     cairo:     PKGCONFIG += cairo fontconfig
     equals(QT_MAJOR_VERSION, 5) {
-      shiboken:  INCLUDEPATH += $$PYTHON_SITE_PACKAGES/PySide2/include/shiboken2
-    	pyside:    INCLUDEPATH += $$PYTHON_SITE_PACKAGES/PySide2/include/PySide2
-      pyside:    INCLUDEPATH += $$PYTHON_SITE_PACKAGES/PySide2/include/PySide2/QtCore
-      pyside:    INCLUDEPATH += $$PYTHON_SITE_PACKAGES/PySide2/include/PySide2/QtGui
-      pyside:    INCLUDEPATH += $$PYTHON_SITE_PACKAGES/PySide2/include/PySide2/QtWidgets
+      shiboken:  INCLUDEPATH += $$system(pkg-config --variable=includedir shiboken2)
+      PYSIDE_INCLUDEDIR = $$system(pkg-config --variable=includedir pyside2)
+      pyside:    INCLUDEPATH += $$PYSIDE_INCLUDEDIR
+      pyside:    INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtCore
+      pyside:    INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtGui
+      pyside:    INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtWidgets
+      shiboken:  PKGCONFIG += shiboken2
+      pyside:    PKGCONFIG += pyside2
     }
     equals(QT_MAJOR_VERSION, 4) {
       shiboken:  PKGCONFIG += shiboken-py$$PYV

--- a/tools/jenkins/build-natron.sh
+++ b/tools/jenkins/build-natron.sh
@@ -170,10 +170,12 @@ if [ "$QT_VERSION_MAJOR" = 5 ]; then
     esac
 
     rm Engine/Qt${QT_VERSION_MAJOR}/NatronEngine/* Gui/Qt${QT_VERSION_MAJOR}/NatronGui/* || true
-    # ${PYTHON_HOME}/lib/python${PYVER}/site-packages/PySide2/include
-    shiboken2-${PYVER} --avoid-protected-hack --enable-pyside-extensions --include-paths=.:Engine:Global:libs/OpenFX/include:${SDK_HOME}/include:${QTDIR}/include:${PYTHON_HOME}/include/python${PYVER}:${PYTHON_HOME}/lib/python${PYVER}/site-packages/PySide2/include --typesystem-paths=${PYTHON_HOME}/lib/python${PYVER}/site-packages/PySide2/typesystems --output-directory=Engine/Qt${QT_VERSION_MAJOR} Engine/Pyside2_Engine_Python.h  Engine/typesystem_engine.xml
+    UNIX_PYTHON_HOME=`cygpath -u "${PYTHON_HOME}"`
+    SHIBOKEN_INCLUDE_PATHS=".:./Engine:./Global:libs/OpenFX/include:${UNIX_PYTHON_HOME}/include/python${PYVER}:${UNIX_PYTHON_HOME}/include/PySide2"
+    SHIBOKEN_TYPESYSTEM_PATHS="${UNIX_PYTHON_HOME}/share/PySide2/typesystems"
+    shiboken2 --avoid-protected-hack --enable-pyside-extensions --include-paths=${SHIBOKEN_INCLUDE_PATHS} --typesystem-paths=${SHIBOKEN_TYPESYSTEM_PATHS} --output-directory=Engine/Qt${QT_VERSION_MAJOR} Engine/Pyside2_Engine_Python.h  Engine/typesystem_engine.xml
 
-    shiboken2-${PYVER} --avoid-protected-hack --enable-pyside-extensions --include-paths=.:Engine:Global:libs/OpenFX/include:${SDK_HOME}/include:${QTDIR}/include:${QTDIR}/include/QtWidgets:${PYTHON_HOME}/include/python${PYVER}:${PYTHON_HOME}/lib/python${PYVER}/site-packages/PySide2/include --typesystem-paths=${PYTHON_HOME}/lib/python${PYVER}/site-packages/PySide2/typesystems:Engine:Shiboken --output-directory=Gui/Qt${QT_VERSION_MAJOR} Gui/Pyside2_Gui_Python.h  Gui/typesystem_natronGui.xml
+    shiboken2 --avoid-protected-hack --enable-pyside-extensions --include-paths=${SHIBOKEN_INCLUDE_PATHS}:${QTDIR}/include/QtWidgets:${QTDIR}/include/QtCore --typesystem-paths=${SHIBOKEN_TYPESYSTEM_PATHS}:./Engine:./Shiboken --output-directory=Gui/Qt${QT_VERSION_MAJOR} Gui/Pyside2_Gui_Python.h  Gui/typesystem_natronGui.xml
 
     tools/utils/runPostShiboken2.sh Engine/Qt${QT_VERSION_MAJOR}/NatronEngine natronengine
     tools/utils/runPostShiboken2.sh Gui/Qt${QT_VERSION_MAJOR}/NatronGui natrongui

--- a/tools/jenkins/genDllVersions.sh
+++ b/tools/jenkins/genDllVersions.sh
@@ -89,26 +89,62 @@ function catDll() {
 INIT_VAR=1
 DLL_VAR_PREFIX="NATRON"
 BIN_PATH="$SDK_HOME_BIN"
-# all Qt libraries are necessary for PySide
-catDll Qt3Support4
-catDll QtCLucene4
-catDll QtCore4
-catDll QtDBus4
-catDll QtDeclarative4
-catDll QtDesigner4
-catDll QtDesignerComponents4
-catDll QtGui4
-catDll QtHelp4
-catDll QtMultimedia4
-catDll QtNetwork4
-catDll QtOpenGL4
-catDll QtScript4
-catDll QtScriptTools4
-catDll QtSql4
-catDll QtSvg4
-catDll QtTest4
-catDll QtXml4
-catDll QtXmlPatterns4
+if [ "$QT_VERSION_MAJOR" = "4" ]; then
+    # all Qt libraries are necessary for PySide
+    catDll Qt3Support4
+    catDll QtCLucene4
+    catDll QtCore4
+    catDll QtDBus4
+    catDll QtDeclarative4
+    catDll QtDesigner4
+    catDll QtDesignerComponents4
+    catDll QtGui4
+    catDll QtHelp4
+    catDll QtMultimedia4
+    catDll QtNetwork4
+    catDll QtOpenGL4
+    catDll QtScript4
+    catDll QtScriptTools4
+    catDll QtSql4
+    catDll QtSvg4
+    catDll QtTest4
+    catDll QtXml4
+    catDll QtXmlPatterns4
+
+    catDll phonon4
+    catDll libmng-
+    catDll libpcre-
+elif [ "$QT_VERSION_MAJOR" = "5" ]; then
+    catDll Qt5Concurrent
+    catDll Qt5Core
+    catDll Qt5DBus
+    catDll Qt5Gui
+    catDll Qt5Network
+    catDll Qt5OpenGL
+    catDll Qt5PrintSupport
+    catDll Qt5Qml
+    catDll Qt5QmlModels
+    catDll Qt5QmlWorkerScript
+    catDll Qt5Quick
+    catDll Qt5QuickParticles
+    catDll Qt5QuickShapes
+    catDll Qt5QuickTest
+    catDll Qt5QuickWidgets
+    catDll Qt5Sql
+    catDll Qt5Test
+    catDll Qt5Widgets
+    catDll Qt5Xml
+    catDll Qt5XmlPatterns
+
+    catDll libdouble-conversion
+    catDll libicuin
+    catDll libpcre2-16-
+    catDll libmd4c
+else
+    echo "Unsupported QT_MAJOR_VERSION" ${QT_VERSION_MAJOR}
+    exit 1
+fi
+
 
 catDll fbclient
 catDll libass-
@@ -157,7 +193,6 @@ catDll libjpeg-
 catDll liblcms2-
 catDll liblzma-
 catDll libmfx
-catDll libmng-
 catDll libmodplug-
 catDll libmp3lame-
 catDll libnettle-
@@ -200,7 +235,6 @@ catDll libwebpdemux-
 catDll libwebpmux-
 catDll libwinpthread-
 catDll libxml2-
-catDll phonon4
 #catDll SDL2
 #catDll SSLEAY32
 catDll zlib1


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

This change fixes various Qt5 related build busters on Windows.
- Fixes event API function name and signature change in FileTypeMainWindow_win
- Added cast in TaskBar to deal with differing typedefs for WId.
- Replaced the WId _wid member variable in TaskBar with HWND _hwnd since that reflects what the code actually needs and makes it so we only have to cast from WId to HWND in a single location.
- Added some Qt headers to Gui/Pyside_Gui_Python.h and Gui/PythonPanels.h to make shiboken2 happy. It would segfault, complain about unknown types, or complain about not finding suitable default constructors without these.
- Updated tools/jenkins scripts so they could properly handle Qt4 & Qt5 builds on windows.


**Have you tested your changes (if applicable)? If so, how?**

Yes. I built Qt4 and Qt5 installers on Windows in a MSYS2 environment with tools/jenkins/launchBuildMain.sh. I was able to unzip the generated zip files and launch Natron. I verified I was able to load a simple project in each of these builds, but I did not do exhaustive testing to verify all features work with Qt5.

