### PR TITLE
Fix CrashReporter process invocation on Windows.

### DIFF
--- a/CrashReporter/CallbacksManager.cpp
+++ b/CrashReporter/CallbacksManager.cpp
@@ -531,7 +531,7 @@ CallbacksManager::initInternal()
     QObject::connect( _natronProcess, SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(onSpawnedProcessFinished(int,QProcess::ExitStatus)) );
     QObject::connect( _natronProcess, SIGNAL(error(QProcess::ProcessError)), this, SLOT(onSpawnedProcessError(QProcess::ProcessError)) );
     QStringList processArgs;
-    for (int i = 0; i < _argc; ++i) {
+    for (int i = 1; i < _argc; ++i) {
         processArgs.push_back( QString::fromUtf8(_argv[i]) );
     }
     if (enableBreakpad) {
@@ -541,8 +541,6 @@ CallbacksManager::initInternal()
         qint64 crashReporterPid = qApp->applicationPid();
         QString pidStr = QString::number(crashReporterPid);
         processArgs.push_back(pidStr);
-        processArgs.push_back( QString::fromUtf8("--" NATRON_BREAKPAD_CLIENT_FD_ARG) );
-        processArgs.push_back( QString::number(-1) );
         processArgs.push_back( QString::fromUtf8("--" NATRON_BREAKPAD_PIPE_ARG) );
         processArgs.push_back(_pipePath);
         processArgs.push_back( QString::fromUtf8("--" NATRON_BREAKPAD_COM_PIPE_ARG) );


### PR DESCRIPTION

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

This change fixes the CrashReporter code that launches the actual Natron binary. It removes a parameter that was not needed on Windows that caused the Natron binary to immediately exit. It also fixes the command-line parameters passed to the child process. The old code was passing in the CrashReporter binary name as the first parameter which was causing the command-line parsing code to fail because it interpreted this as an unknown/unhandled parameter.


**Have you tested your changes (if applicable)? If so, how?**

Yes. I built a Windows build with tools/jenkins/launchBuildMain with DISABLE_BREAKPAD=0. I was able to successfully launch the Natron UI. I then clicked on the "Test Crash Reporting" button in Edit -> Preferences. This brought up the "Problem Report" dialog and I was able to save a minidump locally by clicking the "Save Report" button.  With [an updated version of Natron breakpad](https://github.com/NatronGitHub/breakpad/pull/5) and [the updated MinGW packages for Qt5](https://github.com/NatronGitHub/Natron/pull/879), I was able to view the crash stack trace with minidump_stackwalk and the symbol files generated by tools/jenkins/launchBuildMain. 

