### PR TITLE
Fix MinGW opencolorio package and python zip creation

### DIFF
--- a/tools/MINGW-packages/mingw-w64-opencolorio2-git/Findyaml-cpp.patch
+++ b/tools/MINGW-packages/mingw-w64-opencolorio2-git/Findyaml-cpp.patch
@@ -1,0 +1,22 @@
+diff --git a/share/cmake/modules/Findyaml-cpp.cmake b/share/cmake/modules/Findyaml-cpp.cmake
+index 1dd81055..13f58c54 100644
+--- a/share/cmake/modules/Findyaml-cpp.cmake
++++ b/share/cmake/modules/Findyaml-cpp.cmake
+@@ -34,7 +34,7 @@ if(NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL ALL)
+     endif()
+ 
+     if(yaml-cpp_FOUND)
+-        get_target_property(yaml-cpp_LIBRARY yaml-cpp LOCATION)
++        get_target_property(yaml-cpp_LIBRARY yaml-cpp::yaml-cpp LOCATION)
+     else()
+ 
+         # As yaml-cpp-config.cmake search fails, search an installed library
+@@ -114,7 +114,7 @@ endif()
+ ###############################################################################
+ ### Create target (if previous 'find_package' call hasn't) ###
+ 
+-if(NOT TARGET yaml-cpp)
++if(NOT TARGET yaml-cpp::yaml-cpp)
+     add_library(yaml-cpp UNKNOWN IMPORTED GLOBAL)
+     set(_yaml-cpp_TARGET_CREATE TRUE)
+ endif()

--- a/tools/MINGW-packages/mingw-w64-opencolorio2-git/PKGBUILD
+++ b/tools/MINGW-packages/mingw-w64-opencolorio2-git/PKGBUILD
@@ -26,10 +26,12 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cmake"
 options=('strip')
 source=("${_realname}"::"git+https://github.com/imageworks/OpenColorIO.git#commit=${gitcommit}"
         OpenColorIO.pc
-        ocio-2.1.1.patch)
+        ocio-2.1.1.patch
+        Findyaml-cpp.patch)
 sha256sums=('SKIP'
             '1e825196e03f26f30d426f84c01ad408ab6cbaaae5b7a06faa7571c2733d6936'
-            '8047d94b5b940c9686b2df34f441ff53947877bcdaae82072180d68c9d547138')
+            '8047d94b5b940c9686b2df34f441ff53947877bcdaae82072180d68c9d547138'
+            'bb8a10566c3f105d7e9323bf84f7c943a9085d74660316b354c3b506da880101')
 
 pkgver() {
   cd "${srcdir}/${_realname}"
@@ -39,6 +41,7 @@ pkgver() {
 prepare() {
   cd ${_realname}
   #patch -p1 -i ${srcdir}/ocio-2.1.1.patch
+  patch -p1 -i ${srcdir}/Findyaml-cpp.patch
 }
 
 build() {

--- a/tools/jenkins/zip-python-mingw.sh
+++ b/tools/jenkins/zip-python-mingw.sh
@@ -35,6 +35,7 @@ logging
 msilib
 multiprocessing
 pydoc_data
+re
 sqlite3
 unittest
 urllib


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

This change fixes the MinGW opencolorio package build and fixes the installer python zip script to work with python 3.11.


**Have you tested your changes (if applicable)? If so, how?**

Yes. Built the MinGW packages and installer locally and via GitHub actions.
