### PR TITLE
Linux build documentation and readme improvements

### DIFF
--- a/INSTALL_LINUX.md
+++ b/INSTALL_LINUX.md
@@ -6,8 +6,7 @@ This file is supposed to guide you step by step to have working (compiling) vers
 * It's recommended to use Docker for the easiest hands-off installation method - see [here](#using-docker) for more details
 * If you are on Arch Linux or Manjaro, see [this](#arch-linux) for relevant details
 * If you are on Fedora or RHEL, see [here](#fedorarhel-based) for specific instructions
-* If you are on Debian or a Debian/Ubuntu-based Linux (such as KDE Neon, ElementaryOS etc.) see [here](#debian-based) for details
-* If you are on Ubuntu see [here](#ubuntu) for details
+* If you are on Debian or a Debian-based system (such as Ubuntu, Linux Mint, KDE Neon, ElementaryOS etc.) see [here](#debian-based) for details
 * If you are willing to try the complete installation process, the instructions are below
 
 0. [Using Docker](#using-docker)
@@ -34,7 +33,6 @@ This file is supposed to guide you step by step to have working (compiling) vers
 4. [Distribution specific](#distribution-specific)
     - [Arch Linux](#arch-linux)
     - [Debian-based](#debian-based)
-    - [Ubuntu](#ubuntu)
     - [Fedora/RHEL-based](#fedorarhel-based)
 5. [Generating Python bindings](#generating-python-bindings)
 
@@ -370,14 +368,22 @@ The binaries will be found in the `build/App` folder. In order to launch Natron 
 Installing dependencies using `apt-get` or `apt` should work on
 any Debian-based distribution.
 
-Install the required packages:
+For Ubuntu 22.04 using Python 3.10 and Qt 5.15, install the required dependencies:
+
 ```
-sudo apt install qt5base-dev libboost-serialization-dev libboost-system-dev libexpat1-dev libcairo2-dev python3-dev python3-pyside2 libpyside2-dev libshiboken2-dev
+sudo apt install build-essential libboost-serialization-dev libboost-system-dev libexpat1-dev libcairo2-dev qt5-qmake qtbase5-dev python3-dev libshiboken2-dev libpyside2-dev python3-pyside2.qtwidgets python3-qtpy
 ```
 
 For Debian 12, install the following packages instead:
+
 ```
 sudo apt install qtbase5-dev libboost-serialization-dev libboost-system-dev libexpat1-dev libcairo2-dev python3-dev python3-pyside2.qtcore libpyside2-dev libshiboken2-dev
+```
+
+For most Debian/Ubuntu-based systems, install the required packages:
+
+```
+sudo apt install qt5base-dev libboost-serialization-dev libboost-system-dev libexpat1-dev libcairo2-dev python3-dev python3-pyside2 libpyside2-dev libshiboken2-dev
 ```
 
 For the Qt4 config.pri use:
@@ -404,16 +410,6 @@ pyside {
         INCLUDEPATH += $$system(env PKG_CONFIG_PATH=$$PYSIDE_PKG_CONFIG_PATH pkg-config --variable=includedir pyside)/QtCore
         INCLUDEPATH += $$system(env PKG_CONFIG_PATH=$$PYSIDE_PKG_CONFIG_PATH pkg-config --variable=includedir pyside)/QtGui
 }
-```
-
-## Ubuntu
-
-Instructions for Ubuntu 22.04 using Python 3.10 and Qt 5.15.
-
-Install the required dependencies:
-
-```
-sudo apt install build-essential libboost-serialization-dev libboost-system-dev libexpat1-dev libcairo2-dev qt5-qmake qtbase5-dev python3-dev libshiboken2-dev libpyside2-dev python3-pyside2.qtwidgets python3-qtpy
 ```
 
 Get Natron:

--- a/INSTALL_LINUX.md
+++ b/INSTALL_LINUX.md
@@ -367,7 +367,7 @@ The binaries will be found in the `build/App` folder. In order to launch Natron 
 
 ## Debian-based
 
-Installing dependencies using `apt-get` should work on
+Installing dependencies using `apt-get` or `apt` should work on
 any Debian-based distribution.
 
 Install the required packages:
@@ -390,7 +390,7 @@ pyside: INCLUDEPATH += $$system(env PKG_CONFIG_PATH=$$PYSIDE_PKG_CONFIG_PATH pkg
 pyside: INCLUDEPATH += $$system(env PKG_CONFIG_PATH=$$PYSIDE_PKG_CONFIG_PATH pkg-config --variable=includedir pyside)/QtGui
 ```
 
-for linux mint you will need to add:
+for Linux Mint you will need to add:
 
 ```
 pyside {
@@ -444,18 +444,20 @@ make test
 
 ## Fedora/RHEL-based
 
-Instructions for Fedora, Red Hat Enterprise Linux and derivatives.
+Instructions for Fedora, Red Hat Enterprise Linux and derivatives. You can use either the dnf or yum package managers
 
 On RHEL and derivative distributions you need the EPEL repository:
 
-```
-yum install epel-release
-```
+``` yum install epel-release ``` or ``` dnf install epel-release ```
 
 Install required packages:
 
 ```
 yum install fontconfig-devel gcc-c++ expat-devel python-pyside2-devel shiboken2-devel qt5-qtbase-devel boost-devel pixman-devel cairo-devel
+```
+or
+```
+dnf install fontconfig-devel gcc-c++ expat-devel python-pyside2-devel shiboken2-devel qt5-qtbase-devel boost-devel pixman-devel cairo-devel
 ```
 
 Qt4 config.pri:

--- a/INSTALL_LINUX.md
+++ b/INSTALL_LINUX.md
@@ -6,7 +6,7 @@ This file is supposed to guide you step by step to have working (compiling) vers
 * It's recommended to use Docker for the easiest hands-off installation method - see [here](#using-docker) for more details
 * If you are on Arch Linux or Manjaro, see [this](#arch-linux) for relevant details
 * If you are on Fedora or RHEL, see [here](#fedorarhel-based) for specific instructions
-* If you are on a Debian-based Linux (such as KDE Neon, ElementaryOS etc.) see [here](#debian-based) for details
+* If you are on Debian or a Debian/Ubuntu-based Linux (such as KDE Neon, ElementaryOS etc.) see [here](#debian-based) for details
 * If you are on Ubuntu see [here](#ubuntu) for details
 * If you are willing to try the complete installation process, the instructions are below
 
@@ -372,7 +372,12 @@ any Debian-based distribution.
 
 Install the required packages:
 ```
-sudo apt-get install qt5base-dev libboost-serialization-dev libboost-system-dev libexpat1-dev libcairo2-dev python3-dev python3-pyside2 libpyside2-dev libshiboken2-dev
+sudo apt install qt5base-dev libboost-serialization-dev libboost-system-dev libexpat1-dev libcairo2-dev python3-dev python3-pyside2 libpyside2-dev libshiboken2-dev
+```
+
+For Debian 12, install the following packages instead:
+```
+sudo apt install qtbase5-dev libboost-serialization-dev libboost-system-dev libexpat1-dev libcairo2-dev python3-dev python3-pyside2.qtcore libpyside2-dev libshiboken2-dev
 ```
 
 For the Qt4 config.pri use:
@@ -408,19 +413,7 @@ Instructions for Ubuntu 22.04 using Python 3.10 and Qt 5.15.
 Install the required dependencies:
 
 ```
-sudo apt install \
-build-essential \
-libboost-serialization-dev \
-libboost-system-dev \
-libexpat1-dev \
-libcairo2-dev \
-qt5-qmake \
-qtbase5-dev \
-python3-dev \
-libshiboken2-dev \
-libpyside2-dev \
-python3-pyside2.qtwidgets \
-python3-qtpy
+sudo apt install build-essential libboost-serialization-dev libboost-system-dev libexpat1-dev libcairo2-dev qt5-qmake qtbase5-dev python3-dev libshiboken2-dev libpyside2-dev python3-pyside2.qtwidgets python3-qtpy
 ```
 
 Get Natron:

--- a/INSTALL_LINUX.md
+++ b/INSTALL_LINUX.md
@@ -6,8 +6,8 @@ This file is supposed to guide you step by step to have working (compiling) vers
 * It's recommended to use Docker for the easiest hands-off installation method - see [here](#using-docker) for more details
 * If you are on Arch Linux or Manjaro, see [this](#arch-linux) for relevant details
 * If you are on Fedora or RHEL, see [here](#fedorarhel-based) for specific instructions
-* If you are on a Debian-based Linux (such as KDE Plasma, ElementaryOS etc.) see [here](#debian-based) for details
-* If you are on a Ubuntu see [here](#ubuntu) for details
+* If you are on a Debian-based Linux (such as KDE Neon, ElementaryOS etc.) see [here](#debian-based) for details
+* If you are on Ubuntu see [here](#ubuntu) for details
 * If you are willing to try the complete installation process, the instructions are below
 
 0. [Using Docker](#using-docker)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you are willing to help, please contact the development team on the [pixls.us
 
 - 32-bit floating-point linear color processing pipeline.
 - Color management handled by [OpenColorIO](https://opencolorio.org/).
-- Dozens of file formats supported: EXR, DPX, TIFF, JPG, PNG through [OpenImageIO](https://github.com/OpenImageIO/oiio) and [FFmpeg](https://ffmpeg.org/).
+- Dozens of video and image formats supported: H264, DNxHR, EXR, DPX, TIFF, JPG, PNG through [OpenImageIO](https://github.com/OpenImageIO/oiio) and [FFmpeg](https://ffmpeg.org/).
 - Support for many free, open-source, and commercial OpenFX plugins—currently almost all features of OpenFX v1.4 are supported. Those marked with (+) are included in the binary releases.
   - [OpenFX-IO](https://github.com/NatronGitHub/openfx-io) (+)
   - [OpenFX-Misc](https://github.com/NatronGitHub/openfx-misc) (+)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you are willing to help, please contact the development team on the [pixls.us
 
 - 32-bit floating-point linear color processing pipeline.
 - Color management handled by [OpenColorIO](https://opencolorio.org/).
-- Dozens of video and image formats supported: H264, DNxHR, EXR, DPX, TIFF, JPG, PNG through [OpenImageIO](https://github.com/OpenImageIO/oiio) and [FFmpeg](https://ffmpeg.org/).
+- Dozens of video and image formats supported such as: H264, DNxHR, EXR, DPX, TIFF, JPG, PNG through [OpenImageIO](https://github.com/OpenImageIO/oiio) and [FFmpeg](https://ffmpeg.org/).
 - Support for many free, open-source, and commercial OpenFX plugins—currently almost all features of OpenFX v1.4 are supported. Those marked with (+) are included in the binary releases.
   - [OpenFX-IO](https://github.com/NatronGitHub/openfx-io) (+)
   - [OpenFX-Misc](https://github.com/NatronGitHub/openfx-misc) (+)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Standalone binary distributions of Natron are available for GNU/Linux, Windows, 
 - [openfx-arena](https://github.com/NatronGitHub/openfx-arena)
 - [openfx-gmic](https://github.com/NatronGitHub/openfx-gmic)
 
+Alternatively, on Linux systems you can install Natron through flatpak: ``` flatpak install fr.natron.Natron ```
+
 For each architecture / operating system, you can either download a stable release, a release candidate (if available), or one of the latest snapshots. Note that snapshots contain the latest features and bug fixes, but may be unstable.
 
 ### Building and installing from source


### PR DESCRIPTION
I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
I've formatted my code according to Natron's code style
I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

PR Type: Improvement

Hello. I took a close look at the build instructions for Linux systems and noticed there were a few minor things that could be changed and added. I also added a small detail to the main README.md

Changes:

- Replaced "KDE Plasma" with "KDE Neon" since Plasma is just the desktop, while Neon is the distro the documentation is actually referring to
- Replaced "apt-get" with "apt", while keeping the mention that you can also use apt-get
- For Fedora/RHEL instructions, I added dnf as an alternative to yum, dnf is an improved version of yum and both come with the system
- Replaced "linux mint" with "Linux Mint"
- Added dependency package installation info for Debian 12.
- Merged the lines of Ubuntu's dependency installation into 1 line to match the rest of the dependency instructions
- Merged Debian-based and Ubuntu into 1 section while keeping all the info. This is because the final build instructions are meant to be used for both categories but were only seen in the Ubuntu category
- In README.md, I replaced "dozens of file formats... etc" with "dozens of video and image formats", and added the examples of H264 and DNxHR
- In the binary distributions section of README.md, I also added information for installing Natron through Flatpak

What's untested:

- The dependency installation list for Debian 12 has not been tested