### PR TITLE
Fix FFmpeg build buster on Windows.

### DIFF
--- a/tools/MINGW-packages/mingw-w64-ffmpeg-gpl2/PKGBUILD
+++ b/tools/MINGW-packages/mingw-w64-ffmpeg-gpl2/PKGBUILD
@@ -46,11 +46,16 @@ depends=("${MINGW_PACKAGE_PREFIX}-bzip2"
 makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
              "${MINGW_PACKAGE_PREFIX}-pkg-config"
 	     "${MINGW_PACKAGE_PREFIX}-nasm")
-source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz)
-sha256sums=('6c5b6c195e61534766a0b5fe16acc919170c883362612816d0a1c7f4f947006e')
+source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz
+        https://github.com/FFmpeg/FFmpeg/commit/effadce6c756247ea8bae32dc13bb3e6f464f0eb.patch)
+sha256sums=('6c5b6c195e61534766a0b5fe16acc919170c883362612816d0a1c7f4f947006e'
+            '206f4d8437b21f6197ffc444c86d0504892a5c2137cb227b4af1c1e8bf2c426c')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+
+  # https://github.com/msys2/MINGW-packages/issues/17946
+  patch -Nbp1 -i "${srcdir}"/effadce6c756247ea8bae32dc13bb3e6f464f0eb.patch
 }
 
 build() {


### PR DESCRIPTION

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

MinGW started using a newer version of binutils that breaks the ffmpeg build. This change adds the patch that MinGW uses to address this issue in its own FFmpeg package.

**Have you tested your changes (if applicable)? If so, how?**

Yes. I built the ffmpeg package locally and also verified that the "build pacman repo" GitHub Action builds again (https://github.com/acolwell/Natron/actions/runs/5779385803). This action should also build when this pull request is submitted.

