### PR TITLE
Fix CI GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,8 @@ jobs:
           cd build
 
           mkdir Plugins && cd Plugins
-          wget https://github.com/acolwell/openfx-io/releases/download/natron_testing/IO.ofx.bundle_${MATRIX_OS}.tar.gz
-          tar xvf IO.ofx.bundle_${MATRIX_OS}.tar.gz
+          wget https://github.com/NatronGitHub/openfx-io/releases/download/natron_testing/openfx-io-build-ubuntu_22-testing.zip
+          unzip openfx-io-build-ubuntu_22-testing.zip
           cd ..
 
           OFX_PLUGIN_PATH=$PWD/Plugins OCIO=$PWD/../OpenColorIO-Configs/blender/config.ocio ctest -V
@@ -149,7 +149,7 @@ jobs:
           cd build
 
           mkdir Plugins && cd Plugins
-          wget https://github.com/acolwell/openfx-io/releases/download/natron_testing/IO.ofx.bundle_${MATRIX_OS}.zip
+          wget https://github.com/NatronGitHub/openfx-io/releases/download/natron_testing/openfx-io-build-windows_latest-testing.zip
           unzip IO.ofx.bundle_${MATRIX_OS}.zip
           cd ..
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
 
           mkdir Plugins && cd Plugins
           wget https://github.com/NatronGitHub/openfx-io/releases/download/natron_testing/openfx-io-build-windows_latest-testing.zip
-          unzip IO.ofx.bundle_${MATRIX_OS}.zip
+          unzip openfx-io-build-windows_latest-testing.zip
           cd ..
 
           PYTHONHOME=/mingw64 OFX_PLUGIN_PATH=$PWD/Plugins OCIO=$PWD/../OpenColorIO-Configs/blender/config.ocio ctest -V

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,23 @@
 name: Tests
 
 on:
+  workflow_dispatch: {}
   push:
     branches:
     - RB-2.5
+    - RB-2.6
+    - fix-ci # For testing. Remove before commit.
     paths-ignore:
       - Documentation
   pull_request:
     branches:
     - RB-2.5
+    - RB-2.6
     paths-ignore:
       - Documentation
 
 jobs:
-  test:
+  unix_test:
     name: Test ${{ matrix.os }} Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     defaults:
@@ -22,60 +26,141 @@ jobs:
     env:
       CI: 'True'
       PYTHON_VERSION: ${{ matrix.python-version }}
-      # PYSIDE2_VERSION: ${{ matrix.pyside2-version }}
-      # PYSIDE2_QT_VERSION: ${{ matrix.pyside2-qt-version }}
+      OCIO_CONFIG_VERSION: 2.5
+      MATRIX_OS: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04] # macos-latest, windows-latest
-        python-version: ['2.7'] # '3.6', '3.9'
+        os: [ubuntu-latest] #macos-latest
+        python-version: ['3.10']
         include:
-        - os: ubuntu-18.04
+        - os: ubuntu-latest
           special-invocation: 'xvfb-run --auto-servernum '
-          python-version: '2.7'
-        #  python-version: '3.6'
-        #  pyside2-version: 5.12.0  # 5.12.1-5.12.6 fails on collection/segfaults on patch test
-        # - os: windows-latest
-        #   python-version: '3.9'
-        #   pyside2-version: 5.15  # No 5.12 wheel on Windows and Python 3.9
-        # - os: macos-latest
-        #   python-version: '2.7'
-        #  python-version: '3.6'
+          python-version: '3.10'
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Install Linux system packages
         if: contains(matrix.os, 'ubuntu')
         shell: bash
         run: |
           sudo apt update
-          sudo apt install libpulse-dev libegl1-mesa libopengl0 gcc-8 g++-8 libqt4-dev libqt4-opengl-dev libglew-dev libexpat1-dev \
-            gdb libcairo2-dev python-dev python-pyside libpyside-dev libshiboken-dev libtinyxml-dev liblcms2-dev libyaml-cpp-dev \
-            libopenjp2-7-dev libtiff-dev libjpeg-dev libpng-dev libwebp-dev libraw-dev libfreetype6-dev libssl-dev libboost-all-dev \
-            python-qtpy
+          sudo apt install build-essential libboost-serialization-dev libboost-system-dev libexpat1-dev libcairo2-dev \
+            qt5-qmake qtbase5-dev qtdeclarative5-dev \
+            python3-dev libshiboken2-dev libpyside2-dev python3-pyside2.qtwidgets python3-qtpy \
+            libwayland-dev libwayland-client0 libwayland-egl1 \
+            extra-cmake-modules clang
       - name: Install Macos system packages
         if: contains(matrix.os, 'macos')
         shell: bash
         run: |
           brew install xctool python@2 boost giflib jpeg libpng libtiff libxml2 openssl pcre readline sqlite expat cairo \
             gnu-sed glew openssl ilmbase openexr freetype fontconfig ffmpeg openjpeg libraw libheif openvdb
-      - name: Build
-        if: always() && !contains(github.ref, 'coverity_scan')
+
+      - name: Download OpenColorIO-Configs
         run: |
-          ./.github/workflows/gen_config.sh
-          ./tools/travis/build.sh
-      - name: Upload coverage data to coveralls.io
-        if: contains(matrix.os, 'ubuntu') && contains(github.ref, 'coverity_scan')
-        shell: bash
-        env:
-          COVERALLS_FLAG_NAME: ${{ matrix.os }} Python ${{ matrix.python-version }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          wget https://github.com/NatronGitHub/OpenColorIO-Configs/archive/Natron-v${OCIO_CONFIG_VERSION}.tar.gz
+          tar xzf Natron-v${OCIO_CONFIG_VERSION}.tar.gz
+          mv OpenColorIO-Configs-Natron-v${OCIO_CONFIG_VERSION} OpenColorIO-Configs
+
+      - name: Build Unix
         run: |
-          ln -s Tests/google-mock Tests/google-test .
-          pushd Tests
-          gcov -lp *.gcno > /dev/null
-          popd ..
-          python -m pip install --upgrade cpp-coveralls
-          python -b -X dev -m cpp-coveralls -n --exclude /usr/include --exclude 'Tests/google-test' --exclude 'Tests/google-mock' \
-            --exclude 'google-test' --exclude 'google-mock' --exclude 'libs/OpenFX' --exclude-pattern '.*/moc_.*\.cpp' \
-            --exclude-pattern='.*/Tests/.*\.cpp' --exclude-pattern='.*/Tests/.*\.h'
+          mkdir build && cd build
+          cmake ../
+          make -j2
+
+      - name: Run Unix Tests
+        id: run-unix-tests
+        # Allow continuing after error so logs can be uploaded.
+        continue-on-error: true
+        run: |
+          cd build
+
+          mkdir Plugins && cd Plugins
+          wget https://github.com/acolwell/openfx-io/releases/download/natron_testing/IO.ofx.bundle_${MATRIX_OS}.tar.gz
+          tar xvf IO.ofx.bundle_${MATRIX_OS}.tar.gz
+          cd ..
+
+          OFX_PLUGIN_PATH=$PWD/Plugins OCIO=$PWD/../OpenColorIO-Configs/blender/config.ocio ctest -V
+
+      - name: Upload ${{ matrix.os }} Test Log artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.os }} Test Logs
+          path: ${{ github.workspace }}/build/Testing/Temporary/LastTest.log
+
+      - name: Check for test failures
+        if: steps.run-unix-tests.outcome == 'failure'
+        run: exit 1
+
+  win-test:
+    name: Test ${{ matrix.os }} Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: msys2 {0}
+    env:
+      CI: 'True'
+      PYTHON_VERSION: ${{ matrix.python-version }}
+      OCIO_CONFIG_VERSION: 2.5
+      MATRIX_OS: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest]
+        python-version: ['3.10']
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Windows system packages
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: mingw64
+          update: true
+          install: git base-devel mingw-w64-x86_64-cc mingw-w64-x86_64-qt5-base mingw-w64-x86_64-pyside2
+            mingw-w64-x86_64-shiboken2 mingw-w64-x86_64-python-qtpy mingw-w64-x86_64-ninja
+            mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-cairo mingw-w64-x86_64-expat
+            mingw-w64-x86_64-wget unzip
+
+      - name: Download OpenColorIO-Configs
+        run: |
+          wget https://github.com/NatronGitHub/OpenColorIO-Configs/archive/Natron-v${OCIO_CONFIG_VERSION}.tar.gz
+          tar xzf Natron-v${OCIO_CONFIG_VERSION}.tar.gz
+          mv OpenColorIO-Configs-Natron-v${OCIO_CONFIG_VERSION} OpenColorIO-Configs
+
+      - name: Build Windows
+        run: |
+          mkdir build && cd build
+          cmake ../
+          ninja
+
+      - name: Run Windows Tests
+        id: run-windows-tests
+        # Allow continuing after error so logs can be uploaded.
+        continue-on-error: true
+        run: |
+          cd build
+
+          mkdir Plugins && cd Plugins
+          wget https://github.com/acolwell/openfx-io/releases/download/natron_testing/IO.ofx.bundle_${MATRIX_OS}.zip
+          unzip IO.ofx.bundle_${MATRIX_OS}.zip
+          cd ..
+
+          PYTHONHOME=/mingw64 OFX_PLUGIN_PATH=$PWD/Plugins OCIO=$PWD/../OpenColorIO-Configs/blender/config.ocio ctest -V
+
+      - name: Upload ${{ matrix.os }} Test Log artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.os }} Test Logs
+          path: ${{ github.workspace }}/build/Testing/Temporary/LastTest.log
+
+      - name: Check for test failures
+        if: steps.run-windows-tests.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

- Fixed Linux so it builds again.
- Added Windows build.
- Made unit tests run on both platforms. These rely on prebuilt, self-contained, openfx-io plugin binaries so that this project's CI action does not have to worry about how to build the plugins or what their dependencies might be.

**Have you tested your changes (if applicable)? If so, how?**

Yes. I've run this updated CI action in my fork (https://github.com/acolwell/Natron/actions/runs/5481256325). It should also run when this pull request is submitted.

**Futher details of this pull request**

This change depends on https://github.com/NatronGitHub/openfx-io/pull/35. Without that patch the Windows build can hang during shutdown and make the CI process unreliable. Currently this action is running against self-contained plugin binaries that contain this pull request. Once https://github.com/NatronGitHub/openfx-io/pull/35 and https://github.com/NatronGitHub/openfx-io/pull/36 are landed, I can change this CI action to point to binaries generated by the official openfx-io CI action.
