### PR TITLE
Fix bugs and add support for UNC paths on Windows.

### DIFF
--- a/Engine/FileSystemModel.h
+++ b/Engine/FileSystemModel.h
@@ -236,6 +236,8 @@ public:
 
     static bool isDriveName(const QString& name);
     static bool startsWithDriveName(const QString& name);
+    static QStringList getSplitPath(const QString& path);
+    static QString cleanPath(const QString& path);
     virtual QVariant headerData(int section, Qt::Orientation orientation, int role) const OVERRIDE FINAL WARN_UNUSED_RETURN;
     virtual Qt::ItemFlags flags(const QModelIndex &index) const OVERRIDE FINAL WARN_UNUSED_RETURN;
     virtual int columnCount(const QModelIndex & parent) const OVERRIDE FINAL WARN_UNUSED_RETURN;
@@ -270,8 +272,6 @@ public:
      * has gathered all info.
      **/
     bool setRootPath(const QString& path);
-
-    QVariant myComputer(int role = Qt::DisplayRole) const WARN_UNUSED_RETURN;
 
     void setFilter(const QDir::Filters& filters);
 

--- a/Gui/SequenceFileDialog.h
+++ b/Gui/SequenceFileDialog.h
@@ -120,11 +120,11 @@ private:
     void changed(const QString &path);
     void addIndexToWatch(const QString &path, const QModelIndex &index);
 
-    QString mapUrlToDisplayName(const QString& originalName);
+    QString mapPathToDisplayName(const QString& originalName);
 
     QFileSystemModel *fileSystemModel;
     std::vector<std::pair<QModelIndex, QString> > watching;
-    std::vector<QUrl> invalidUrls;
+    std::set<QUrl> invalidUrls;
     std::map<std::string, std::string> envVars;
 };
 
@@ -542,6 +542,8 @@ private:
 
     void getSequenceFromFilesForFole(const QString & file, SequenceParsing::SequenceFromFiles* sequence) const;
 
+    void updateFileExtensionCombo(const QString& extension);
+
 private:
     // FIXME: PIMPL
 
@@ -565,7 +567,6 @@ private:
     Button* _openButton;
     Button* _cancelButton;
     Button* _addFavoriteButton;
-    Button* _editFavoriteButton;
     Button* _removeFavoriteButton;
     FileDialogLineEdit* _selectionLineEdit;
     Label* _relativeLabel;

--- a/Gui/SequenceFileDialog.h
+++ b/Gui/SequenceFileDialog.h
@@ -543,6 +543,7 @@ private:
     void getSequenceFromFilesForFole(const QString & file, SequenceParsing::SequenceFromFiles* sequence) const;
 
     void updateFileExtensionCombo(const QString& extension);
+    void updateUpButton(const QString &newPath);
 
 private:
     // FIXME: PIMPL

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -22,14 +22,14 @@ set(Tests_SOURCES
     google-test/src/gtest-all.cc
     google-mock/src/gmock-all.cc
     BaseTest.cpp
+    Curve_Test.cpp
+    FileSystemModel_Test.cpp
     Hash64_Test.cpp
     Image_Test.cpp
+    KnobFile_Test.cpp
     Lut_Test.cpp
     OSGLContext_Test.cpp
-    KnobFile_Test.cpp
-    Curve_Test.cpp
     Tracker_Test.cpp
-    OSGLContext_Test.cpp
     wmain.cpp
 )
 add_executable(Tests ${Tests_HEADERS} ${Tests_SOURCES})

--- a/Tests/FileSystemModel_Test.cpp
+++ b/Tests/FileSystemModel_Test.cpp
@@ -1,0 +1,248 @@
+/* ***** BEGIN LICENSE BLOCK *****
+ * This file is part of Natron <https://natrongithub.github.io/>,
+ * (C) 2018-2023 The Natron developers
+ * (C) 2013-2018 INRIA and Alexandre Gauthier-Foichat
+ *
+ * Natron is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Natron is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Natron.  If not, see <http://www.gnu.org/licenses/gpl-2.0.html>
+ * ***** END LICENSE BLOCK ***** */
+
+#include "Global/Macros.h"
+
+#include <gtest/gtest.h>
+
+#include "Engine/FileSystemModel.h"
+
+NATRON_NAMESPACE_USING
+
+namespace {
+
+class MockSortableView : public SortableViewI {
+ public:
+  MockSortableView() = default;
+  ~MockSortableView() override {}
+
+  // SortableViewI methods
+  Qt::SortOrder sortIndicatorOrder() const override { return _sortOrder; }
+
+  int sortIndicatorSection() const override { return _sortSection; }
+
+  void onSortIndicatorChanged(int logicalIndex, Qt::SortOrder order) override {
+    _sortSection = logicalIndex;
+    _sortOrder = order;
+  }
+
+ private:
+  int _sortSection = 0;
+  Qt::SortOrder _sortOrder = Qt::AscendingOrder;
+};
+
+}  // namespace
+
+TEST(FileSystemModelTest, DriveName) {
+  MockSortableView sortableView;
+  auto model = std::make_shared<FileSystemModel>();
+  model->initialize(&sortableView);
+
+  struct DriveNameTestCase {
+    const char* input;
+    bool isWindowsDriveName;
+    bool startsWithWindowsDriveName;
+    bool isUnixDriveName;
+    bool startsWithUnixDriveName;
+  };
+  std::vector<DriveNameTestCase> testCases({
+      {"", false, false, false, false},
+      {"filename.txt", false, false, false, false},
+      {"somedir/", false, false, false, false},
+      {"somedir/filename.txt", false, false, false, false},
+      {"/", false, false, true, true},
+      {"/filename.txt", false, false, false, true},
+      {"/somedir/", false, false, false, true},
+      {"/somedir/filename.txt", false, false, false, true},
+      {"c:", false, false, false, false},
+      {"c:/", true, true, false, false},
+      {"c:\\", true, true, false, false},
+      {"c:/filename.txt", false, true, false, false},
+      {"c:\\filename.txt", false, true, false, false},
+      {"c:/somedir/", false, true, false, false},
+      {"c:/somedir/filename.txt", false, true, false, false},
+      {"c:\\somedir\\", false, true, false, false},
+      {"c:\\somedir\\filename.txt", false, true, false, false},
+      {"//", false, false, false, true},
+      {"//somehost", false, false, false, true},
+      {"//somehost/", false, false, false, true},
+      {"//somehost/somedir/", false, false, false, true},
+      {"//somehost/somedir/filename.txt", false, false, false, true},
+  });
+
+  for (const auto& testCase : testCases) {
+    const QString input = QString::fromUtf8(testCase.input);
+#ifdef __NATRON_WIN32__
+    const bool expectedIsDriveName = testCase.isWindowsDriveName;
+    const bool expectedStartsWithDriveName =
+        testCase.startsWithWindowsDriveName;
+#else
+    const bool expectedIsDriveName = testCase.isUnixDriveName;
+    const bool expectedStartsWithDriveName = testCase.startsWithUnixDriveName;
+#endif
+
+    EXPECT_EQ(expectedIsDriveName, FileSystemModel::isDriveName(input))
+        << " input '" << testCase.input << "'";
+    EXPECT_EQ(expectedStartsWithDriveName,
+              FileSystemModel::startsWithDriveName(input))
+        << " input '" << testCase.input << "'";
+  }
+}
+
+TEST(FileSystemModelTest, GetSplitPath) {
+  MockSortableView sortableView;
+  auto model = std::make_shared<FileSystemModel>();
+  model->initialize(&sortableView);
+
+  struct SplitPathTestCase {
+    const char* input;
+    std::vector<const char*> expectedWindowsOutput;
+    std::vector<const char*> expectedUnixOutput;
+  };
+  std::vector<SplitPathTestCase> testCases({
+      {"", {}, {}},
+      {"filename.txt", {"filename.txt"}, {"filename.txt"}},
+      {"somedir/", {"somedir"}, {"somedir"}},
+      {"somedir/filename.txt",
+       {"somedir", "filename.txt"},
+       {"somedir", "filename.txt"}},
+      {"/", {""}, {"/", ""}},
+      {"/filename.txt", {"", "filename.txt"}, {"/", "filename.txt"}},
+      {"/somedir/", {"", "somedir"}, {"/", "somedir"}},
+      {"/somedir/filename.txt",
+       {"", "somedir", "filename.txt"},
+       {"/", "somedir", "filename.txt"}},
+      {"c:", {"c:"}, {"c:"}},
+      {"c:/", {"c:/", ""}, {"c:"}},
+      {"c:\\", {"c:\\", ""}, {"c:\\"}},
+      {"c:/filename.txt", {"c:/", "filename.txt"}, {"c:", "filename.txt"}},
+      {"c:\\filename.txt", {"c:\\", "filename.txt"}, {"c:\\filename.txt"}},
+      {"c:/somedir/", {"c:/", "somedir"}, {"c:", "somedir"}},
+      {"c:/somedir/filename.txt",
+       {"c:/", "somedir", "filename.txt"},
+       {"c:", "somedir", "filename.txt"}},
+      {"c:\\somedir\\", {"c:\\", "somedir\\"}, {"c:\\somedir\\"}},
+      {"c:\\somedir\\filename.txt",
+       {"c:\\", "somedir\\filename.txt"},
+       {"c:\\somedir\\filename.txt"}},
+      {"//", {"", ""}, {"/", ""}},
+      {"//somehost",
+       {"", "", "somehost"},  // Not considered a network path because
+                              // of missing slash after hostname.
+       {"/", "", "somehost"}},
+      {"//somehost/", {"", "", "somehost"}, {"/", "", "somehost"}},
+      {"//somehost/somedir/",
+       {"", "", "somehost", "somedir"},
+       {"/", "", "somehost", "somedir"}},
+      {"//somehost/somedir/filename.txt",
+       {"", "", "somehost", "somedir", "filename.txt"},
+       {"/", "", "somehost", "somedir", "filename.txt"}},
+  });
+
+  for (const auto& testCase : testCases) {
+    const QString input = QString::fromUtf8(testCase.input);
+
+#ifdef __NATRON_WIN32__
+    const auto& expectedOutput = testCase.expectedWindowsOutput;
+#else
+    const auto& expectedOutput = testCase.expectedUnixOutput;
+#endif
+
+    const int expectedSize = static_cast<int>(expectedOutput.size());
+    const auto output = FileSystemModel::getSplitPath(input);
+    EXPECT_EQ(expectedSize, output.size()) << "input '" << testCase.input
+                                           << "'";
+
+    for (int i = 0; i < expectedSize && i < output.size(); ++i) {
+      EXPECT_EQ(expectedOutput[i], output[i].toStdString())
+          << "input '" << testCase.input << "' i " << i;
+    }
+  }
+}
+
+TEST(FileSystemModelTest, CleanPath) {
+  MockSortableView sortableView;
+  auto model = std::make_shared<FileSystemModel>();
+  model->initialize(&sortableView);
+
+  struct CleanPathTestCase {
+    const char* input;
+    const char* expectedWindowsOutput;  // nullptr if the expectation is the
+                                        // same as input.
+    const char* expectedUnixOutput;  // nullptr if the expectation is the same
+                                     // as expectedWindowsOutput.
+  };
+
+  std::vector<CleanPathTestCase> testCases({
+      // Paths that behave the same on all platforms.
+      // - Verify trailing slashes are removed.
+      {"", nullptr, nullptr},
+      {"filename.txt", nullptr, nullptr},
+      {"somedir/", "somedir", nullptr},
+      {"somedir/filename.txt", nullptr, nullptr},
+      {"/", nullptr, nullptr},
+      {"/filename.txt", nullptr, nullptr},
+      {"/somedir/", "/somedir", nullptr},
+      {"/somedir/filename.txt", nullptr, nullptr},
+      {"c:", nullptr, nullptr},
+      // Platform specific path behaviors.
+      {"c:/", "c:/", "c:"},
+      {"c:\\", "c:/", "c:\\"},
+      {"c:/filename.txt", "c:/filename.txt", "c:/filename.txt"},
+      {"c:\\filename.txt", "c:/filename.txt", "c:\\filename.txt"},
+      {"c:/somedir/", "c:/somedir", nullptr},
+      {"c:/somedir/filename.txt", "c:/somedir/filename.txt", nullptr},
+      {"c:\\somedir\\", "c:/somedir", "c:\\somedir\\"},
+      {"c:\\somedir\\filename.txt", "c:/somedir/filename.txt",
+       "c:\\somedir\\filename.txt"},
+      {"//", "/", nullptr},
+      {"//somehost", "//somehost", "/somehost"},
+      {"//somehost/", "//somehost", "/somehost"},
+      {"//somehost/somedir/", "//somehost/somedir", "/somehost/somedir"},
+      {"//somehost/somedir/filename.txt",
+        "//somehost/somedir/filename.txt",
+        "/somehost/somedir/filename.txt"},
+  });
+
+  for (const auto& testCase : testCases) {
+    const QString input = QString::fromUtf8(testCase.input);
+    std::string expectedOutput;
+
+#ifdef __NATRON_WIN32__
+    if (testCase.expectedWindowsOutput != nullptr) {
+      expectedOutput = testCase.expectedWindowsOutput;
+    } else {
+      expectedOutput = testCase.input;
+    }
+#else
+    if (testCase.expectedUnixOutput != nullptr) {
+      expectedOutput = testCase.expectedUnixOutput;
+    } else if (testCase.expectedWindowsOutput != nullptr) {
+      expectedOutput = testCase.expectedWindowsOutput;
+    } else {
+      expectedOutput = testCase.input;
+    }
+#endif
+    // Make sure the expectation was actually set to something.
+    assert(!expectedOutput.isNull());
+
+    const auto output = FileSystemModel::cleanPath(input).toStdString();
+    EXPECT_EQ(expectedOutput, output) << " input '" << testCase.input << "'";
+  }
+}

--- a/Tests/Tests.pro
+++ b/Tests/Tests.pro
@@ -44,13 +44,14 @@ SOURCES += \
     google-test/src/gtest-all.cc \
     google-mock/src/gmock-all.cc \
     BaseTest.cpp \
+    Curve_Test.cpp \
+    FileSystemModel_Test.cpp \
     Hash64_Test.cpp \
     Image_Test.cpp \
-    Lut_Test.cpp \
     KnobFile_Test.cpp \
-    Curve_Test.cpp \
-    Tracker_Test.cpp \
+    Lut_Test.cpp \
     OSGLContext_Test.cpp \
+    Tracker_Test.cpp \
     wmain.cpp
 
 HEADERS += \


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

This pull request fixes a variety of issues with network share paths on Windows in the file dialogs. (#896 )

The change is split into 2 pieces. The first commit mainly just cleans up the code a little bit by introducing some helper functions, removing duplicate code, and introducing unit tests for key FileSystemModel functionality related to paths.  No major behavior changes are in this commit. It is mainly just moving stuff around and trying to make the code a little more consistent and readable.

The second commit contains the bug fixes and new logic to support network paths on Windows. It fixes the major issues with navigating network shares and should address all the issues mentioned in (#896). 


**Have you tested your changes (if applicable)? If so, how?**

Yes. I created unit tests to verify the key path manipulation functionality in FileSystemModel. I also built a Windows version of Natron locally and did a bunch of manual tests on the file dialog with network shares. The behavior is MUCH better than it was and the network shares essentially behave just like drives.
