### PR TITLE
Remove threadHasACurrentContext() asserts

### DIFF
--- a/Engine/OSGLContext.cpp
+++ b/Engine/OSGLContext.cpp
@@ -303,13 +303,10 @@ OSGLContext::OSGLContext(const FramebufferConfig& pixelFormatAttrs,
         _imp->_platformContext.reset( new OSGLContext_x11(pixelFormatAttrs, major, minor, coreProfile, rendererID, shareContext ? static_cast<const OSGLContext_x11 *>(shareContext->_imp->_platformContext.get()) : nullptr) );
     }
 #endif
-    assert(!threadHasACurrentContext());
 }
 
 OSGLContext::~OSGLContext()
 {
-    assert(!threadHasACurrentContext());
-
     setContextCurrentNoRender();
     if (_imp->pboID) {
         glDeleteBuffers(1, &_imp->pboID);


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

This change removes the asserts in OSGLContext::OSGLContext() and OSGLContext::~OSGLContext() that check to see if the context is set on the thread. These were invalid assumptions because Qt appears to leave the current context set to its own GL contexts when it dispatches event handlers for things like button clicks. Removing the asserts avoid crashes and the tests that were added in #871 make sure that Natron code properly clears its own contexts.

**Have you tested your changes (if applicable)? If so, how?**

Yes. I verified that Natron on Linux does not crash with assert failures when trying to add nodes anymore.

