### PR TITLE
Verify plugins are loadable in Windows installer builds and fix missing dependencies

### DIFF
--- a/.github/workflows/build_installer.yml
+++ b/.github/workflows/build_installer.yml
@@ -59,6 +59,22 @@ jobs:
           echo "INSTALLER_NAME=${INSTALLER_NAME}" >> $GITHUB_OUTPUT
           echo "INSTALLER_DIR=$(cygpath -m ${INSTALLER_DIR})" >> $GITHUB_OUTPUT
 
+      - name: Build verify_plugin_loads binary
+        run: |
+          g++ -DWINDOWS -o verify_plugin_loads .github/workflows/verify_plugin_loads.cpp libs/OpenFX/HostSupport/src/ofxhBinary.cpp libs/OpenFX/HostSupport/src/ofxhUtilities.cpp -I libs/OpenFX/HostSupport/include/ -I libs/OpenFX/include/
+
+      - name: Uninstall Natron dependencies
+        run: |
+          pacman -Rs --noconfirm mingw-w64-x86_64-natron-build-deps-qt5
+
+      - name: Verify plugin loading
+        run: |
+          INSTALLER_DIR=$(cygpath -u '${{ steps.build.outputs.INSTALLER_DIR }}')/${{ steps.build.outputs.INSTALLER_NAME }}
+          for x in $(find ${INSTALLER_DIR}/Plugins -name *.ofx); do
+            echo "Testing $(basename ${x}) ..."
+            PATH=${INSTALLER_DIR}/bin ./verify_plugin_loads.exe "${x}"
+          done
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.3.1
         with:
@@ -124,6 +140,22 @@ jobs:
 
           echo "SYMBOLS_NAME=${SYMBOLS_NAME}" >> $GITHUB_OUTPUT
           echo "SYMBOLS_DIR=$(cygpath -m ${SYMBOLS_DIR})" >> $GITHUB_OUTPUT
+
+      - name: Build verify_plugin_loads binary
+        run: |
+          g++ -DWINDOWS -o verify_plugin_loads .github/workflows/verify_plugin_loads.cpp libs/OpenFX/HostSupport/src/ofxhBinary.cpp libs/OpenFX/HostSupport/src/ofxhUtilities.cpp -I libs/OpenFX/HostSupport/include/ -I libs/OpenFX/include/
+
+      - name: Uninstall Natron dependencies
+        run: |
+          pacman -Rs --noconfirm mingw-w64-x86_64-natron-build-deps-qt5
+
+      - name: Verify plugin loading
+        run: |
+          INSTALLER_DIR=$(cygpath -u '${{ steps.build.outputs.INSTALLER_DIR }}')/${{ steps.build.outputs.INSTALLER_NAME }}
+          for x in $(find ${INSTALLER_DIR}/Plugins -name *.ofx); do
+            echo "Testing $(basename ${x}) ..."
+            PATH=${INSTALLER_DIR}/bin ./verify_plugin_loads.exe "${x}"
+          done
 
       - name: Upload installer
         uses: actions/upload-artifact@v4.3.1

--- a/.github/workflows/verify_plugin_loads.cpp
+++ b/.github/workflows/verify_plugin_loads.cpp
@@ -1,0 +1,58 @@
+
+#include "ofxhBinary.h"
+#include "ofxhPluginCache.h"
+
+int
+main(int argc, const char* argv[])
+{
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <plugin>\n";
+        return 1;
+    }
+
+    const char* const binaryPath = argv[1];
+
+    // TODO: Change code to _dlHandle = dlopen(_binaryPath.c_str(), RTLD_NOW|RTLD_LOCAL);
+    OFX::Binary bin(binaryPath);
+
+    if (bin.isInvalid()) {
+        std::cerr << "error: '" << binaryPath << "' is invalid.\n";
+        return 1;
+    }
+
+    bin.load();
+
+    if (!bin.isLoaded()) {
+        std::cerr << "error: '" << binaryPath << "' failed to load.\n";
+        return 1;
+    }
+
+    auto* getNumberOfPlugins = (OFX::Host::OfxGetNumberOfPluginsFunc)bin.findSymbol("OfxGetNumberOfPlugins");
+    auto* getPluginFunc = (OFX::Host::OfxGetPluginFunc)bin.findSymbol("OfxGetPlugin");
+
+    if (getNumberOfPlugins == nullptr || getPluginFunc == nullptr) {
+        std::cerr << "error: '" << binaryPath << "' missing required symbols.\n";
+        return 1;
+    }
+
+    const int numPlugins = getNumberOfPlugins();
+
+    std::cout << "numPlugins: " << numPlugins << "\n";
+
+    if (numPlugins <= 0) {
+        std::cerr << "error: unexpected number of plugins.\n";
+        return 1;
+    }
+
+    for (int i = 0; i < numPlugins; ++i) {
+        auto* plugin = getPluginFunc(i);
+        if (plugin == nullptr) {
+            std::cerr << "Failed to get plugin " << i << "\n";
+            return 1;
+        }
+
+        std::cout << "plugin[" << i << "] : " << plugin->pluginIdentifier << " v" << plugin->pluginVersionMajor << "." << plugin->pluginVersionMinor << "\n";
+    }
+
+    return 0;
+}

--- a/tools/jenkins/genDllVersions.sh
+++ b/tools/jenkins/genDllVersions.sh
@@ -254,6 +254,8 @@ catDll libdatrie-
 catDll libsnappy
 #catDll libpugixml
 catDll libheif
+catDll libkvazaar-
+catDll libcryptopp
 catDll rav1e
 catDll libde265-
 catDll libx265


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

- Adds logic to the "Build Installer" GitHub action that verifies that the plugins that are built are actually loadable. This is intended to catch missing dependencies.
- Added missing libheif dependencies that were preventing the Arena and IO plugins from loading.


**Have you tested your changes (if applicable)? If so, how?**

Yes. I tested that the new logic properly detects that the plugins were not loadable and causes the build to fail (https://github.com/acolwell/Natron/actions/runs/7935008735). I then added the missing dependencies and verified that the build started passing again (https://github.com/acolwell/Natron/actions/runs/7935721812).

**Futher details of this pull request**

I'm not exactly sure when libheif took on the new dependencies, but I do know my nightly builds were passing even though the plugins had missing dependencies. This change is intended to make it easier to detect when these new dependencies sneak in and break plugin loading.
