### PR TITLE
Fix libsox MinGW package

### DIFF
--- a/tools/MINGW-packages/mingw-w64-sox/PKGBUILD
+++ b/tools/MINGW-packages/mingw-w64-sox/PKGBUILD
@@ -14,8 +14,18 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              #"${MINGW_PACKAGE_PREFIX}-cmake"
              )
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-libmad")
-source=("https://downloads.sourceforge.net/sourceforge/${_realname}/${_realname}-$pkgver.tar.bz2")
-sha256sums=('81a6956d4330e75b5827316e44ae381e6f1e8928003c6aa45896da9041ea149c')
+source=("https://downloads.sourceforge.net/sourceforge/${_realname}/${_realname}-$pkgver.tar.bz2"
+        "remove-libssp-detection.patch")
+sha256sums=('81a6956d4330e75b5827316e44ae381e6f1e8928003c6aa45896da9041ea149c'
+            '57d8fe423a97b554d4f34a9952a9827974ecc5f706ac602c4dd77d32bae2afd6')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+
+  patch -Np1 -i "${srcdir}/remove-libssp-detection.patch"
+
+  autoreconf -fiv
+}
 
 build() {
   [[ -d "build-${MINGW_CHOST}" ]] && rm -rf "build-${MINGW_CHOST}"

--- a/tools/MINGW-packages/mingw-w64-sox/remove-libssp-detection.patch
+++ b/tools/MINGW-packages/mingw-w64-sox/remove-libssp-detection.patch
@@ -1,0 +1,12 @@
+diff -ur a/configure.ac b/configure.ac
+--- a/configure.ac	2023-05-24 12:03:25.035127900 -0700
++++ b/configure.ac	2023-05-24 13:30:49.809646400 -0700
+@@ -114,7 +114,7 @@
+     # break here)
+ 
+     # Get -lssp if it exists
+-    GCC_STACK_PROTECT_LIB
++    #GCC_STACK_PROTECT_LIB
+ 
+     AC_MSG_CHECKING([whether stack-smashing protection is available])
+     ssp_old_cflags="$CFLAGS"


### PR DESCRIPTION

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

[Recent changes in MinGW](https://github.com/msys2/MINGW-packages/commit/94387bf65577e9ea53dc6031fb77b28a0d42e42e) caused the libssp DLL to no longer exist. This change caused the libsox build to fail to generate a shared library. Without the libsox DLL, the openfx-arena plugin build fails. This change removes a line from the configure script that tries to detect libssp. This fixes the libsox package build so it builds static and shared libraries again.

**Have you tested your changes (if applicable)? If so, how?**

Yes. With this change I am able to build the openfx-arena plugin and the Natron installer again.

