### PR TITLE
Refactor RectI & RectD methods to simplify code and improve readability.

### DIFF
--- a/Engine/EffectInstance.cpp
+++ b/Engine/EffectInstance.cpp
@@ -655,8 +655,7 @@ EffectInstance::retrieveGetImageDataUponFailure(const double time,
     }
 
     assert( !( (supportsRenderScaleMaybe() == eSupportsNo) && !(scale.x == 1. && scale.y == 1.) ) );
-    RectI pixelRod;
-    rod.toPixelEnclosing(scale, getAspectRatio(-1), &pixelRod);
+    const RectI pixelRod = rod.toPixelEnclosing(scale, getAspectRatio(-1));
     try {
         int identityInputNb;
         double identityTime;
@@ -992,8 +991,7 @@ EffectInstance::getImage(int inputNb,
     }
 
 
-    RectI pixelRoI;
-    roi.toPixelEnclosing(renderScaleOneUpstreamIfRenderScaleSupportDisabled ? 0 : mipMapLevel, par, &pixelRoI);
+    RectI pixelRoI = roi.toPixelEnclosing(renderScaleOneUpstreamIfRenderScaleSupportDisabled ? 0 : mipMapLevel, par);
 
     ImagePtr inputImg;
 
@@ -1115,23 +1113,19 @@ EffectInstance::getImage(int inputNb,
         assert(inputImgMipMapLevel != 0);
         ///Resize the image according to the requested scale
         ImageBitDepthEnum bitdepth = inputImg->getBitDepth();
-        RectI bounds;
-        inputImg->getRoD().toPixelEnclosing(0, par, &bounds);
+        const RectI bounds = inputImg->getRoD().toPixelEnclosing(0, par);
         ImagePtr rescaledImg = std::make_shared<Image>( inputImg->getComponents(), inputImg->getRoD(),
                                                          bounds, 0, par, bitdepth, inputImg->getPremultiplication(), inputImg->getFieldingOrder() );
         inputImg->upscaleMipMap( inputImg->getBounds(), inputImgMipMapLevel, 0, rescaledImg.get() );
         if (roiPixel) {
-            RectD canonicalPixelRoI;
-
             if (!inputRoDSet) {
                 bool isProjectFormat;
                 StatusEnum st = inputEffect->getRegionOfDefinition_public(inputEffect->getRenderHash(), time, scale, view, &inputRoD, &isProjectFormat);
                 Q_UNUSED(st);
             }
 
-            pixelRoI.toCanonical(inputImgMipMapLevel, par, inputRoD, &canonicalPixelRoI);
-            canonicalPixelRoI.toPixelEnclosing(0, par, roiPixel);
-            pixelRoI = *roiPixel;
+            pixelRoI = pixelRoI.toNewMipMapLevel(inputImgMipMapLevel, 0, par, inputRoD);
+            *roiPixel = pixelRoI;
         }
 
         inputImg = rescaledImg;
@@ -1185,7 +1179,7 @@ EffectInstance::calcDefaultRegionOfDefinition(U64 /*hash*/,
     unsigned int mipMapLevel = Image::getLevelFromScale(scale.x);
     RectI format = getOutputFormat();
     double par = getAspectRatio(-1);
-    format.toCanonical_noClipping(mipMapLevel, par, rod);
+    *rod = format.toCanonical_noClipping(mipMapLevel, par);
 }
 
 StatusEnum
@@ -1288,7 +1282,7 @@ EffectInstance::ifInfiniteApplyHeuristic(U64 hash,
         assert(!format.isNull());
         double par = getAspectRatio(-1);
         unsigned int mipMapLevel = Image::getLevelFromScale(scale.x);
-        format.toCanonical_noClipping(mipMapLevel, par, &canonicalFormat);
+        canonicalFormat = format.toCanonical_noClipping(mipMapLevel, par);
     }
 
     // BE CAREFUL:
@@ -1680,7 +1674,7 @@ EffectInstance::getImageFromCacheAndConvertIfNeeded(bool /*useCache*/,
                 ////just discard this entry
                 Format projectFormat;
                 getApp()->getProject()->getProjectDefaultFormat(&projectFormat);
-                RectD canonicalProject = projectFormat.toCanonicalFormat();
+                const RectD canonicalProject = projectFormat.toCanonicalFormat();
                 if ( canonicalProject != (*it)->getRoD() ) {
                     appPTR->removeFromNodeCache(*it);
                     continue;
@@ -1740,21 +1734,11 @@ EffectInstance::getImageFromCacheAndConvertIfNeeded(bool /*useCache*/,
                 //The rodParam might be different of oldParams->getRoD() simply because the RoD is dependent on the mipmap level
                 const RectD & rod = rodParam ? *rodParam : oldParams->getRoD();
 
-
-                //RectD imgToConvertCanonical;
-                //imgToConvertBounds.toCanonical(imageToConvert->getMipMapLevel(), imageToConvert->getPixelAspectRatio(), rod, &imgToConvertCanonical);
-                RectI downscaledBounds;
-                rod.toPixelEnclosing(mipMapLevel, imageToConvert->getPixelAspectRatio(), &downscaledBounds);
-                //imgToConvertCanonical.toPixelEnclosing(imageToConvert->getMipMapLevel(), imageToConvert->getPixelAspectRatio(), &imgToConvertBounds);
-                //imgToConvertCanonical.toPixelEnclosing(mipMapLevel, imageToConvert->getPixelAspectRatio(), &downscaledBounds);
+                RectI downscaledBounds = rod.toPixelEnclosing(mipMapLevel, imageToConvert->getPixelAspectRatio());
 
                 if (boundsParam) {
                     downscaledBounds.merge(*boundsParam);
                 }
-
-                //RectI pixelRoD;
-                //rod.toPixelEnclosing(mipMapLevel, oldParams->getPixelAspectRatio(), &pixelRoD);
-                //downscaledBounds.intersect(pixelRoD, &downscaledBounds);
 
                 ImageParamsPtr imageParams = Image::makeParams(rod,
                                                                                downscaledBounds,
@@ -1786,9 +1770,9 @@ EffectInstance::getImageFromCacheAndConvertIfNeeded(bool /*useCache*/,
                  */
                 int downscaleLevels = img->getMipMapLevel() - imageToConvert->getMipMapLevel();
                 RectI dstRoi = imgToConvertBounds.downscalePowerOfTwoSmallestEnclosing(downscaleLevels);
-                dstRoi.intersect(downscaledBounds, &dstRoi);
+                dstRoi.clipIfOverlaps(downscaledBounds);
                 dstRoi = dstRoi.upscalePowerOfTwo(downscaleLevels);
-                dstRoi.intersect(imgToConvertBounds, &dstRoi);
+                dstRoi.clipIfOverlaps(imgToConvertBounds);
 
                 if (imgToConvertBounds.area() > 1) {
                     imageToConvert->downscaleMipMap( rod,
@@ -2229,11 +2213,9 @@ EffectInstance::Implementation::tiledRenderingFunctor(const RectToRender & rectT
 
 
     ///Upscale the RoI to a region in the full scale image so it is in canonical coordinates
-    RectD canonicalRectToRender;
-    renderMappedRectToRender.toCanonical(renderMappedMipMapLevel, par, rod, &canonicalRectToRender);
     if (renderFullScaleThenDownscale) {
         assert(mipMapLevel > 0 && renderMappedMipMapLevel != mipMapLevel);
-        canonicalRectToRender.toPixelEnclosing(mipMapLevel, par, &downscaledRectToRender);
+        downscaledRectToRender = renderMappedRectToRender.toNewMipMapLevel(renderMappedMipMapLevel, mipMapLevel, par, rod);
     }
 
     // at this point, it may be unnecessary to call render because it was done a long time ago => check the bitmap here!
@@ -2296,10 +2278,9 @@ EffectInstance::Implementation::tiledRenderingFunctor(const RectToRender & rectT
     RenderScale scale( Image::getScaleFromMipMapLevel(mipMapLevel) );
     // check the dimensions of all input and output images
     const RectD & dstRodCanonical = firstPlaneToRender.renderMappedImage->getRoD();
-    RectI dstBounds;
-    dstRodCanonical.toPixelEnclosing(firstPlaneToRender.renderMappedImage->getMipMapLevel(), par, &dstBounds); // compute dstRod at level 0
-    RectI dstRealBounds = firstPlaneToRender.renderMappedImage->getBounds();
+    const RectI dstBounds = dstRodCanonical.toPixelEnclosing(firstPlaneToRender.renderMappedImage->getMipMapLevel(), par); // compute dstRod at level 0
     if (!frameArgs->tilesSupported) {
+        const RectI dstRealBounds = firstPlaneToRender.renderMappedImage->getBounds();
         assert(dstRealBounds.x1 == dstBounds.x1);
         assert(dstRealBounds.x2 == dstBounds.x2);
         assert(dstRealBounds.y1 == dstBounds.y1);
@@ -2311,8 +2292,7 @@ EffectInstance::Implementation::tiledRenderingFunctor(const RectToRender & rectT
          ++it) {
         for (ImageList::const_iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2) {
             const RectD & srcRodCanonical = (*it2)->getRoD();
-            RectI srcBounds;
-            srcRodCanonical.toPixelEnclosing( (*it2)->getMipMapLevel(), (*it2)->getPixelAspectRatio(), &srcBounds ); // compute srcRod at level 0
+            const RectI srcBounds = srcRodCanonical.toPixelEnclosing( (*it2)->getMipMapLevel(), (*it2)->getPixelAspectRatio() ); // compute srcRod at level 0
 
             if (!frameArgs->tilesSupported) {
                 // http://openfx.sourceforge.net/Documentation/1.3/ofxProgrammingReference.html#kOfxImageEffectPropSupportsTiles
@@ -2325,7 +2305,7 @@ EffectInstance::Implementation::tiledRenderingFunctor(const RectToRender & rectT
                  * Blur will actually retrieve the image from the cache and downscale it rather than recompute it.
                  * Since the Writer does not support tiles, the Blur image is the full image and not a tile, which can be veryfied by
                  *
-                 * blurCachedImage->getRod().toPixelEnclosing(blurCachedImage->getMipMapLevel(), blurCachedImage->getPixelAspectRatio(), &bounds)
+                 * bounds = blurCachedImage->getRod().toPixelEnclosing(blurCachedImage->getMipMapLevel(), blurCachedImage->getPixelAspectRatio())
                  *
                  * Since the Blur RoD changed (the RoD at mmlevel 0 is different than the ROD at mmlevel 1),
                  * the resulting bounds of the downscaled image are not necessarily exactly result of the new downscaled RoD to the enclosing pixel
@@ -2553,8 +2533,7 @@ EffectInstance::Implementation::renderHandler(const EffectTLSDataPtr& tls,
 
                         ///then upscale
                         const RectD & rod = sourceImage->getRoD();
-                        RectI bounds;
-                        rod.toPixelEnclosing(it->second.renderMappedImage->getMipMapLevel(), it->second.renderMappedImage->getPixelAspectRatio(), &bounds);
+                        const RectI bounds = rod.toPixelEnclosing(it->second.renderMappedImage->getMipMapLevel(), it->second.renderMappedImage->getPixelAspectRatio());
                         ImagePtr inputPlane = std::make_shared<Image>(it->first,
                                                        rod,
                                                        bounds,
@@ -2576,8 +2555,7 @@ EffectInstance::Implementation::renderHandler(const EffectTLSDataPtr& tls,
                         if ( ( it->second.downscaleImage->getComponents() != idIt->second->getComponents() ) || ( it->second.downscaleImage->getBitDepth() != idIt->second->getBitDepth() ) ) {
                             ViewerColorSpaceEnum colorspace = _publicInterface->getApp()->getDefaultColorSpaceForBitDepth( idIt->second->getBitDepth() );
                             ViewerColorSpaceEnum dstColorspace = _publicInterface->getApp()->getDefaultColorSpaceForBitDepth( it->second.fullscaleImage->getBitDepth() );
-                            RectI convertWindow;
-                            idIt->second->getBounds().intersect(downscaledRectToRender, &convertWindow);
+                            const RectI convertWindow = idIt->second->getBounds().intersect(downscaledRectToRender);
                             idIt->second->convertToFormat( convertWindow, colorspace, dstColorspace, 3, false, false, it->second.downscaleImage.get() );
                         } else {
                             it->second.downscaleImage->pasteFrom(*(idIt->second), downscaledRectToRender, false, glContext);

--- a/Engine/Format.h
+++ b/Engine/Format.h
@@ -116,11 +116,7 @@ public:
 
     RectD toCanonicalFormat() const
     {
-        RectD ret;
-
-        toCanonical_noClipping(0, _par, &ret);
-
-        return ret;
+        return toCanonical_noClipping(0, _par);
     }
 
     Format & operator=(const Format & other)

--- a/Engine/FrameEntry.cpp
+++ b/Engine/FrameEntry.cpp
@@ -94,8 +94,8 @@ FrameEntry::copy(const FrameEntry& other)
     srcBoundsRect.x2 = srcBounds.x2;
     srcBoundsRect.y1 = srcBounds.y1;
     srcBoundsRect.y2 = srcBounds.y2;
-    RectI roi;
-    if ( !dstBounds.intersect(srcBoundsRect, &roi) ) {
+    const RectI roi = dstBounds.intersect(srcBoundsRect);
+    if (roi.isNull()) {
         return;
     }
 

--- a/Engine/Image.h
+++ b/Engine/Image.h
@@ -685,8 +685,7 @@ public:
             return;
         }
         QWriteLocker locker(&_entryLock);
-        RectI intersection;
-        _bounds.intersect(roi, &intersection);
+        const RectI intersection = _bounds.intersect(roi);
         _bitmap.markForRendered(intersection);
     }
 
@@ -698,8 +697,7 @@ public:
             return;
         }
         QWriteLocker locker(&_entryLock);
-        RectI intersection;
-        _bounds.intersect(roi, &intersection);
+        const RectI intersection = _bounds.intersect(roi);
         _bitmap.markForRendering(intersection);
     }
 
@@ -711,8 +709,7 @@ public:
             return;
         }
         QWriteLocker locker(&_entryLock);
-        RectI intersection;
-        _bounds.intersect(roi, &intersection);
+        const RectI intersection = _bounds.intersect(roi);
         _bitmap.clear(intersection);
     }
 

--- a/Engine/ImageConvert.cpp
+++ b/Engine/ImageConvert.cpp
@@ -138,9 +138,9 @@ Image::convertToFormatInternal_sameComps(const RectI & renderWindow,
                                          bool copyBitmap)
 {
     const RectI & r = srcImg._bounds;
-    RectI intersection;
+    const RectI intersection = renderWindow.intersect(r);
 
-    if ( !renderWindow.intersect(r, &intersection) ) {
+    if ( intersection.isNull() ) {
         return;
     }
 

--- a/Engine/ImageCopyChannels.cpp
+++ b/Engine/ImageCopyChannels.cpp
@@ -619,8 +619,7 @@ Image::copyUnProcessedChannels(const RectI& roi,
     assert( !originalImage || getBitDepth() == originalImage->getBitDepth() );
 
 
-    RectI srcRoi;
-    roi.intersect(_bounds, &srcRoi);
+    const RectI srcRoi = roi.intersect(_bounds);
 
     if (getStorageMode() == eStorageModeGLTex) {
         assert(glContext);

--- a/Engine/ImageMaskMix.cpp
+++ b/Engine/ImageMaskMix.cpp
@@ -208,8 +208,7 @@ Image::applyMaskMix(const RectI& roi,
     if (maskImg) {
         maskLock.reset( new QReadLocker(&maskImg->_entryLock) );
     }
-    RectI realRoI;
-    roi.intersect(_bounds, &realRoI);
+    const RectI realRoI = roi.intersect(_bounds);
 
     assert( !originalImg || getBitDepth() == originalImg->getBitDepth() );
     assert( !masked || !maskImg || maskImg->getComponents() == ImagePlaneDesc::getAlphaComponents() );

--- a/Engine/Lut.cpp
+++ b/Engine/Lut.cpp
@@ -171,7 +171,7 @@ static bool
 clip(RectI* what,
      const RectI & to)
 {
-    return what->intersect(to, what);
+    return what->clipIfOverlaps(to);
 }
 
 #ifdef DEAD_CODE

--- a/Engine/Node.cpp
+++ b/Engine/Node.cpp
@@ -3333,8 +3333,7 @@ Node::makePreviewImage(SequenceTime time,
     scale.y = scale.x;
 
     const double par = effect->getAspectRatio(-1);
-    RectI renderWindow;
-    rod.toPixelEnclosing(mipMapLevel, par, &renderWindow);
+    const RectI renderWindow = rod.toPixelEnclosing(mipMapLevel, par);
 
     NodePtr thisNode = shared_from_this();
     RenderingFlagSetter flagIsRendering(thisNode);

--- a/Engine/OfxImageEffectInstance.cpp
+++ b/Engine/OfxImageEffectInstance.cpp
@@ -327,8 +327,7 @@ OfxImageEffectInstance::getProjectSize(double & xSize,
     pixelF.x2 = f.x2;
     pixelF.y1 = f.y1;
     pixelF.y2 = f.y2;
-    RectD canonicalF;
-    pixelF.toCanonical_noClipping(0, f.getPixelAspectRatio(), &canonicalF);
+    const RectD canonicalF = pixelF.toCanonical_noClipping(0, f.getPixelAspectRatio());
     xSize = canonicalF.width();
     ySize = canonicalF.height();
 }
@@ -350,8 +349,7 @@ OfxImageEffectInstance::getProjectOffset(double & xOffset,
     pixelF.x2 = f.x2;
     pixelF.y1 = f.y1;
     pixelF.y2 = f.y2;
-    RectD canonicalF;
-    pixelF.toCanonical_noClipping(0, f.getPixelAspectRatio(), &canonicalF);
+    const RectD canonicalF = pixelF.toCanonical_noClipping(0, f.getPixelAspectRatio());
     xOffset = canonicalF.left();
     yOffset = canonicalF.bottom();
 }
@@ -373,8 +371,7 @@ OfxImageEffectInstance::getProjectExtent(double & xSize,
     pixelF.x2 = f.x2;
     pixelF.y1 = f.y1;
     pixelF.y2 = f.y2;
-    RectD canonicalF;
-    pixelF.toCanonical_noClipping(0, f.getPixelAspectRatio(), &canonicalF);
+    const RectD canonicalF = pixelF.toCanonical_noClipping(0, f.getPixelAspectRatio());
     xSize = canonicalF.right();
     ySize = canonicalF.top();
 }

--- a/Engine/OutputSchedulerThread.cpp
+++ b/Engine/OutputSchedulerThread.cpp
@@ -2301,9 +2301,7 @@ private:
                         components.push_back(*it2);
                     }
                 }
-                RectI renderWindow;
-                rod.toPixelEnclosing(scale, par, &renderWindow);
-
+                const RectI renderWindow = rod.toPixelEnclosing(scale, par);
 
                 AbortableRenderInfoPtr abortInfo = AbortableRenderInfo::create(true, 0);
                 if (isAbortableThread) {
@@ -2413,8 +2411,6 @@ DefaultScheduler::processFrame(const BufferedFrames& frames)
     OutputEffectInstancePtr effect = _effect.lock();
     U64 hash = effect->getHash();
     bool isProjectFormat;
-    RectD rod;
-    RectI roi;
     std::list<ImagePlaneDesc> components;
 
     {
@@ -2447,9 +2443,9 @@ DefaultScheduler::processFrame(const BufferedFrames& frames)
                                                  false,
                                                  false,
                                                  it->stats);
-
+        RectD rod;
         ignore_result( effect->getRegionOfDefinition_public(hash, it->time, scale, it->view, &rod, &isProjectFormat) );
-        rod.toPixelEnclosing(0, par, &roi);
+        const RectI roi = rod.toPixelEnclosing(0, par);
 
 
         RenderingFlagSetter flagIsRendering( effect->getNode() );

--- a/Engine/ParallelRenderArgs.cpp
+++ b/Engine/ParallelRenderArgs.cpp
@@ -260,10 +260,9 @@ EffectInstance::treeRecurseFunctor(bool isRenderFunctor,
                                     frameArgs->request->getFrameViewCanonicalRoI(f, viewIt->first, &roi);
                                 }
 
-                                RectI inputRoIPixelCoords;
                                 const unsigned int upstreamMipMapLevel = useScaleOneInputs ? 0 : originalMipMapLevel;
                                 const RenderScale & upstreamScale = useScaleOneInputs ? scaleOne : scale;
-                                roi.toPixelEnclosing(upstreamMipMapLevel, inputPar, &inputRoIPixelCoords);
+                                const RectI inputRoIPixelCoords = roi.toPixelEnclosing(upstreamMipMapLevel, inputPar);
 
                                 std::map<ImagePlaneDesc, ImagePtr> inputImgs;
                                 {
@@ -381,8 +380,7 @@ EffectInstance::getInputsRoIsFunctor(bool useTransforms,
         fvRequest->globalData.identityView = view;
 
 
-        RectI identityRegionPixel;
-        canonicalRenderWindow.toPixelEnclosing(mappedLevel, par, &identityRegionPixel);
+        const RectI identityRegionPixel = canonicalRenderWindow.toPixelEnclosing(mappedLevel, par);
 
         if ( (view != 0) && (viewInvariance == eViewInvarianceAllViewsInvariant) ) {
             fvRequest->globalData.isIdentity = true;

--- a/Engine/RectD.cpp
+++ b/Engine/RectD.cpp
@@ -33,28 +33,25 @@
 
 NATRON_NAMESPACE_ENTER
 
-void
-RectD::toPixelEnclosing(const RenderScale & scale,
-                        double par,
-                        RectI *rect) const
+RectI
+RectD::toPixelEnclosing(const RenderScale& scale,
+                        double par) const
 {
-    rect->x1 = std::floor(x1 * scale.x / par);
-    rect->y1 = std::floor(y1 * scale.y);
-    rect->x2 = std::ceil(x2 * scale.x / par);
-    rect->y2 = std::ceil(y2 * scale.y);
+    return RectI(std::floor(x1 * scale.x / par),
+                 std::floor(y1 * scale.y),
+                 std::ceil(x2 * scale.x / par),
+                 std::ceil(y2 * scale.y));
 }
 
-void
+RectI
 RectD::toPixelEnclosing(unsigned int mipMapLevel,
-                        double par,
-                        RectI *rect) const
+                        double par) const
 {
-    double scale = 1. / (1 << mipMapLevel);
-
-    rect->x1 = std::floor(x1 * scale / par);
-    rect->y1 = std::floor(y1 * scale);
-    rect->x2 = std::ceil(x2 * scale / par);
-    rect->y2 = std::ceil(y2 * scale);
+    const double scale = 1. / (1 << mipMapLevel);
+    return RectI(std::floor(x1 * scale / par),
+                 std::floor(y1 * scale),
+                 std::ceil(x2 * scale / par),
+                 std::ceil(y2 * scale));
 }
 
 NATRON_NAMESPACE_EXIT

--- a/Engine/RectD.h
+++ b/Engine/RectD.h
@@ -219,15 +219,19 @@ public:
         y2 = std::max(y2, t);
     }
 
-    /*intersection of two boxes*/
-    bool intersect(const RectD & r,
+private:
+    /**
+     * @brief Computes intersection of this rectangle and the one provided as a parameter, if they overlap.
+     *
+     * @param[in] r The rectangle to intersect with this rectangle.
+     * @param[out] intersection Updated to contain the intersection of the two rectangles if this method returns true. Otherwise left unmodified.
+     * @returns True if this rectangle and the one passed in are not null and overlap.
+     **/
+    // Note: This is private to encourage the use of intersect() or clipIfOverlaps().
+    bool intersectInternal(const RectD & r,
                    RectD* intersection) const
     {
-        if ( isNull() || r.isNull() ) {
-            return false;
-        }
-
-        if ( (x1 > r.x2) || (r.x1 > x2) || (y1 > r.y2) || (r.y1 > y2) ) {
+        if (!intersects(r)) {
             return false;
         }
 
@@ -239,13 +243,36 @@ public:
         return true;
     }
 
-    bool intersect(double l,
-                   double b,
-                   double r,
-                   double t,
-                   RectD* intersection) const
+public:
+
+    /**
+     * @brief Computes the intersection of this rectangle and rect.
+     *
+     * @returns Intersection of the two rectangles if they overlap. If there is no overlap a null (i.e. default constructed) rectangle is returned.
+     **/
+    RectD intersect(const RectD & rect) const
     {
-        return intersect(RectD(l, b, r, t), intersection);
+        RectD intersection;
+        intersectInternal(rect, &intersection);
+        return intersection;
+    }
+
+    RectD intersect(double l,
+                    double b,
+                    double r,
+                    double t) const
+    {
+        return intersect(RectD(l, b, r, t));
+    }
+
+    /**
+     * @brief Updates this rectangle to the intersection rectangle if this rectangle overlaps with rect. If there is no overlap then this rectangle remains unchanged.
+     *
+     * @returns True if the rectangles overlap and this rectangle was clipped.
+     **/
+    bool clipIfOverlaps(const RectD& rect)
+    {
+        return intersectInternal(rect, this);
     }
 
     /// returns true if the rect passed as parameter is intersects this one
@@ -307,13 +334,11 @@ public:
 
 #endif
 
-    void toPixelEnclosing(const RenderScale & scale,
-                          double par,
-                          RectI *rect) const;
+    RectI toPixelEnclosing(const RenderScale & scale,
+                          double par) const;
 
-    void toPixelEnclosing(unsigned int mipMapLevel,
-                          double par,
-                          RectI *rect) const;
+    RectI toPixelEnclosing(unsigned int mipMapLevel,
+                          double par) const;
 
     static void ofxRectDToRectD(const OfxRectD & r,
                                 RectD *ret)

--- a/Engine/RectI.cpp
+++ b/Engine/RectI.cpp
@@ -114,25 +114,30 @@ std::vector<RectI> RectI::splitIntoSmallerRects(int splitsCount) const
     return ret;
 } // RectI::splitIntoSmallerRects
 
-void
+RectD
 RectI::toCanonical(unsigned int thisLevel,
                    double par,
-                   const RectD & rod,
-                   RectD *rect) const
+                   const RectD& rod) const
 {
-    toCanonical_noClipping(thisLevel, par, rect);
-    rect->intersect(rod, rect);
+    RectD rect = toCanonical_noClipping(thisLevel, par);
+    rect.clipIfOverlaps(rod);
+    return rect;
 }
 
-void
+RectD
 RectI::toCanonical_noClipping(unsigned int thisLevel,
-                              double par,
-                              RectD *rect) const
+                              double par) const
 {
-    rect->x1 = (x1 << thisLevel) * par;
-    rect->x2 = (x2 << thisLevel) * par;
-    rect->y1 = y1 << thisLevel;
-    rect->y2 = y2 << thisLevel;
+    return RectD((x1 << thisLevel) * par,
+                 y1 << thisLevel,
+                 (x2 << thisLevel) * par,
+                 y2 << thisLevel);
+}
+
+RectI
+RectI::toNewMipMapLevel(unsigned int fromLevel, unsigned int toLevel, double par, const RectD& rod) const
+{
+    return toCanonical(fromLevel, par, rod).toPixelEnclosing(toLevel, par);
 }
 
 NATRON_NAMESPACE_EXIT

--- a/Engine/RotoContext.cpp
+++ b/Engine/RotoContext.cpp
@@ -2540,9 +2540,7 @@ RotoStrokeItem::renderSingleStroke(const RectD& pointsBbox,
     getColor(time, shapeColor);
 
     ImagePtr source = *image;
-    RectI pixelPointsBbox;
-    pointsBbox.toPixelEnclosing(mipmapLevel, par, &pixelPointsBbox);
-
+    const RectI pixelPointsBbox = pointsBbox.toPixelEnclosing(mipmapLevel, par);
 
     NodePtr node = getContext()->getNode();
     ImageFieldingOrderEnum fielding = node->getEffectInstance()->getFieldingOrder();
@@ -2565,13 +2563,10 @@ RotoStrokeItem::renderSingleStroke(const RectD& pointsBbox,
             mipMapLevelChanged = true;
 
             RectD otherRoD = (*image)->getRoD();
-            RectI oldBounds;
-            otherRoD.toPixelEnclosing( (*image)->getMipMapLevel(), par, &oldBounds );
+            const RectI oldBounds = otherRoD.toPixelEnclosing( (*image)->getMipMapLevel(), par);
             RectD mergeRoD = pointsBbox;
             mergeRoD.merge(otherRoD);
-            RectI mergeBounds;
-            mergeRoD.toPixelEnclosing(mipmapLevel, par, &mergeBounds);
-
+            const RectI mergeBounds = mergeRoD.toPixelEnclosing(mipmapLevel, par);
 
             //upscale the original image
             source.reset( new Image(components,
@@ -2590,12 +2585,10 @@ RotoStrokeItem::renderSingleStroke(const RectD& pointsBbox,
             mipMapLevelChanged = true;
 
             RectD otherRoD = (*image)->getRoD();
-            RectI oldBounds;
-            otherRoD.toPixelEnclosing( (*image)->getMipMapLevel(), par, &oldBounds );
+            const RectI oldBounds = otherRoD.toPixelEnclosing( (*image)->getMipMapLevel(), par );
             RectD mergeRoD = pointsBbox;
             mergeRoD.merge(otherRoD);
-            RectI mergeBounds;
-            mergeRoD.toPixelEnclosing(mipmapLevel, par, &mergeBounds);
+            const RectI mergeBounds = mergeRoD.toPixelEnclosing(mipmapLevel, par);
 
             //downscale the original image
             source.reset( new Image(components,
@@ -2814,9 +2807,7 @@ RotoDrawableItem::renderMaskFromStroke(const ImagePlaneDesc& components,
         rotoBbox.merge(rotoNodeSrcRod);
     }
 
-    RectI pixelRod;
-    rotoBbox.toPixelEnclosing(mipmapLevel, 1., &pixelRod);
-
+    const RectI pixelRod = rotoBbox.toPixelEnclosing(mipmapLevel, 1.);
 
     ImageParamsPtr params = Image::makeParams( rotoBbox,
                                                                pixelRod,

--- a/Engine/RotoPaint.cpp
+++ b/Engine/RotoPaint.cpp
@@ -1455,8 +1455,7 @@ RotoPaint::isIdentity(double time,
         bool isProjectFormat;
         StatusEnum s = maskInput->getRegionOfDefinition_public(maskInput->getRenderHash(), time, scale, view, &maskRod, &isProjectFormat);
         Q_UNUSED(s);
-        RectI maskPixelRod;
-        maskRod.toPixelEnclosing(scale, getAspectRatio(ROTOPAINT_MASK_INPUT_INDEX), &maskPixelRod);
+        const RectI maskPixelRod = maskRod.toPixelEnclosing(scale, getAspectRatio(ROTOPAINT_MASK_INPUT_INDEX));
         if ( !maskPixelRod.intersects(roi) ) {
             *inputTime = time;
             *inputNb = 0;
@@ -1628,8 +1627,8 @@ RotoPaint::render(const RenderActionArgs& args)
                     plane->second->fillZero(dRect);
 
                     if ( bgImg->getComponents() != plane->second->getComponents() ) {
-                        RectI intersection;
-                        if (args.roi.intersect(bgImg->getBounds(), &intersection)) {
+                        const RectI intersection = args.roi.intersect(bgImg->getBounds());
+                        if (!intersection.isNull()) {
                             bgImg->convertToFormat( intersection,
                                                 getApp()->getDefaultColorSpaceForBitDepth( rotoImagesIt->second->getBitDepth() ),
                                                 getApp()->getDefaultColorSpaceForBitDepth( plane->second->getBitDepth() ), 3

--- a/Engine/RotoSmear.cpp
+++ b/Engine/RotoSmear.cpp
@@ -128,8 +128,7 @@ RotoSmear::isIdentity(double time,
     NodePtr node = getNode();
     node->getPaintStrokeRoD(time, &maskRod);
 
-    RectI maskPixelRod;
-    maskRod.toPixelEnclosing(scale, getAspectRatio(-1), &maskPixelRod);
+    const RectI maskPixelRod = maskRod.toPixelEnclosing(scale, getAspectRatio(-1));
     if ( !maskPixelRod.intersects(roi) ) {
         *inputTime = time;
         *inputNb = 0;
@@ -153,9 +152,7 @@ renderSmearDot(const unsigned char* maskData,
 {
     /// First copy the portion of the image around the previous dot into tmpBuf
     RectD prevDotRoD(prev.x - brushSizePixels / 2., prev.y - brushSizePixels / 2., prev.x + brushSizePixels / 2., prev.y + brushSizePixels / 2.);
-    RectI prevDotBounds;
-
-    prevDotRoD.toPixelEnclosing(0, outputImage->getPixelAspectRatio(), &prevDotBounds);
+    const RectI prevDotBounds = prevDotRoD.toPixelEnclosing(0, outputImage->getPixelAspectRatio());
     ImagePtr tmpBuf( new Image(outputImage->getComponents(),
                                prevDotRoD,
                                prevDotBounds,

--- a/Engine/TrackMarker.cpp
+++ b/Engine/TrackMarker.cpp
@@ -1152,15 +1152,12 @@ TrackMarker::getMarkerImageRoI(int time) const
     roiCanonical.x2 = swTr->getValueAtTime(time, 0) + center.x + offset.x;
     roiCanonical.y2 = swTr->getValueAtTime(time, 1) + center.y + offset.y;
 
-    RectI roi;
     NodePtr node = getContext()->getNode();
     NodePtr input = node->getInput(0);
     if (!input) {
         return RectI();
     }
-    roiCanonical.toPixelEnclosing(mipmapLevel, input ? input->getEffectInstance()->getAspectRatio(-1) : 1., &roi);
-
-    return roi;
+    return roiCanonical.toPixelEnclosing(mipmapLevel, input ? input->getEffectInstance()->getAspectRatio(-1) : 1.);
 }
 
 std::pair<ImagePtr, RectI>

--- a/Engine/TrackerFrameAccessor.cpp
+++ b/Engine/TrackerFrameAccessor.cpp
@@ -347,7 +347,7 @@ TrackerFrameAccessor::GetImage(int /*clip*/,
             return (mv::FrameAccessor::Key)0;
         }
         double par = effect->getAspectRatio(-1);
-        precomputedRoD.toPixelEnclosing( (unsigned int)downscale, par, &roi );
+        roi = precomputedRoD.toPixelEnclosing( (unsigned int)downscale, par);
     }
 
     std::list<ImagePlaneDesc> components;
@@ -400,8 +400,8 @@ TrackerFrameAccessor::GetImage(int /*clip*/,
     assert( !planes.empty() );
     const ImagePtr& sourceImage = planes.begin()->second;
     RectI sourceBounds = sourceImage->getBounds();
-    RectI intersectedRoI;
-    if ( !roi.intersect(sourceBounds, &intersectedRoI) ) {
+    const RectI intersectedRoI = roi.intersect(sourceBounds);
+    if ( intersectedRoI.isNull() ) {
 #ifdef TRACE_LIB_MV
         qDebug() << QThread::currentThread() << "FrameAccessor::GetImage():" << "RoI does not intersect the source image bounds (RoI x1="
                  << roi.x1 << "y1=" << roi.y1 << "x2=" << roi.x2 << "y2=" << roi.y2 << ")";

--- a/Engine/TrackerNodeInteract.cpp
+++ b/Engine/TrackerNodeInteract.cpp
@@ -725,8 +725,7 @@ TrackerNodeInteract::drawSelectedMarkerKeyframes(const std::pair<double, double>
                 textureRectCanonical.y1 = textureRectCanonical.y2 - height;
 
 
-                RectD canonicalSearchWindow;
-                texRect.toCanonical_noClipping(0, texRect.par, &canonicalSearchWindow);
+                const RectD canonicalSearchWindow = texRect.toCanonical_noClipping(0, texRect.par);
 
                 //Remove any offset to the center to see the marker in the magnification window
                 double xCenterPercent = (center.x - canonicalSearchWindow.x1 + offset.x) / (canonicalSearchWindow.x2 - canonicalSearchWindow.x1);
@@ -899,8 +898,7 @@ TrackerNodeInteract::drawSelectedMarkerTexture(const std::pair<double, double>& 
     texCoords.x1 = texCoords.y1 = 0.;
     texCoords.x2 = texCoords.y2 = 1.;
 
-    RectD canonicalSearchWindow;
-    texRect.toCanonical_noClipping(0, texRect.par, &canonicalSearchWindow);
+    const RectD canonicalSearchWindow = texRect.toCanonical_noClipping(0, texRect.par);
 
     Point centerPoint, innerTopLeft, innerTopRight, innerBtmLeft, innerBtmRight;
 
@@ -1157,7 +1155,7 @@ TrackerNodeInteract::convertImageTosRGBOpenGLTexture(const ImagePtr& image,
 
     if (image) {
         bounds = image->getBounds();
-        renderWindow.intersect(bounds, &roi);
+        roi = renderWindow.intersect(bounds);
     } else {
         bounds = renderWindow;
         roi = bounds;

--- a/Engine/typesystem_engine.xml
+++ b/Engine/typesystem_engine.xml
@@ -236,37 +236,9 @@
        <modify-function signature="roundPowerOfTwoSmallestEnclosing(unsigned int)const" remove="all"/>
        <modify-function signature="downscalePowerOfTwoLargestEnclosed(unsigned int)const" remove="all"/>
        <modify-function signature="downscalePowerOfTwoSmallestEnclosing(unsigned int)const" remove="all"/>
-       <modify-function signature="toCanonical(unsigned int,double,RectD,RectD*)const" remove="all"/>
-       <modify-function signature="toCanonical_noClipping(unsigned int,double,RectD*)const" remove="all"/>
+       <modify-function signature="toCanonical(unsigned int,double,RectD)const" remove="all"/>
+       <modify-function signature="toCanonical_noClipping(unsigned int,double)const" remove="all"/>
        <modify-function signature="splitIntoSmallerRects(int)const" remove="all"/>
-       <modify-function signature="intersect(RectI,RectI*)const">
-           <modify-argument index="2">
-               <remove-argument/>
-           </modify-argument>
-           <modify-argument index="return">
-               <replace-type modified-type="RectI"/>
-           </modify-argument>
-           <inject-code class="target" position="beginning">
-               RectI t;
-               %CPPSELF.%FUNCTION_NAME(%1,&amp;t);
-               %PYARG_0 = %CONVERTTOPYTHON[RectI](t);
-               return %PYARG_0;
-           </inject-code>
-       </modify-function>
-       <modify-function signature="intersect(int,int,int,int,RectI*)const">
-           <modify-argument index="5">
-               <remove-argument/>
-           </modify-argument>
-           <modify-argument index="return">
-               <replace-type modified-type="RectI"/>
-           </modify-argument>
-           <inject-code class="target" position="beginning">
-               RectI t;
-               %CPPSELF.%FUNCTION_NAME(%1,%2,%3,%4,&amp;t);
-               %PYARG_0 = %CONVERTTOPYTHON[RectI](t);
-               return %PYARG_0;
-           </inject-code>
-       </modify-function>
    </object-type>
 
    <object-type name="ExprUtils">
@@ -737,36 +709,7 @@
    </object-type>
    <object-type name="RectD">
        <modify-function signature="operator=(RectD)" remove="all"/>
-       <modify-function signature="toPixelEnclosing(unsigned int,double,RectI*)const" remove="all"/>
-       <modify-function signature="intersect(RectD,RectD*)const">
-           <modify-argument index="2">
-               <remove-argument/>
-           </modify-argument>
-           <modify-argument index="return">
-               <replace-type modified-type="RectD"/>
-           </modify-argument>
-           <inject-code class="target" position="beginning">
-               RectD t;
-               %CPPSELF.%FUNCTION_NAME(%1,&amp;t);
-               %PYARG_0 = %CONVERTTOPYTHON[RectD](t);
-               return %PYARG_0;
-           </inject-code>
-       </modify-function>
-       <modify-function signature="intersect(double,double,double,double,RectD*)const">
-           <modify-argument index="5">
-               <remove-argument/>
-           </modify-argument>
-           <modify-argument index="return">
-               <replace-type modified-type="RectD"/>
-           </modify-argument>
-           <inject-code class="target" position="beginning">
-               RectD t;
-               %CPPSELF.%FUNCTION_NAME(%1,%2,%3,%4,&amp;t);
-               %PYARG_0 = %CONVERTTOPYTHON[RectD](t);
-               return %PYARG_0;
-           </inject-code>
-       </modify-function>
-       
+       <modify-function signature="toPixelEnclosing(unsigned int,double)const" remove="all"/>
    </object-type>
 
     <value-type name="ImageLayer" copyable="true" hash-function="ImageLayer::getHash">

--- a/Gui/Gui40.cpp
+++ b/Gui/Gui40.cpp
@@ -642,7 +642,8 @@ Gui::debugImage(const Image* image,
     if ( roi.isNull() ) {
         renderWindow = bounds;
     } else {
-        if ( !roi.intersect(bounds, &renderWindow) ) {
+        renderWindow = roi.intersect(bounds);
+        if ( renderWindow.isNull() ) {
             qDebug() << "The RoI does not intersect the bounds of the image.";
 
             return;

--- a/Gui/ProjectGui.cpp
+++ b/Gui/ProjectGui.cpp
@@ -242,8 +242,7 @@ AddFormatDialog::onCopyFromViewer()
             RectD f = tab->getViewer()->getRoD(0);
             RectD canonicalFormat = tab->getViewer()->getCanonicalFormat(0);
             double par = tab->getViewer()->getPAR(0);
-            RectI format;
-            canonicalFormat.toPixelEnclosing(0, par, &format);
+            const RectI format = canonicalFormat.toPixelEnclosing(0, par);
             _widthSpinBox->setValue( format.width() );
             _heightSpinBox->setValue( format.height() );
             _pixelAspectSpinBox->setValue(par);

--- a/Gui/ViewerGLPrivate.cpp
+++ b/Gui/ViewerGLPrivate.cpp
@@ -250,11 +250,8 @@ ViewerGL::Implementation::drawRenderingVAO(unsigned int mipMapLevel,
     ///This is the coordinates in the image being rendered where datas are valid, this is in pixel coordinates
     ///at the time we initialize it but we will convert it later to canonical coordinates. See 1)
     const double par = roiRounded.par;
-    RectD canonicalRoIRoundedToTileSize;
-    roiRounded.toCanonical_noClipping(mipMapLevel, par /*, rod*/, &canonicalRoIRoundedToTileSize);
-
-    RectD canonicalRoINotRounded;
-    roiNotRounded.toCanonical_noClipping(mipMapLevel, par, &canonicalRoINotRounded);
+    const RectD canonicalRoIRoundedToTileSize = roiRounded.toCanonical_noClipping(mipMapLevel, par);
+    const RectD canonicalRoINotRounded = roiNotRounded.toCanonical_noClipping(mipMapLevel, par);
 
     ///the RoD of the image in canonical coords.
     RectD rod = _this->getRoD(textureIndex);
@@ -265,12 +262,12 @@ ViewerGL::Implementation::drawRenderingVAO(unsigned int mipMapLevel,
         clipToDisplayWindow = this->clipToDisplayWindow;
     }
     RectD rectClippedToRoI(canonicalRoIRoundedToTileSize);
-    rectClippedToRoI.intersect(rod, &rectClippedToRoI);
+    rectClippedToRoI.clipIfOverlaps(rod);
 
 
     if (clipToDisplayWindow) {
-        rod.intersect(this->displayTextures[textureIndex].format, &rod);
-        rectClippedToRoI.intersect(this->displayTextures[textureIndex].format, &rectClippedToRoI);
+        rod.clipIfOverlaps(this->displayTextures[textureIndex].format);
+        rectClippedToRoI.clipIfOverlaps(this->displayTextures[textureIndex].format);
     }
 
     
@@ -297,11 +294,11 @@ ViewerGL::Implementation::drawRenderingVAO(unsigned int mipMapLevel,
         {
             QMutexLocker l(&this->userRoIMutex);
             //if the userRoI isn't intersecting the rod, just don't render anything
-            if ( !rod.intersect(this->userRoI, &rod) ) {
+            if ( !rod.clipIfOverlaps(this->userRoI) ) {
                 return;
             }
         }
-        rectClippedToRoI.intersect(rod, &rectClippedToRoI);
+        rectClippedToRoI.clipIfOverlaps(rod);
         //clipTexCoords<RectD>(canonicalTexRect,rectClippedToRoI,texBottom,texTop,texLeft,texRight);
     }
 

--- a/Gui/ViewerTab30.cpp
+++ b/Gui/ViewerTab30.cpp
@@ -1219,9 +1219,8 @@ ViewerTab::onClipPreferencesChanged()
             setInfoBarAndViewerResolution(format, canonicalFormat, format.getPixelAspectRatio(), i);
         } else {
             RectI inputFormat = input->getOutputFormat();
-            RectD inputCanonicalFormat;
             double inputPar = input->getAspectRatio(-1);
-            inputFormat.toCanonical_noClipping(0, inputPar, &inputCanonicalFormat);
+            RectD inputCanonicalFormat = inputFormat.toCanonical_noClipping(0, inputPar);
 
             setInfoBarAndViewerResolution(inputFormat, inputCanonicalFormat, inputPar, i);
 


### PR DESCRIPTION
- 

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

The main goal of this change is to simplify the code and improve readability for some RectI and RectD usage. It does not
change any existing functionality, but it changes some key function signatures and adds a few helpers to make the code
simpler and a little easier to follow. The new signatures also make it easier to declare various variables const now, which 
makes it a lot easier to reason about behavior in some of the large functions in the rendering path.

Here is a summary of the changes made:
- Changed RectI::toCanonical(), RectI::toCanonical_noClip() and RectD::toPixelEnclosing() to return their value instead if using an out pointer param. This simplifies a lot of callers, avoids default construction in a lot of cases, and allows many variables to be marked const which makes it easier to ensure values don't change unexpectedly in large functions.

- Added RectI::toNewMipMapLevel() helper function to reduce duplicate code and make the code a little more readable.

- Added RectI::intersect() and RectD::intersect() methods that return the intersection or a null rect. Updated a few places where this form simplifies or makes the code more clear.

- Added RectI::clipIfOverlaps() and RectD::clipIfOverlaps() helper functions to replace a common usage of the existing intersect() method. The intent is to make it a little more clear that the intersection only happens if there is an overlap and it avoids having to specify a variable name twice.

- Renamed the original intersect() to intersectInternal() and made it private. The intersect() and clipIfOverlaps() changes above made it so there were no callers outside of RectI and RectD that needed this.

- Removed some comment out code and a few variables/computations that weren't actually used for anything.

- Added documentation for a few methods to make their behavior a little more clear.

- Updated python wrapper type definitions to reflect the changes above. The intersect modifications could be removed because the new intersect() signature and semantics match the desired python signature and semantics.


**Have you tested your changes (if applicable)? If so, how?**

Yes. I've build this locally, verified the tests still run and Natron appears to work as expected. No change in behavior has been observed.
