### PR TITLE
Update Windows OpenImageIO to 2.4.13.0 release and fix shutdown.

### DIFF
--- a/tools/MINGW-packages/mingw-w64-openimageio/PKGBUILD
+++ b/tools/MINGW-packages/mingw-w64-openimageio/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=openimageio
 pkgbase=mingw-w64-natron_${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-natron_${_realname}"
-pkgver=2.4.10.0
+pkgver=2.4.13.0
 pkgrel=99.1
 pkgdesc="A library for reading and writing images, including classes, utilities, and applications (mingw-w64)"
 arch=('any')
@@ -33,12 +33,14 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/OpenImageIO/oiio/archi
         oiio-2.1.10-boost.diff
         oiio-2.0.8-invalidatespec.patch
         oiio-2.2.14-libraw.diff
+        oiio-2.4.13.0-thread-shutdown.patch # Remove when updating to a future 2.5 release that has these changes.
        )
-sha256sums=('59f523a0b9a1014993bedcf7752993af43b348761165f52ea6eb84787f57aed5'
+sha256sums=('72b7d2d5edd1049bb7fc09becad4d8be64a9918cdf79bae98b4b32e1fda762cd'
             'SKIP'
             'e8aec185fd20a6e5cdf77a7155fcaedb301c07bd806f73bd30dfc75af721ac83'
             'd9c2e066ce0e94404d31fd649341cc0ee03faf9b4023dfcdf5cf59fbbf466127'
             '89e21326d6445304293bcedc3a52bfa1dfec9b769b397f6a312ca27d1de93423'
+            '3847eba62ac7a689c4c70b814461583d9c6e921259dd0343b17509d8b35d6f0f'
            )
 
 prepare() {
@@ -46,6 +48,7 @@ prepare() {
   #patch -p0 -i ${srcdir}/oiio-2.1.10-boost.diff
   patch -p1 -i ${srcdir}/oiio-2.0.8-invalidatespec.patch
   patch -p0 -i ${srcdir}/oiio-2.2.14-libraw.diff
+  patch -p1 -i ${srcdir}/oiio-2.4.13.0-thread-shutdown.patch
 }
 
 build() {

--- a/tools/MINGW-packages/mingw-w64-openimageio/oiio-2.4.13.0-thread-shutdown.patch
+++ b/tools/MINGW-packages/mingw-w64-openimageio/oiio-2.4.13.0-thread-shutdown.patch
@@ -1,0 +1,157 @@
+diff --git a/src/include/OpenImageIO/thread.h b/src/include/OpenImageIO/thread.h
+index fa66f06de..c6f1b6c38 100644
+--- a/src/include/OpenImageIO/thread.h
++++ b/src/include/OpenImageIO/thread.h
+@@ -31,6 +31,7 @@
+ #include <OpenImageIO/platform.h>
+ 
+ 
++#define NATRON_OIIO_HAS_DEFAULT_THREAD_POOL_SHUTDOWN 1
+ 
+ // OIIO_THREAD_ALLOW_DCLP, if set to 0, prevents us from using a dodgy
+ // "double checked lock pattern" (DCLP).  We are very careful to construct
+@@ -112,11 +113,19 @@ pause(int delay) noexcept
+ 
+ #elif defined(_MSC_VER)
+     for (int i = 0; i < delay; ++i) {
+-#    if defined(_WIN64)
+-        YieldProcessor();
+-#    else
++        // A reimplementation of winnt.h YieldProcessor,
++        // to avoid including windows headers.
++        #if defined(_M_AMD64)
++        _mm_pause();
++        #elif defined(_M_ARM64) || defined(_M_HYBRID_X86_ARM64)
++        __dmb(_ARM64_BARRIER_ISHST);
++        __yield();
++        #elif defined(_M_ARM)
++        __dmb(_ARM_BARRIER_ISHST);
++        __yield();
++        #else
+         _asm pause
+-#    endif /* _WIN64 */
++        #endif
+     }
+ 
+ #else
+@@ -762,10 +771,18 @@ private:
+ 
+ 
+ /// Return a reference to the "default" shared thread pool. In almost all
+-/// ordinary circumstances, you should use this exclusively to get a
+-/// single shared thread pool, since creating multiple thread pools
+-/// could result in hilariously over-threading your application.
+-OIIO_UTIL_API thread_pool* default_thread_pool ();
++/// ordinary circumstances, you should use this exclusively to get a single
++/// shared thread pool, since creating multiple thread pools could result in
++/// hilariously over-threading your application. Note that this call may
++/// (safely, and only once) trigger creation of the thread pool and its
++/// worker threads if it has not yet been created.
++OIIO_UTIL_API thread_pool* default_thread_pool();
++
++/// If a thread pool has been created, this call will safely terminate its
++/// worker threads. This should presumably be called by an application
++/// immediately before it exists, when it is confident the thread pool will
++/// no longer be needed.
++OIIO_UTIL_API void default_thread_pool_shutdown();
+ 
+ 
+ 
+diff --git a/src/libutil/thread.cpp b/src/libutil/thread.cpp
+index 234e4ceb5..84ce66d32 100644
+--- a/src/libutil/thread.cpp
++++ b/src/libutil/thread.cpp
+@@ -35,6 +35,13 @@
+ 
+ #include <boost/container/flat_map.hpp>
+ 
++#ifdef _WIN32
++#    define WIN32_LEAN_AND_MEAN
++#    define VC_EXTRALEAN
++#    define NOMINMAX
++#    include <windows.h>
++#endif
++
+ #if 0
+ 
+ // Use boost::lockfree::queue for the task queue
+@@ -151,10 +158,10 @@ public:
+                     this->set_thread(i);
+                 }
+             } else {  // the number of threads is decreased
++                std::vector<std::unique_ptr<std::thread>> terminating_threads;
+                 for (int i = oldNThreads - 1; i >= nThreads; --i) {
+                     *this->flags[i] = true;  // this thread will finish
+-                    this->terminating_threads.push_back(
+-                        std::move(this->threads[i]));
++                    terminating_threads.push_back(std::move(this->threads[i]));
+                     this->threads.erase(this->threads.begin() + i);
+                 }
+                 {
+@@ -162,6 +169,11 @@ public:
+                     std::unique_lock<std::mutex> lock(this->mutex);
+                     this->cv.notify_all();
+                 }
++                // wait for the terminated threads to finish
++                for (auto& thread : terminating_threads) {
++                    if (thread->joinable())
++                        thread->join();
++                }
+                 this->threads.resize(
+                     nThreads);  // safe to delete because the threads are detached
+                 this->flags.resize(
+@@ -238,16 +250,10 @@ public:
+             if (thread->joinable())
+                 thread->join();
+         }
+-        // wait for the terminated threads to finish
+-        for (auto& thread : this->terminating_threads) {
+-            if (thread->joinable())
+-                thread->join();
+-        }
+         // if there were no threads in the pool but some functors in the queue, the functors are not deleted by the threads
+         // therefore delete them here
+         this->clear_queue();
+         this->threads.clear();
+-        this->terminating_threads.clear();
+         this->flags.clear();
+     }
+ 
+@@ -349,7 +355,6 @@ private:
+     }
+ 
+     std::vector<std::unique_ptr<std::thread>> threads;
+-    std::vector<std::unique_ptr<std::thread>> terminating_threads;
+     std::vector<std::shared_ptr<std::atomic<bool>>> flags;
+     mutable pvt::ThreadsafeQueue<std::function<void(int id)>*> q;
+     std::atomic<bool> isDone;
+@@ -471,15 +476,29 @@ thread_pool::very_busy() const
+ 
+ 
+ 
++static atomic_int default_thread_pool_created(0);
++
++
++
+ thread_pool*
+ default_thread_pool()
+ {
+     static std::unique_ptr<thread_pool> shared_pool(new thread_pool);
++    default_thread_pool_created = 1;
+     return shared_pool.get();
+ }
+ 
+ 
+ 
++void
++default_thread_pool_shutdown()
++{
++    if (default_thread_pool_created)
++        default_thread_pool()->resize(0);
++}
++
++
++
+ void
+ task_set::wait_for_task(size_t taskindex, bool block)
+ {


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

- Updating MinGW package to use latest stable OpenImageIO version.
- Backport some recent fixes on master for threading that should fix the shutdown hangs we see on Windows.
- Added NATRON_OIIO_HAS_DEFAULT_THREAD_POOL_SHUTDOWN define so code can detect this patched version and use default_thread_pool_shutdown().

**Have you tested your changes (if applicable)? If so, how?**

Yes. I've built the MinGW package locally and the [Build build_pacman_repo GitHub action](https://github.com/acolwell/Natron/actions/runs/5437343300) also successfully built this package. I then the built openfx-io plugins, on Windows, with this new version of OpenImageIO and repeatedly ran the Natron unit tests with this plugin under high CPU load. With the old OpenImageIO, this scenario would reliably cause the unit tests to hang within 20-30 runs. With this new package, I was unable to get the unit tests to hang after several hundred runs of the unit tests. This gives me strong confidence that these changes fix our Windows shutdown problems. 


**Futher details of this pull request**

The thread changes on OpenImageIO master are slated to be included in the next 2.5 release (i.e. 2.5.3), but 2.5 tags are just dev builds right now. If I understand their release process correctly, 2.5 won't have stable releases until sometime this fall. Given that the changes are relatively isolated and easy to understand I thought it would be useful to backport them to the latest stable release. This helps fix a persistent hanging problem on Windows and will make it easier to roll out continuous integration and testing for Windows. This seemed worth the minor inconvenience of having to maintain our own patch for a few months.  https://github.com/NatronGitHub/openfx-io/pull/35 contains the changes to openfx-io while testing.