### PR TITLE
Fix deprecation warnings for Qt classes.

### DIFF
--- a/Gui/FileTypeMainWindow_win.h
+++ b/Gui/FileTypeMainWindow_win.h
@@ -121,7 +121,7 @@ public:
      * Creates a DocumentWindow with a given @arg parent and @arg flags.
      */
     explicit DocumentWindow(QWidget* parent = 0,
-                            Qt::WindowFlags flags = 0);
+                            Qt::WindowFlags flags = Qt::WindowFlags());
 
     /**
      * Destructor
@@ -230,8 +230,8 @@ protected:
      */
     void registerCommand(const QString& command,
                          const QString& documentId,
-                         const QString cmdLineArg = QString::null,
-                         const QString ddeCommand = QString::null);
+                         const QString cmdLineArg = QString(),
+                         const QString ddeCommand = QString());
 
     /**
      * Call this method to enable the user to open data files associated with your application
@@ -262,7 +262,7 @@ private:
     /**
      * Sets specified value in the registry under HKCU\Software\Classes, which is mapped to HKCR then.
      */
-    bool SetHkcrUserRegKey(QString key, const QString& value, const QString& valueName = QString::null);
+    bool SetHkcrUserRegKey(QString key, const QString& value, const QString& valueName = QString());
 
     /**
      * this method is called to do the DDE command handling. It does argument splitting and then calls


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Fixes deprecation warnings for a few Qt classes. This simply uses default constructors for parameter defaults instead of deprecated constants.

**Have you tested your changes (if applicable)? If so, how?**

Yes. Code builds locally without the deprecation warnings now.

