### PR TITLE
Add BT1886 view EOTF

### DIFF
--- a/Engine/ImageConvert.cpp
+++ b/Engine/ImageConvert.cpp
@@ -115,6 +115,9 @@ lutFromColorspace(ViewerColorSpaceEnum cs)
     case eViewerColorSpaceRec709:
         lut = Color::LutManager::Rec709Lut();
         break;
+    case eViewerColorSpaceBT1886:
+        lut = Color::LutManager::BT1886Lut();
+        break;
     case eViewerColorSpaceLinear:
     default:
         lut = 0;

--- a/Engine/Lut.cpp
+++ b/Engine/Lut.cpp
@@ -1293,6 +1293,12 @@ LutManager::sRGBLut()
     return LutManager::m_instance.getLut("sRGB", from_func_srgb, to_func_srgb);
 }
 
+const Lut*
+LutManager::BT1886Lut()
+{
+    return LutManager::m_instance.getLut("BT1886", from_func_bt1886, to_func_bt1886);
+}
+
 // Rec.709 and Rec.2020 share the same transfer function (and illuminant), except that
 // Rec.2020 is more precise.
 // https://www.itu.int/dms_pubrec/itu-r/rec/bt/R-REC-BT.2020-0-201208-S!!PDF-E.pdf

--- a/Engine/Lut.h
+++ b/Engine/Lut.h
@@ -89,6 +89,7 @@ public:
     ///buit-ins color-spaces
     static const Lut* sRGBLut();
     static const Lut* Rec709Lut();
+    static const Lut* BT1886Lut();
     static const Lut* CineonLut();
     static const Lut* Gamma1_8Lut();
     static const Lut* Gamma2_2Lut();
@@ -494,6 +495,18 @@ to_func_srgb(float v)
     } else {
         return 1.055f * std::pow(v, 1.0f / 2.4f) - 0.055f;
     }
+}
+
+inline float
+from_func_bt1886(float v)
+{
+    return std::pow(v, 2.4);
+}
+
+inline float
+to_func_bt1886(float v)
+{
+    return std::pow(v, 1.0/2.4);
 }
 
 // r,g,b values are from 0 to 1

--- a/Engine/Project.cpp
+++ b/Engine/Project.cpp
@@ -1001,6 +1001,7 @@ Project::initializeKnobs()
     colorSpaces.push_back(ChoiceOption("Linear","",""));
     colorSpaces.push_back(ChoiceOption("sRGB","",""));
     colorSpaces.push_back(ChoiceOption("Rec.709","",""));
+    colorSpaces.push_back(ChoiceOption("BT1886","",""));
 
     _imp->colorSpace8u = AppManager::createKnob<KnobChoice>( this, tr("8-Bit LUT") );
     _imp->colorSpace8u->setName("defaultColorSpace8u");

--- a/Engine/ViewerInstance.cpp
+++ b/Engine/ViewerInstance.cpp
@@ -140,6 +140,9 @@ ViewerInstance::lutFromColorspace(ViewerColorSpaceEnum cs)
     case eViewerColorSpaceRec709:
         lut = Color::LutManager::Rec709Lut();
         break;
+    case eViewerColorSpaceBT1886:
+        lut = Color::LutManager::BT1886Lut();
+        break;
     case eViewerColorSpaceLinear:
     default:
         lut = 0;

--- a/Global/Enums.h
+++ b/Global/Enums.h
@@ -441,7 +441,8 @@ enum ViewerColorSpaceEnum
 {
     eViewerColorSpaceSRGB = 0,
     eViewerColorSpaceLinear,
-    eViewerColorSpaceRec709
+    eViewerColorSpaceRec709,
+    eViewerColorSpaceBT1886
 };
 
 enum ImageBitDepthEnum

--- a/Gui/Shaders.cpp
+++ b/Gui/Shaders.cpp
@@ -45,24 +45,22 @@ const char* fragRGB =
     "float linear_to_bt1886(float c) {"
     "    return pow(c,1.0/2.4);\n"
     "}\n"
-    "void main(){\n"
+    "void main() {\n"
     "    vec4 color_tmp = texture2D(Tex,gl_TexCoord[0].st);\n"
     "    color_tmp.rgb = (color_tmp.rgb * gain) + offset;\n"
-    "    if(lut == 0){ // srgb\n"
+    "    if (lut == 0) { // srgb\n"
 // << TO SRGB
     "       color_tmp.r = linear_to_srgb(color_tmp.r);\n"
     "       color_tmp.g = linear_to_srgb(color_tmp.g);\n"
     "       color_tmp.b = linear_to_srgb(color_tmp.b);\n"
 // << END TO SRGB
-    "   }\n"
-    "   else if (lut == 2){ // Rec 709\n"
+    "   } else if (lut == 2) { // Rec 709\n"
 // << TO REC 709
     "       color_tmp.r = linear_to_rec709(color_tmp.r);\n"
     "       color_tmp.g = linear_to_rec709(color_tmp.g);\n"
     "       color_tmp.b = linear_to_rec709(color_tmp.b);\n"
 // << END TO REC 709
-    "   }\n"
-    "   else if (lut == 3){ // BT1886\n"
+    "   } else if (lut == 3) { // BT1886\n"
 // << TO BT1886
     "       color_tmp.r = linear_to_bt1886(color_tmp.r);\n"
     "       color_tmp.g = linear_to_bt1886(color_tmp.g);\n"

--- a/Gui/Shaders.cpp
+++ b/Gui/Shaders.cpp
@@ -42,6 +42,9 @@ const char* fragRGB =
     "float linear_to_rec709(float c) {"
     "    return (c<0.018) ? (4.500*c) : (1.099*pow(c,0.45) - 0.099);\n"
     "}\n"
+    "float linear_to_bt1886(float c) {"
+    "    return pow(c,1.0/2.4);\n"
+    "}\n"
     "void main(){\n"
     "    vec4 color_tmp = texture2D(Tex,gl_TexCoord[0].st);\n"
     "    color_tmp.rgb = (color_tmp.rgb * gain) + offset;\n"
@@ -52,11 +55,20 @@ const char* fragRGB =
     "       color_tmp.b = linear_to_srgb(color_tmp.b);\n"
 // << END TO SRGB
     "   }\n"
-    "   else if (lut == 2){ // Rec 709\n" // << TO REC 709
+    "   else if (lut == 2){ // Rec 709\n"
+// << TO REC 709
     "       color_tmp.r = linear_to_rec709(color_tmp.r);\n"
     "       color_tmp.g = linear_to_rec709(color_tmp.g);\n"
     "       color_tmp.b = linear_to_rec709(color_tmp.b);\n"
-    "   }\n" // << END TO REC 709
+// << END TO REC 709
+    "   }\n"
+    "   else if (lut == 3){ // BT1886\n"
+// << TO BT1886
+    "       color_tmp.r = linear_to_bt1886(color_tmp.r);\n"
+    "       color_tmp.g = linear_to_bt1886(color_tmp.g);\n"
+    "       color_tmp.b = linear_to_bt1886(color_tmp.b);\n"
+// << END TO BT1886
+    "   }\n"
     "   if (gamma <= 0.) {\n"
     "       color_tmp.r = (color_tmp.r >= 1.) ? 1. : 0.;\n"
     "       color_tmp.g = (color_tmp.g >= 1.) ? 1. : 0.;\n"

--- a/Gui/ViewerTab.cpp
+++ b/Gui/ViewerTab.cpp
@@ -528,6 +528,7 @@ ViewerTab::ViewerTab(const std::list<NodeGuiPtr> & existingNodesContext,
     _imp->viewerColorSpace->addItem( QString::fromUtf8("Linear(None)") );
     _imp->viewerColorSpace->addItem( QString::fromUtf8("sRGB") );
     _imp->viewerColorSpace->addItem( QString::fromUtf8("Rec.709") );
+    _imp->viewerColorSpace->addItem( QString::fromUtf8("BT1886") );
     _imp->viewerColorSpace->setCurrentIndex(1);
 
     QPixmap pixCheckerboardEnabled, pixCheckerboardDisabld;

--- a/Gui/ViewerTab10.cpp
+++ b/Gui/ViewerTab10.cpp
@@ -76,6 +76,8 @@ ViewerTab::onColorSpaceComboBoxChanged(int v)
         colorspace = eViewerColorSpaceSRGB;
     } else if (v == 2) {
         colorspace = eViewerColorSpaceRec709;
+    } else if (v == 3) {
+        colorspace = eViewerColorSpaceBT1886;
     } else {
         assert(false);
         throw std::logic_error("ViewerTab::onColorSpaceComboBoxChanged(): unknown colorspace");

--- a/Gui/ViewerTab30.cpp
+++ b/Gui/ViewerTab30.cpp
@@ -89,8 +89,11 @@ ViewerTab::getColorSpace() const
 
         return "Rec.709";
         break;
-    default:
+    case eViewerColorSpaceBT1886:
 
+        return "BT1886";
+        break;
+    default:
         return "";
         break;
     }


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Add BT1886 display EOTF

**Have you tested your changes (if applicable)? If so, how?**

Yes, by comparing with other software (Nuke)

**Futher details of this pull request**

I added this EOTF because it was missing. BT1886 is the correct monitor "gamma" for Rec2020/Rec709 HDTV.
I discovered that the Rec709 EOTF used in Natron is the one for camera linear to non-linear signal, so it seems a bit useless to me.

Here is a note about it in wikipedia : 

**Rec. 709 specifies a [non-linear](https://en.wikipedia.org/wiki/Nonlinear_system) OETF ([opto-electrical transfer function](https://en.wikipedia.org/wiki/Opto-electronic_transfer_function)) which is known as the "camera [gamma](https://en.wikipedia.org/wiki/Gamma_correction)" and which describes how [HDTV](https://en.wikipedia.org/wiki/High-definition_television) camera encodes the [linear](https://en.wikipedia.org/wiki/Linear_function_(calculus)) scene light into a non-linear electrical signal value. Rec. 709 doesn't specify the display EOTF ([electro-optical transfer function](https://en.wikipedia.org/wiki/Electro-optical_transfer_function)) which describes how [HDTV](https://en.wikipedia.org/wiki/High-definition_television) displays should convert the non-linear electrical signal into linear displayed light, that was done in [ITU-R BT.1886](https://en.wikipedia.org/wiki/ITU-R_BT.1886). Rec.709 is "scene-referred", which means that change of primaries should happen on scene linear light (by applying inverse OETF, changing primaries and applying OETF again, only after which you convert to display linear light using EOTF).**
