### PR TITLE
Fix Windows build busters.

### DIFF
--- a/.github/workflows/build_installer.yml
+++ b/.github/workflows/build_installer.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch: {}
   push:
 
+env:
+  NATRON_BUILD_WORKSPACE: 'D:/nbw'
+  CI: 'True'
+
 jobs:
   win-installer:
     name: Windows Installer
@@ -11,8 +15,6 @@ jobs:
     defaults:
       run:
         shell: msys2 {0}
-    env:
-      CI: 'True'
 
     steps:
       - name: Checkout branch
@@ -41,7 +43,6 @@ jobs:
       - name: Build
         id: build
         run: |
-          NATRON_BUILD_WORKSPACE=${GITHUB_WORKSPACE}/natron_build
           NATRON_BUILD_WORKSPACE_UNIX=$(cygpath -u ${NATRON_BUILD_WORKSPACE})
           mkdir ${NATRON_BUILD_WORKSPACE_UNIX}
 
@@ -76,8 +77,6 @@ jobs:
     defaults:
       run:
         shell: msys2 {0}
-    env:
-      CI: 'True'
 
     steps:
       - name: Checkout branch
@@ -106,7 +105,6 @@ jobs:
       - name: Build
         id: build
         run: |
-          NATRON_BUILD_WORKSPACE=${GITHUB_WORKSPACE}/natron_build
           NATRON_BUILD_WORKSPACE_UNIX=$(cygpath -u ${NATRON_BUILD_WORKSPACE})
           mkdir ${NATRON_BUILD_WORKSPACE_UNIX}
 

--- a/Global/GlobalDefines.h
+++ b/Global/GlobalDefines.h
@@ -26,6 +26,7 @@
 #include <Python.h>
 // ***** END PYTHON BLOCK *****
 
+#include <cstdint>
 #include <utility>
 #if defined(_WIN32)
 #include <string>
@@ -47,9 +48,6 @@
 #undef isalpha
 #undef isalnum
 
-#if !defined(Q_MOC_RUN) && !defined(SBK_RUN)
-#include <cstdint>
-#endif
 #include <QtCore/QtGlobal>
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 #include <QtCore/QForeachContainer>


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**
This change fixes the Windows build. Recently msys2 updated pyside2/shiboken2 to version 5.15.11. This caused the build to start complaining about types like std::uint32_t & std::uint64_t being undefined when running shiboken2 to generate python stubs. This change makes the code always include cstdint since the typedefs derived from cstdint types are not guarded by #ifdefs. A few other minor changes were made to make the build process a little more robust.

This pull request contains the following changes:
- Always include cstdint in GlobalDefines.h to avoid missing decl errors.
- Change NATRON_BUILD_WORKSPACE to a shorter path to avoid path length errors that can occur during python file compilation.
- Change logic in build-Windows-installer.sh related to mt.exe and the Qt Installer Framework so that these binaries could be retrieved from the Windows SDK and msys2 respectively.

**Have you tested your changes (if applicable)? If so, how?**

Yes. The "Build Installer" and "Tests" GitHub actions build on Windows again. (https://github.com/acolwell/Natron/actions/runs/6537802581)
(https://github.com/acolwell/Natron/actions/runs/6539421923)
