### PR TITLE
Fix expansion-to-defined compiler warnings

### DIFF
--- a/Global/Macros.h
+++ b/Global/Macros.h
@@ -444,27 +444,19 @@ GCC_ONLY_DIAG_OFF(pragmas)  // warning: unknown option after '#pragma GCC diagno
 #endif
 #endif
 
-// silence warnings from the COMPILER() COMPILER_SUPPORTS() and COMPILER_QUIRK() macros below
-#if __has_warning("-Wexpansion-to-defined")
-// clang-format off
-CLANG_DIAG_OFF(expansion-to-defined)
-// clang-format on
-#endif
-
-
 /////////////////////////////////////////////////////////////////////////////////////////////
 // The following was grabbed from WTF/wtf/Compiler.h (where WTF was replaced by NATRON)
 // see https://trac.webkit.org/browser/webkit/trunk/Source/WTF/wtf/Compiler.h?format=txt
 /////////////////////////////////////////////////////////////////////////////////////////////
 
 /* COMPILER() - the compiler being used to build the project */
-#define COMPILER(NATRON_FEATURE) (defined NATRON_COMPILER_ ## NATRON_FEATURE && NATRON_COMPILER_ ## NATRON_FEATURE)
+#define COMPILER(NATRON_FEATURE) (NATRON_COMPILER_ ## NATRON_FEATURE)
 
 /* COMPILER_SUPPORTS() - whether the compiler being used to build the project supports the given feature. */
-#define COMPILER_SUPPORTS(NATRON_COMPILER_FEATURE) (defined NATRON_COMPILER_SUPPORTS_ ## NATRON_COMPILER_FEATURE && NATRON_COMPILER_SUPPORTS_ ## NATRON_COMPILER_FEATURE)
+#define COMPILER_SUPPORTS(NATRON_COMPILER_FEATURE) (NATRON_COMPILER_SUPPORTS_ ## NATRON_COMPILER_FEATURE)
 
 /* COMPILER_QUIRK() - whether the compiler being used to build the project requires a given quirk. */
-#define COMPILER_QUIRK(NATRON_COMPILER_QUIRK) (defined NATRON_COMPILER_QUIRK_ ## NATRON_COMPILER_QUIRK && NATRON_COMPILER_QUIRK_ ## NATRON_COMPILER_QUIRK)
+#define COMPILER_QUIRK(NATRON_COMPILER_QUIRK) (NATRON_COMPILER_QUIRK_ ## NATRON_COMPILER_QUIRK)
 
 /* COMPILER_HAS_CLANG_HEATURE() - whether the compiler supports a particular language or library feature. */
 /* http://clang.llvm.org/docs/LanguageExtensions.html#has-feature-and-has-extension */


### PR DESCRIPTION

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

This change fixes the tons of compiler warnings caused by using "defined" in the COMPILER() and COMPILER_XX() macros. I simply removed the defined expression since it isn't necessary. If the preprocessor macro is not defined, it is given a value of 0 which will return the same result as the (defined(X) && (X)) expressions used in these macros.

https://stackoverflow.com/questions/5085392/what-is-the-value-of-an-undefined-constant-used-in-if

**Have you tested your changes (if applicable)? If so, how?**

Yes. Built the code on Windows and Linux and didn't notice any change in behavior other than a lot less compiler warning messages. ;)

