### PR TITLE
Fix pacman repo build

### DIFF
--- a/tools/MINGW-packages/mingw-w64-ffmpeg-gpl2/PKGBUILD
+++ b/tools/MINGW-packages/mingw-w64-ffmpeg-gpl2/PKGBUILD
@@ -49,7 +49,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
 source=(https://ffmpeg.org/releases/${_realname}-${pkgver}.tar.xz
         https://github.com/FFmpeg/FFmpeg/commit/effadce6c756247ea8bae32dc13bb3e6f464f0eb.patch)
 sha256sums=('6c5b6c195e61534766a0b5fe16acc919170c883362612816d0a1c7f4f947006e'
-            '206f4d8437b21f6197ffc444c86d0504892a5c2137cb227b4af1c1e8bf2c426c')
+            '8fad5f253bcda7a17523dbfcbfcfd60b3db23783dcdb65998005cddc7c7776c3')
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"

--- a/tools/MINGW-packages/mingw-w64-openimageio/PKGBUILD
+++ b/tools/MINGW-packages/mingw-w64-openimageio/PKGBUILD
@@ -35,7 +35,7 @@ source=(${_realname}-${pkgver}.tar.gz::https://github.com/OpenImageIO/oiio/archi
         oiio-2.2.14-libraw.diff
         oiio-2.4.13.0-thread-shutdown.patch # Remove when updating to a future 2.5 release that has these changes.
        )
-sha256sums=('72b7d2d5edd1049bb7fc09becad4d8be64a9918cdf79bae98b4b32e1fda762cd'
+sha256sums=('bb10a7ab6dff5dae2c6d854e9da38136546232235913237e8b1b3c99abb7dd0b'
             'SKIP'
             'e8aec185fd20a6e5cdf77a7155fcaedb301c07bd806f73bd30dfc75af721ac83'
             'd9c2e066ce0e94404d31fd649341cc0ee03faf9b4023dfcdf5cf59fbbf466127'
@@ -44,7 +44,7 @@ sha256sums=('72b7d2d5edd1049bb7fc09becad4d8be64a9918cdf79bae98b4b32e1fda762cd'
            )
 
 prepare() {
-  cd ${srcdir}/oiio-${pkgver}
+  cd ${srcdir}/OpenImageIO-${pkgver}
   #patch -p0 -i ${srcdir}/oiio-2.1.10-boost.diff
   patch -p1 -i ${srcdir}/oiio-2.0.8-invalidatespec.patch
   patch -p0 -i ${srcdir}/oiio-2.2.14-libraw.diff
@@ -92,7 +92,7 @@ build() {
     -DCMAKE_CXX_STANDARD=14 \
     -DCMAKE_SHARED_LINKER_FLAGS=" -Wl,--export-all-symbols -Wl,--enable-auto-import " \
     ${extra_config} \
-    ../oiio-${pkgver}
+    ../OpenImageIO-${pkgver}
   make
 }
 


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

This fixes pacman repo build failures.
- The OpenImageIO source tar ball changed the directory name it stores the source files in, which in turn caused the sha256sum to change. The directory name and tarball sha256sum were updated.
- Some index hashes in an ffmpeg patch we were fetching from github now have extra digits. This caused the sha256sum to change, which caused the build to fail. The sha256sum was updated for the patch file.

**Have you tested your changes (if applicable)? If so, how?**

Yes. I've verified the pacman repo successfully builds with these changes .(https://github.com/acolwell/Natron/actions/runs/6398435536)

