### PR TITLE
Add autotools to sox makedepends

### DIFF
--- a/.github/workflows/build_pacman_repo.yml
+++ b/.github/workflows/build_pacman_repo.yml
@@ -2,6 +2,10 @@ name: Build pacman repo
 
 on:
   workflow_dispatch: {}
+  pull_request:
+    paths:
+      - 'tools/MINGW-packages/**'
+      - '.github/workflows/build_pacman_repo.yml'
   push:
     paths:
       - 'tools/MINGW-packages/**'

--- a/.github/workflows/build_pacman_repo.yml
+++ b/.github/workflows/build_pacman_repo.yml
@@ -3,9 +3,6 @@ name: Build pacman repo
 on:
   workflow_dispatch: {}
   push:
-    branches:
-      - 'main'
-      - 'build_natron_packages'
     paths:
       - 'tools/MINGW-packages/**'
       - '.github/workflows/build_pacman_repo.yml'

--- a/tools/MINGW-packages/mingw-w64-sox/PKGBUILD
+++ b/tools/MINGW-packages/mingw-w64-sox/PKGBUILD
@@ -11,7 +11,7 @@ url="https://sourceforge.net/projects/sox"
 license=("LGPL")
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
-             #"${MINGW_PACKAGE_PREFIX}-cmake"
+             "${MINGW_PACKAGE_PREFIX}-autotools"
              )
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs" "${MINGW_PACKAGE_PREFIX}-libmad")
 source=("https://downloads.sourceforge.net/sourceforge/${_realname}/${_realname}-$pkgver.tar.bz2"


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

- Adding autotools to sox makedepends to fix build_pacman_repo action failure.

- Removed branch constraints on build_pacman_repo action so that it will run when changes are made to files in tools/MINGW-packages directory. This should make detecting failures in the MINGW package builds easier.

**Have you tested your changes (if applicable)? If so, how?**
Yes. The build_pacman_repo  action ran successfully when I uploaded this change in my repo (https://github.com/acolwell/Natron/actions/runs/5231120859) . This pull request should also trigger the action to run in the Natron repo.

