### PR TITLE
Temporarily add clang dependency to natron-build-deps-qt5 package.

### DIFF
--- a/tools/MINGW-packages/mingw-w64-natron-build-deps-qt5/PKGBUILD
+++ b/tools/MINGW-packages/mingw-w64-natron-build-deps-qt5/PKGBUILD
@@ -15,6 +15,12 @@ depends=(
   "${MINGW_PACKAGE_PREFIX}-qt5-base"
   "${MINGW_PACKAGE_PREFIX}-pyside2"
   "${MINGW_PACKAGE_PREFIX}-shiboken2"
+  # Clang is needed by shiboken2 for now because shiboken2 can't seem to find g++. It appears
+  # shiboken2 includes hard-coded paths to the g++ binary that is used when shiboken2 is built for msys2.
+  # Remove this dependency when the shiboken2 package is fixed so it works w/o clang or updates its pkg deps.
+  # The following change to msys2 made adding this clang dependency necessary.
+  # https://github.com/msys2/MINGW-packages/commit/c21027404c9d8776ad7dad94973a209bdc3aede2
+  "${MINGW_PACKAGE_PREFIX}-clang"
   "${MINGW_PACKAGE_PREFIX}-python-qtpy"
   # openfx-misc deps
   "${MINGW_PACKAGE_PREFIX}-osmesa"


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Updates the natron-build-deps-qt5 MinGW package to have a dependency on the clang package. This is needed because a recent change to the MSYS shiboken2 package (https://github.com/msys2/MINGW-packages/commit/c21027404c9d8776ad7dad94973a209bdc3aede2) broke the Windows Natron build. I believe the underlying issue stems from the MSYS shiboken2 not being able to find g++ because it tries to look for it in a hard-coded path that is only valid when that package was built. Unfortunately fixing that issue might not be straight forward, so for now I'm adding back the dependency on clang so that Natron is at least able to build again on Windows.


**Have you tested your changes (if applicable)? If so, how?**

Yes. I've rebuilt the natron-build-deps-qt5 package locally and used it to build Natron. I've also verified that "Build pacman repo" action is able to build the package as well (https://github.com/acolwell/Natron/actions/runs/7341376846).

**Futher details of this pull request**

The Windows installer and Test build actions will not start working again until the "Natron MinGW pacman repository" release (https://github.com/NatronGitHub/Natron/releases/tag/windows-mingw-package-repo) is updated with the new packages. My plan is to land this change and then update the release with a new zip file generated from the "Build pacman repo" action. Once that is done, the  Windows installer and Test actions should start working again.
