### PR TITLE
Updating CI workflow on Windows to use Natron pacman repo for deps.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,10 +139,18 @@ jobs:
         with:
           msystem: mingw64
           update: true
-          install: git base-devel mingw-w64-x86_64-cc mingw-w64-x86_64-qt5-base mingw-w64-x86_64-pyside2
-            mingw-w64-x86_64-shiboken2 mingw-w64-x86_64-python-qtpy mingw-w64-x86_64-ninja
-            mingw-w64-x86_64-cmake mingw-w64-x86_64-boost mingw-w64-x86_64-cairo mingw-w64-x86_64-expat
-            mingw-w64-x86_64-wget unzip
+          install: git mingw-w64-x86_64-wget unzip mingw-w64-x86_64-ninja mingw-w64-x86_64-cmake
+
+      - name: Install Natron pacman repository
+        run: |
+          mkdir ${GITHUB_WORKSPACE}/natron_pacman_repo
+          cd ${GITHUB_WORKSPACE}/natron_pacman_repo
+          wget https://github.com/NatronGitHub/Natron/releases/download/windows-mingw-package-repo/natron_package_repo.zip
+          unzip natron_package_repo.zip
+          NATRON_REPO_PATH=`cygpath -u $GITHUB_WORKSPACE`
+          echo -e "#NATRON_REPO_START\n[natron]\nSigLevel = Optional TrustAll\nServer = file://${NATRON_REPO_PATH}/natron_pacman_repo/\n#NATRON_REPO_END" >> /etc/pacman.conf
+          pacman -Syl natron
+          pacman -S --needed --noconfirm mingw-w64-x86_64-natron-build-deps-qt5
 
       - name: Download OpenColorIO-Configs
         run: |


### PR DESCRIPTION

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

It changes the CI workflow to use the Natron pacman repo like the "Build Installer" workflow does. This allows both workflows to benefit from fixes made in the Natron pacman repo.

- Adding a step to the Windows workflow that downloads and sets up the Natron pacman repo. This is copied from the "Build Installer" workflow.
- Removed dependencies from the "Install Windows system packages" that are installed when the mingw-w64-x86_64-natron-build-deps-qt5 package is installed.


**Have you tested your changes (if applicable)? If so, how?**

Yes. I've verified that the "Tests" action in the CI workflow builds again on Windows. (https://github.com/acolwell/Natron/actions/runs/7350002125)

**Futher details of this pull request**

This change is needed so that #935 also fixes the CI "Tests" workflow for Windows. All workflows should now pass.