### PR TITLE
Fix rendering bugs caused by intersecting rects with different mipMapLevels.

### DIFF
--- a/Engine/EffectInstance.cpp
+++ b/Engine/EffectInstance.cpp
@@ -654,7 +654,7 @@ EffectInstance::retrieveGetImageDataUponFailure(const double time,
         getRegionsOfInterest(time, scale, optionalBounds, optionalBounds, ViewIdx(0), inputRois_p);
     }
 
-    assert( !( (supportsRenderScaleMaybe() == eSupportsNo) && !(scale.x == 1. && scale.y == 1.) ) );
+    assert(isSupportedRenderScale(supportsRenderScaleMaybe(), scale));
     const RectI pixelRod = rod.toPixelEnclosing(scale, getAspectRatio(-1));
     try {
         int identityInputNb;
@@ -1192,7 +1192,7 @@ EffectInstance::getRegionOfDefinition(U64 hash,
     bool firstInput = true;
     RenderScale renderMappedScale = scale;
 
-    assert( !( (supportsRenderScaleMaybe() == eSupportsNo) && !(scale.x == 1. && scale.y == 1.) ) );
+    assert(isSupportedRenderScale(supportsRenderScaleMaybe(), scale));
 
     for (int i = 0; i < getNInputs(); ++i) {
         if ( isInputMask(i) ) {
@@ -2402,7 +2402,7 @@ EffectInstance::Implementation::renderHandler(const EffectTLSDataPtr& tls,
     actionArgs.byPassCache = byPassCache;
     actionArgs.processChannels = processChannels;
     actionArgs.mappedScale.x = actionArgs.mappedScale.y = Image::getScaleFromMipMapLevel( firstPlane.renderMappedImage->getMipMapLevel() );
-    assert( !( (_publicInterface->supportsRenderScaleMaybe() == eSupportsNo) && !(actionArgs.mappedScale.x == 1. && actionArgs.mappedScale.y == 1.) ) );
+    assert(isSupportedRenderScale(_publicInterface->supportsRenderScaleMaybe(), actionArgs.mappedScale));
     actionArgs.originalScale.x = Image::getScaleFromMipMapLevel(mipMapLevel);
     actionArgs.originalScale.y = actionArgs.originalScale.x;
     actionArgs.draftMode = frameArgs->draftMode;
@@ -3751,8 +3751,6 @@ EffectInstance::isIdentity_public(bool useIdentityCache, // only set to true whe
                                   ViewIdx* inputView,
                                   int* inputNb)
 {
-    //assert( !( (supportsRenderScaleMaybe() == eSupportsNo) && !(scale.x == 1. && scale.y == 1.) ) );
-
     if (useIdentityCache) {
         double timeF = 0.;
         bool foundInCache = _imp->actionsCache->getIdentityResult(hash, time, view, inputNb, inputView, &timeF);
@@ -5954,6 +5952,13 @@ EffectInstance::setClipPreferencesRunning(bool running)
 {
     assert( QThread::currentThread() == qApp->thread() );
     _imp->runningClipPreferences = running;
+}
+
+// static
+bool
+EffectInstance::isSupportedRenderScale(SupportsEnum supportsRS, const RenderScale renderScale)
+{
+    return (supportsRS != eSupportsNo) || (renderScale.x == 1. && renderScale.y == 1.);
 }
 
 NATRON_NAMESPACE_EXIT

--- a/Engine/EffectInstance.cpp
+++ b/Engine/EffectInstance.cpp
@@ -5954,13 +5954,6 @@ EffectInstance::setClipPreferencesRunning(bool running)
     _imp->runningClipPreferences = running;
 }
 
-// static
-bool
-EffectInstance::isSupportedRenderScale(SupportsEnum supportsRS, const RenderScale renderScale)
-{
-    return (supportsRS != eSupportsNo) || (renderScale.x == 1. && renderScale.y == 1.);
-}
-
 NATRON_NAMESPACE_EXIT
 
 NATRON_NAMESPACE_USING

--- a/Engine/EffectInstance.h
+++ b/Engine/EffectInstance.h
@@ -1130,7 +1130,10 @@ protected:
     /**
      * @brief Returns true if the value of renderScale is supported for the given the value of supportsRS.
      **/
-    static bool isSupportedRenderScale(SupportsEnum supportsRS, const RenderScale renderScale);
+    static bool isSupportedRenderScale(SupportsEnum supportsRS, const RenderScale renderScale)
+    {
+        return (supportsRS != eSupportsNo) || (renderScale.x == 1. && renderScale.y == 1.);
+    }
 
 public:
 

--- a/Engine/EffectInstance.h
+++ b/Engine/EffectInstance.h
@@ -1127,6 +1127,11 @@ protected:
      **/
     virtual void getFrameRange(double *first, double *last);
 
+    /**
+     * @brief Returns true if the value of renderScale is supported for the given the value of supportsRS.
+     **/
+    static bool isSupportedRenderScale(SupportsEnum supportsRS, const RenderScale renderScale);
+
 public:
 
     StatusEnum getRegionOfDefinition_public(U64 hash,

--- a/Engine/EffectInstanceRenderRoI.cpp
+++ b/Engine/EffectInstanceRenderRoI.cpp
@@ -387,7 +387,7 @@ EffectInstance::renderRoI(const RenderRoIArgs & args,
         renderMappedMipMapLevel = args.mipMapLevel;
     }
     RenderScale renderMappedScale( Image::getScaleFromMipMapLevel(renderMappedMipMapLevel) );
-    assert( !( (supportsRS == eSupportsNo) && !(renderMappedScale.x == 1. && renderMappedScale.y == 1.) ) );
+    assert(isSupportedRenderScale(supportsRS, renderMappedScale));
 
 
     const FrameViewRequest* requestPassData = 0;
@@ -397,26 +397,27 @@ EffectInstance::renderRoI(const RenderRoIArgs & args,
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     ////////////////////////////// Get the RoD ///////////////////////////////////////////////////////////////
-    RectD rod; //!< rod is in canonical coordinates
+
+    RectD rodNc; //!< rod is in canonical coordinates
     bool isProjectFormat = false;
     {
         ///if the rod is already passed as parameter, just use it and don't call getRegionOfDefinition
         if ( !args.preComputedRoD.isNull() ) {
-            rod = args.preComputedRoD;
+            rodNc = args.preComputedRoD;
         } else {
             ///Check if the pre-pass already has the RoD
             if (requestPassData) {
-                rod = requestPassData->globalData.rod;
+                rodNc = requestPassData->globalData.rod;
                 isProjectFormat = requestPassData->globalData.isProjectFormat;
             } else {
-                assert( !( (supportsRS == eSupportsNo) && !(renderMappedScale.x == 1. && renderMappedScale.y == 1.) ) );
-                StatusEnum stat = getRegionOfDefinition_public(nodeHash, args.time, renderMappedScale, args.view, &rod, &isProjectFormat);
+                assert(isSupportedRenderScale(supportsRS, renderMappedScale));
+                StatusEnum stat = getRegionOfDefinition_public(nodeHash, args.time, renderMappedScale, args.view, &rodNc, &isProjectFormat);
 
                 ///The rod might be NULL for a roto that has no beziers and no input
                 if (stat == eStatusFailed) {
                     ///if getRoD fails, this might be because the RoD is null after all (e.g: an empty Roto node), we don't want the render to fail
                     return eRenderRoIRetCodeOk;
-                } else if ( rod.isNull() ) {
+                } else if ( rodNc.isNull() ) {
                     //Nothing to render
                     return eRenderRoIRetCodeOk;
                 }
@@ -432,18 +433,9 @@ EffectInstance::renderRoI(const RenderRoIArgs & args,
             }
         }
     }
+    const RectD rod = rodNc;
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     ////////////////////////////// End get RoD ///////////////////////////////////////////////////////////////
-    RectI roi;
-    {
-        if (renderFullScaleThenDownscale) {
-            //We cache 'image', hence the RoI should be expressed in its coordinates
-            //renderRoIInternal should check the bitmap of 'image' and not downscaledImage!
-            roi = args.roi.toNewMipMapLevel(args.mipMapLevel, 0, par, rod);
-        } else {
-            roi = args.roi;
-        }
-    }
 
     ///Determine needed planes
     ComponentsNeededMapPtr neededComps = std::make_shared<ComponentsNeededMap>();
@@ -553,7 +545,7 @@ EffectInstance::renderRoI(const RenderRoIArgs & args,
         double inputTimeIdentity = 0.;
         int inputNbIdentity;
         ViewIdx inputIdentityView(args.view);
-        assert( !( (supportsRS == eSupportsNo) && !(renderMappedScale.x == 1. && renderMappedScale.y == 1.) ) );
+        assert(isSupportedRenderScale(supportsRS, renderMappedScale));
         bool identity;
         const RectI pixelRod = rod.toPixelEnclosing(args.mipMapLevel, par);
         ViewInvarianceLevel viewInvariance = isViewInvariant();
@@ -736,39 +728,40 @@ EffectInstance::renderRoI(const RenderRoIArgs & args,
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     ////////////////////////////// Compute RoI depending on render scale ///////////////////////////////////////////////////
 
-
     RectI downscaledImageBoundsNc = rod.toPixelEnclosing(args.mipMapLevel, par);
     RectI upscaledImageBoundsNc = rod.toPixelEnclosing(0, par);
-    {
-        ///Make sure the RoI falls within the image bounds
-        ///Intersection will be in pixel coordinates
-        if (frameArgs->tilesSupported) {
-            if (renderFullScaleThenDownscale) {
-                if ( !roi.clipIfOverlaps(upscaledImageBoundsNc) ) {
-                    return eRenderRoIRetCodeOk;
-                }
-                assert(roi.x1 >= upscaledImageBoundsNc.x1 && roi.y1 >= upscaledImageBoundsNc.y1 &&
-                       roi.x2 <= upscaledImageBoundsNc.x2 && roi.y2 <= upscaledImageBoundsNc.y2);
-            } else {
-                if ( !roi.clipIfOverlaps(downscaledImageBoundsNc) ) {
-                    return eRenderRoIRetCodeOk;
-                }
-                assert(roi.x1 >= downscaledImageBoundsNc.x1 && roi.y1 >= downscaledImageBoundsNc.y1 &&
-                       roi.x2 <= downscaledImageBoundsNc.x2 && roi.y2 <= downscaledImageBoundsNc.y2);
-            }
-#ifndef NATRON_ALWAYS_ALLOCATE_FULL_IMAGE_BOUNDS
-            ///just allocate the roi
-            upscaledImageBoundsNc.clipIfOverlaps(roi);
-            downscaledImageBoundsNc.clipIfOverlaps(args.roi);
-#endif
+    RectI roi;
+
+    if (renderFullScaleThenDownscale) {
+        //We cache 'image', hence the RoI should be expressed in its coordinates
+        //renderRoIInternal should check the bitmap of 'image' and not downscaledImage!
+        roi = args.roi.toNewMipMapLevel(args.mipMapLevel, 0, par, rod);
+
+        if (frameArgs->tilesSupported && !roi.clipIfOverlaps(upscaledImageBoundsNc)) {
+            return eRenderRoIRetCodeOk;
         }
+        assert( upscaledImageBoundsNc.contains(roi));
+    } else {
+        roi = args.roi;
+
+        if (frameArgs->tilesSupported && !roi.clipIfOverlaps(downscaledImageBoundsNc)) {
+            return eRenderRoIRetCodeOk;
+        }
+        assert(downscaledImageBoundsNc.contains(roi));
     }
 
     /*
-     * Keep in memory what the user as requested, and change the roi to the full bounds if the effect doesn't support tiles
+     * Keep in memory what the user has requested, and change the roi to the full bounds if the effect doesn't support tiles
      */
     const RectI originalRoI = roi;
-    if (!frameArgs->tilesSupported) {
+
+    if (frameArgs->tilesSupported) {
+#ifndef NATRON_ALWAYS_ALLOCATE_FULL_IMAGE_BOUNDS
+        ///just allocate the roi
+        upscaledImageBoundsNc.clipIfOverlaps(roi);
+        downscaledImageBoundsNc.clipIfOverlaps(args.roi);
+#endif
+    } else {
         roi = renderFullScaleThenDownscale ? upscaledImageBoundsNc : downscaledImageBoundsNc;
     }
 
@@ -1199,10 +1192,9 @@ EffectInstance::renderRoI(const RenderRoIArgs & args,
                 if (!input) {
                     continue;
                 }
-                bool isProjectFormat;
                 ParallelRenderArgsPtr inputFrameArgs = input->getParallelRenderArgsTLS();
                 U64 inputHash = (inputFrameArgs) ? inputFrameArgs->nodeHash : input->getHash();
-                StatusEnum stat = input->getRegionOfDefinition_public(inputHash, args.time, args.scale, args.view, &inputRod, &isProjectFormat);
+                StatusEnum stat = input->getRegionOfDefinition_public(inputHash, args.time, args.scale, args.view, &inputRod, nullptr);
                 if ( (stat != eStatusOK) && !inputRod.isNull() ) {
                     break;
                 }
@@ -1909,7 +1901,7 @@ EffectInstance::renderRoIInternal(EffectInstance* self,
 
 
     if (callBegin) {
-        assert( !( (self->supportsRenderScaleMaybe() == eSupportsNo) && !(renderMappedScale.x == 1. && renderMappedScale.y == 1.) ) );
+        assert( self->isSupportedRenderScale(self->supportsRenderScaleMaybe(), renderMappedScale) );
         if (self->beginSequenceRender_public(time, time, 1, !appPTR->isBackground(), renderMappedScale, isSequentialRender,
                                        isRenderMadeInResponseToUserInteraction, frameArgs->draftMode, view, planesToRender->useOpenGL, planesToRender->glContextData) == eStatusFailed) {
             renderStatus = eRenderingFunctorRetFailed;
@@ -1997,7 +1989,7 @@ EffectInstance::renderRoIInternal(EffectInstance* self,
 
     ///never call endsequence render here if the render is sequential
     if (callBegin) {
-        assert( !( (self->supportsRenderScaleMaybe() == eSupportsNo) && !(renderMappedScale.x == 1. && renderMappedScale.y == 1.) ) );
+        assert( self->isSupportedRenderScale(self->supportsRenderScaleMaybe(), renderMappedScale) );
         if (self->endSequenceRender_public(time, time, time, false, renderMappedScale,
                                      isSequentialRender,
                                      isRenderMadeInResponseToUserInteraction,

--- a/Engine/OfxEffectInstance.cpp
+++ b/Engine/OfxEffectInstance.cpp
@@ -1598,7 +1598,7 @@ OfxEffectInstance::getRegionsOfInterest(double time,
     Q_UNUSED(outputRoD);
     assert(renderWindow.x2 >= renderWindow.x1 && renderWindow.y2 >= renderWindow.y1);
 
-    assert((supportsRenderScaleMaybe() != eSupportsNo) || (scale.x == 1. && scale.y == 1.));
+    assert(isSupportedRenderScale(supportsRenderScaleMaybe(), scale));
 
     OfxStatus stat;
 
@@ -1828,11 +1828,10 @@ OfxEffectInstance::isIdentity(double time,
     // isIdentity may be the first action with renderscale called on any effect.
     // it may have to check for render scale support.
     SupportsEnum supportsRS = supportsRenderScaleMaybe();
-    bool scaleIsOne = (scale.x == 1. && scale.y == 1.);
-    if ( (supportsRS == eSupportsNo) && !scaleIsOne ) {
-        qDebug() << "isIdentity called with render scale != 1, but effect does not support render scale!";
+    if (!isSupportedRenderScale(supportsRS, scale) ) {
+        qDebug() << "isIdentity called with an unsupported RenderScale!";
         assert(false);
-        throw std::logic_error("isIdentity called with render scale != 1, but effect does not support render scale!");
+        throw std::logic_error("isIdentity called with an unsupported RenderScale");
     }
 
     unsigned int mipMapLevel = Image::getLevelFromScale(scale.x);
@@ -1944,11 +1943,7 @@ OfxEffectInstance::beginSequenceRender(double first,
                                        bool isOpenGLRender,
                                        const EffectInstance::OpenGLContextEffectDataPtr& glContextData)
 {
-    {
-        bool scaleIsOne = (scale.x == 1. && scale.y == 1.);
-        assert( !( (supportsRenderScaleMaybe() == eSupportsNo) && !scaleIsOne ) );
-        Q_UNUSED(scaleIsOne);
-    }
+    assert(isSupportedRenderScale(supportsRenderScaleMaybe(), scale));
 
     OfxStatus stat;
     unsigned int mipMapLevel = Image::getLevelFromScale(scale.x);
@@ -1990,11 +1985,7 @@ OfxEffectInstance::endSequenceRender(double first,
                                      bool isOpenGLRender,
                                      const EffectInstance::OpenGLContextEffectDataPtr& glContextData)
 {
-    {
-        bool scaleIsOne = (scale.x == 1. && scale.y == 1.);
-        assert( !( (supportsRenderScaleMaybe() == eSupportsNo) && !scaleIsOne ) );
-        Q_UNUSED(scaleIsOne);
-    }
+    assert(isSupportedRenderScale(supportsRenderScaleMaybe(), scale));
 
     OfxStatus stat;
     unsigned int mipMapLevel = Image::getLevelFromScale(scale.x);


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

This change fixes 2 bugs where RectI objects containing information for different mipMapLevels were being intersected with each other. This was causing visible compositing errors in the viewer when viewing the image zoomed out, partially clipped by the edge of the viewer, and then pressing the "Forces a new render for the current frame" button. This fix just makes sure the RectIs are converted to the proper mipMapLevel before being intersected.

I also included a few cleanup changes that do not modify existing functionality but make the code a little easier to follow and verify correctness.

- Updated rod computation so that rod could be declared as const.  This is to make it easier to prove that this variable does not change beyond this point.
- Moved initial roi computation down to the image bounds computation code since that is where it is initially used and gets updated.
- Introduced isSupportedRenderScale() helper to remove duplicate code related to RenderScale support.

**Show a few screenshots (if this is a visual change)**

<img width="834" alt="RenderingBeforeBugFix" src="https://github.com/NatronGitHub/Natron/assets/300262/accfb831-237a-4436-af4e-90fb0b647193">
<img width="834" alt="RenderingAfterBugFix" src="https://github.com/NatronGitHub/Natron/assets/300262/cdf9b6f7-0dd6-4061-8fe2-bc16d4b86454">


**Have you tested your changes (if applicable)? If so, how?**

Yes. I've verified that my change fixes the rendering issues as shown in the image above.

**Futher details of this pull request**

These changes likely fix rendering issues in other scenarios as well. The one mentioned above is the easily repeatable one that I discovered and used for testing.

Technically, the  isSupportedRenderScale() change isn't entirely necessary, but I noticed the cleanup opportunity while updating the rod code.

