### PR TITLE
Fix Windows build.

### DIFF
--- a/tools/jenkins/build-natron.sh
+++ b/tools/jenkins/build-natron.sh
@@ -155,12 +155,14 @@ echo "========================================================================"
 # Generate pyside bindings (cmake can generate these, qmake can't)
 if [ "$QT_VERSION_MAJOR" = 5 ]; then
     UNIX_PYTHON_HOME="${PYTHON_HOME}"
+    UNIX_SDK_HOME="${SDK_HOME}"
     case "$system" in
     Linux)
 
         ;;
     Msys|MINGW64_NT-*|MINGW32_NT-*)
         UNIX_PYTHON_HOME="$(cygpath -u "${PYTHON_HOME}")"
+        UNIX_SDK_HOME="$(cygpath -u "${SDK_HOME}")"
         ;;
     Darwin)
         # Check for a missing link in the MacPorts package
@@ -171,8 +173,8 @@ if [ "$QT_VERSION_MAJOR" = 5 ]; then
     esac
 
     rm Engine/Qt${QT_VERSION_MAJOR}/NatronEngine/* Gui/Qt${QT_VERSION_MAJOR}/NatronGui/* || true
-    SHIBOKEN_INCLUDE_PATHS=".:./Engine:./Global:libs/OpenFX/include:${SDK_HOME}/include:${QTDIR}/include:${UNIX_PYTHON_HOME}/include/python${PYVER}:${UNIX_PYTHON_HOME}/include/PySide2:${PYTHON_HOME}/lib/python${PYVER}/site-packages/PySide2/include"
-    SHIBOKEN_TYPESYSTEM_PATHS="${UNIX_PYTHON_HOME}/share/PySide2/typesystems:${PYTHON_HOME}/lib/python${PYVER}/site-packages/PySide2/typesystems"
+    SHIBOKEN_INCLUDE_PATHS=".:./Engine:./Global:libs/OpenFX/include:${UNIX_SDK_HOME}/include:${QTDIR}/include:${UNIX_PYTHON_HOME}/include/python${PYVER}:${UNIX_PYTHON_HOME}/include/PySide2:${UNIX_PYTHON_HOME}/lib/python${PYVER}/site-packages/PySide2/include"
+    SHIBOKEN_TYPESYSTEM_PATHS="${UNIX_PYTHON_HOME}/share/PySide2/typesystems:${UNIX_PYTHON_HOME}/lib/python${PYVER}/site-packages/PySide2/typesystems"
     shiboken2 --avoid-protected-hack --enable-pyside-extensions --include-paths=${SHIBOKEN_INCLUDE_PATHS} --typesystem-paths=${SHIBOKEN_TYPESYSTEM_PATHS} --output-directory=Engine/Qt${QT_VERSION_MAJOR} Engine/Pyside2_Engine_Python.h  Engine/typesystem_engine.xml
 
     shiboken2 --avoid-protected-hack --enable-pyside-extensions --include-paths=${SHIBOKEN_INCLUDE_PATHS}:${QTDIR}/include/QtWidgets:${QTDIR}/include/QtCore --typesystem-paths=${SHIBOKEN_TYPESYSTEM_PATHS}:./Engine:./Shiboken --output-directory=Gui/Qt${QT_VERSION_MAJOR} Gui/Pyside2_Gui_Python.h  Gui/typesystem_natronGui.xml

--- a/tools/jenkins/genDllVersions.sh
+++ b/tools/jenkins/genDllVersions.sh
@@ -245,7 +245,6 @@ catDll libbrotlienc
 catDll libssl-3-
 catDll libcrypto-3-
 catDll libzstd
-catDll libssp-
 
 catDll libSeExpr
 catDll libyaml-cpp


### PR DESCRIPTION

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Recent changes to build-natron.sh, that fix the Mac build, broke the Windows build. This change fixes the Windows build by using a unix version of the SDK_HOME just like PYTHON_HOME. The issue is that both of these paths have drive letters in them which cause problems with the ':' path delimiter used by shiboken2. Using unix paths avoid the unwanted ':'s from the windows paths.

The genDllVersions.sh change simply removes a DLL that is no longer needed. Updating my MSYS2 installation to the latest packages caused this DLL to no longer exist.

**Have you tested your changes (if applicable)? If so, how?**

Yes. Built a Windows installer with these changes.
