### PR TITLE
Fix DeleterThread and CacheCleanerThread locking.

### DIFF
--- a/Engine/Cache.h
+++ b/Engine/Cache.h
@@ -168,8 +168,8 @@ private:
                 {
                     QMutexLocker k(&_entriesQueueMutex);
                     if ( quit && _entriesQueue.empty() ) {
-                        _entriesQueueMutex.unlock();
-                        QMutexLocker k(&mustQuitMutex);
+                        k.unlock();
+                        QMutexLocker k2(&mustQuitMutex);
                         assert(mustQuit);
                         mustQuit = false;
                         mustQuitCond.wakeOne();
@@ -298,8 +298,8 @@ private:
                 {
                     QMutexLocker k(&_requestQueueMutex);
                     if ( quit && _requestsQueues.empty() ) {
-                        _requestQueueMutex.unlock();
-                        QMutexLocker k(&mustQuitMutex);
+                        k.unlock();
+                        QMutexLocker k2(&mustQuitMutex);
                         assert(mustQuit);
                         mustQuit = false;
                         mustQuitCond.wakeOne();


### PR DESCRIPTION

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

This change fixes double unlock that was causing crashes when the Tests binary would exit on Windows.

This change replaces the explicit unlock() on the mutex with a call to unlock() on the QMutexLocker holding the lock. This allows to QMutexLocker to avoid calling unlock() in its destructor when the mutex has already been unlocked.

The QMutexLocker that is declared right after the unlock() was also given a unique name in the function scope. This has no functional effect, but could help avoid accidentally calling the wrong object if this code is modified in the future.


**Have you tested your changes (if applicable)? If so, how?**

Yes. Tests.exe was crashing on Windows in the lock code before this change. It no longer crashes with this change applied.

