### PR TITLE
Refactor clipIfOverlaps() so it does not have a return value.

### DIFF
--- a/Engine/EffectInstanceRenderRoI.cpp
+++ b/Engine/EffectInstanceRenderRoI.cpp
@@ -738,7 +738,8 @@ EffectInstance::renderRoI(const RenderRoIArgs & args,
         roi = args.roi.toNewMipmapLevel(args.mipmapLevel, 0, par, rod);
 
         if (frameArgs->tilesSupported) {
-            if (!roi.clipIfOverlaps(upscaledImageBoundsNc)) {
+            roi.clip(upscaledImageBoundsNc);
+            if (roi.isNull()) {
                 return eRenderRoIRetCodeOk;
             }
             assert(upscaledImageBoundsNc.contains(roi));
@@ -747,7 +748,8 @@ EffectInstance::renderRoI(const RenderRoIArgs & args,
         roi = args.roi;
 
         if (frameArgs->tilesSupported) {
-            if (!roi.clipIfOverlaps(downscaledImageBoundsNc)) {
+            roi.clip(downscaledImageBoundsNc);
+            if (roi.isNull()) {
                 return eRenderRoIRetCodeOk;
             }
             assert(downscaledImageBoundsNc.contains(roi));
@@ -844,8 +846,8 @@ EffectInstance::renderRoI(const RenderRoIArgs & args,
                 renderMappedMipmapLevel = args.mipmapLevel;
                 renderMappedScale = RenderScale::fromMipmapLevel(renderMappedMipmapLevel);
                 if (frameArgs->tilesSupported) {
-                    roi = args.roi;
-                    if ( !roi.clipIfOverlaps(downscaledImageBoundsNc) ) {
+                    roi = args.roi.intersect(downscaledImageBoundsNc);
+                    if ( roi.isNull() ) {
                         return eRenderRoIRetCodeOk;
                     }
                 } else {

--- a/Engine/Lut.cpp
+++ b/Engine/Lut.cpp
@@ -167,11 +167,12 @@ LutManager::~LutManager()
     }
 }
 
-static bool
-clip(RectI* what,
-     const RectI & to)
+static RectI
+clip(const RectI& what,
+     const RectI& srcBounds,
+     const RectI& dstBounds)
 {
-    return what->clipIfOverlaps(to);
+    return what.intersect(srcBounds).intersect(dstBounds);
 }
 
 #ifdef DEAD_CODE
@@ -445,9 +446,9 @@ Lut::to_byte_packed(unsigned char* to,
                     bool premult) const
 {
     ///clip the conversion rect to srcBounds and dstBounds
-    RectI rect = conversionRect;
+    const RectI rect = clip(conversionRect, srcBounds, dstBounds);
 
-    if ( !clip(&rect, srcBounds) || !clip(&rect, dstBounds) ) {
+    if ( rect.isNull() ) {
         return;
     }
 
@@ -546,9 +547,8 @@ Lut::to_float_packed(float* to,
                      bool premult) const
 {
     ///clip the conversion rect to srcBounds and dstBounds
-    RectI rect = conversionRect;
-
-    if ( !clip(&rect, srcBounds) || !clip(&rect, dstBounds) ) {
+    const RectI rect = clip(conversionRect, srcBounds, dstBounds);
+    if ( rect.isNull()) {
         return;
     }
 
@@ -658,8 +658,8 @@ Lut::from_byte_packed(float* to,
     }
 
     ///clip the conversion rect to srcBounds and dstBounds
-    RectI rect = conversionRect;
-    if ( !clip(&rect, srcBounds) || !clip(&rect, dstBounds) ) {
+    const RectI rect = clip(conversionRect, srcBounds, dstBounds);
+    if ( rect.isNull() ) {
         return;
     }
 
@@ -752,8 +752,8 @@ Lut::from_float_packed(float* to,
     }
 
     ///clip the conversion rect to srcBounds and dstBounds
-    RectI rect = conversionRect;
-    if ( !clip(&rect, srcBounds) || !clip(&rect, dstBounds) ) {
+    const RectI rect = clip(conversionRect, srcBounds, dstBounds);
+    if ( rect.isNull() ) {
         return;
     }
 
@@ -863,8 +863,8 @@ from_byte_packed(float *to,
     }
 
     ///clip the conversion rect to srcBounds and dstBounds
-    RectI rect = conversionRect;
-    if ( !clip(&rect, srcBounds) || !clip(&rect, dstBounds) ) {
+    const RectI rect = clip(conversionRect, srcBounds, dstBounds);
+    if ( rect.isNull() ) {
         return;
     }
 
@@ -933,8 +933,8 @@ from_float_packed(float *to,
 
 
     ///clip the conversion rect to srcBounds and dstBounds
-    RectI rect = conversionRect;
-    if ( !clip(&rect, srcBounds) || !clip(&rect, dstBounds) ) {
+    const RectI rect = clip(conversionRect, srcBounds, dstBounds);
+    if ( rect.isNull()) {
         return;
     }
 
@@ -1132,8 +1132,8 @@ to_byte_packed(unsigned char* to,
     }
 
     ///clip the conversion rect to srcBounds and dstBounds
-    RectI rect = conversionRect;
-    if ( !clip(&rect, srcBounds) || !clip(&rect, dstBounds) ) {
+    const RectI rect = clip(conversionRect, srcBounds, dstBounds);
+    if ( rect.isNull() ) {
         return;
     }
 
@@ -1241,8 +1241,8 @@ to_float_packed(float* to,
     }
 
     ///clip the conversion rect to srcBounds and dstBounds
-    RectI rect = conversionRect;
-    if ( !clip(&rect, srcBounds) || !clip(&rect, dstBounds) ) {
+    const RectI rect = clip(conversionRect, srcBounds, dstBounds);
+    if ( rect.isNull() ) {
         return;
     }
 

--- a/Engine/Lut.cpp
+++ b/Engine/Lut.cpp
@@ -168,9 +168,9 @@ LutManager::~LutManager()
 }
 
 static RectI
-clip(const RectI& what,
-     const RectI& srcBounds,
-     const RectI& dstBounds)
+clip2(const RectI& what,
+      const RectI& srcBounds,
+      const RectI& dstBounds)
 {
     return what.intersect(srcBounds).intersect(dstBounds);
 }
@@ -446,7 +446,7 @@ Lut::to_byte_packed(unsigned char* to,
                     bool premult) const
 {
     ///clip the conversion rect to srcBounds and dstBounds
-    const RectI rect = clip(conversionRect, srcBounds, dstBounds);
+    const RectI rect = clip2(conversionRect, srcBounds, dstBounds);
 
     if ( rect.isNull() ) {
         return;
@@ -547,7 +547,7 @@ Lut::to_float_packed(float* to,
                      bool premult) const
 {
     ///clip the conversion rect to srcBounds and dstBounds
-    const RectI rect = clip(conversionRect, srcBounds, dstBounds);
+    const RectI rect = clip2(conversionRect, srcBounds, dstBounds);
     if ( rect.isNull()) {
         return;
     }
@@ -658,7 +658,7 @@ Lut::from_byte_packed(float* to,
     }
 
     ///clip the conversion rect to srcBounds and dstBounds
-    const RectI rect = clip(conversionRect, srcBounds, dstBounds);
+    const RectI rect = clip2(conversionRect, srcBounds, dstBounds);
     if ( rect.isNull() ) {
         return;
     }
@@ -752,7 +752,7 @@ Lut::from_float_packed(float* to,
     }
 
     ///clip the conversion rect to srcBounds and dstBounds
-    const RectI rect = clip(conversionRect, srcBounds, dstBounds);
+    const RectI rect = clip2(conversionRect, srcBounds, dstBounds);
     if ( rect.isNull() ) {
         return;
     }
@@ -863,7 +863,7 @@ from_byte_packed(float *to,
     }
 
     ///clip the conversion rect to srcBounds and dstBounds
-    const RectI rect = clip(conversionRect, srcBounds, dstBounds);
+    const RectI rect = clip2(conversionRect, srcBounds, dstBounds);
     if ( rect.isNull() ) {
         return;
     }
@@ -933,7 +933,7 @@ from_float_packed(float *to,
 
 
     ///clip the conversion rect to srcBounds and dstBounds
-    const RectI rect = clip(conversionRect, srcBounds, dstBounds);
+    const RectI rect = clip2(conversionRect, srcBounds, dstBounds);
     if ( rect.isNull()) {
         return;
     }
@@ -1132,7 +1132,7 @@ to_byte_packed(unsigned char* to,
     }
 
     ///clip the conversion rect to srcBounds and dstBounds
-    const RectI rect = clip(conversionRect, srcBounds, dstBounds);
+    const RectI rect = clip2(conversionRect, srcBounds, dstBounds);
     if ( rect.isNull() ) {
         return;
     }
@@ -1241,7 +1241,7 @@ to_float_packed(float* to,
     }
 
     ///clip the conversion rect to srcBounds and dstBounds
-    const RectI rect = clip(conversionRect, srcBounds, dstBounds);
+    const RectI rect = clip2(conversionRect, srcBounds, dstBounds);
     if ( rect.isNull() ) {
         return;
     }

--- a/Engine/RectD.h
+++ b/Engine/RectD.h
@@ -266,13 +266,22 @@ public:
     }
 
     /**
-     * @brief Updates this rectangle to the intersection rectangle if this rectangle overlaps with rect. If there is no overlap then this rectangle remains unchanged.
-     *
-     * @returns True if the rectangles overlap and this rectangle was clipped.
+     * @brief Updates this rectangle to the intersection of this rectangle and |rect|. If there is no overlap, this rectangle is cleared so it represents a
+     * null rectangle.
      **/
-    bool clipIfOverlaps(const RectD& rect)
+    void clip(const RectD& rect) {
+        if (!intersectInternal(rect, this)) {
+            // |rect| does not intersect with *this so clear this object so it becomes a null rectangle.
+            clear();
+        }
+    }
+
+    /**
+     * @brief Updates this rectangle to the intersection rectangle if this rectangle overlaps with rect. If there is no overlap then this rectangle remains unchanged.
+     **/
+    void clipIfOverlaps(const RectD& rect)
     {
-        return intersectInternal(rect, this);
+        intersectInternal(rect, this);
     }
 
     /// returns true if the rect passed as parameter is intersects this one

--- a/Engine/RectI.h
+++ b/Engine/RectI.h
@@ -406,13 +406,22 @@ public:
     }
 
     /**
-     * @brief Updates this rectangle to the intersection rectangle if this rectangle overlaps with rect. If there is no overlap then this rectangle remains unchanged.
-     *
-     * @returns True if the rectangles overlap and this rectangle was clipped.
+     * @brief Updates this rectangle to the intersection of this rectangle and |rect|. If there is no overlap, this rectangle is cleared so it represents a
+     * null rectangle.
      **/
-    bool clipIfOverlaps(const RectI& rect)
+    void clip(const RectI& rect) {
+        if (!intersectInternal(rect, this)) {
+            // |rect| does not intersect with *this so clear this object so it becomes a null rectangle.
+            clear();
+        }
+    }
+
+    /**
+     * @brief Updates this rectangle to the intersection rectangle if this rectangle overlaps with rect. If there is no overlap then this rectangle remains unchanged.
+     **/
+    void clipIfOverlaps(const RectI& rect)
     {
-        return intersectInternal(rect, this);
+        intersectInternal(rect, this);
     }
 
     /// returns true if the rect passed as parameter  intersects this one

--- a/Engine/ViewerInstance.cpp
+++ b/Engine/ViewerInstance.cpp
@@ -1003,7 +1003,8 @@ ViewerInstance::getViewerRoIAndTexture(const RectD& rod,
             for (std::list<RectD>::iterator it = partialRects.begin(); it != partialRects.end(); ++it) {
                 RectI pixelRect = it->toPixelEnclosing(mipmapLevel, outArgs->params->pixelAspectRatio);
                 ///Intersect to the RoI
-                if ( pixelRect.clipIfOverlaps(outArgs->params->roi) ) {
+                pixelRect.clip(outArgs->params->roi);
+                if ( !pixelRect.isNull() ) {
                     tile.rect.set(pixelRect);
                     tile.rectRounded  = pixelRect;
                     tile.rect.closestPo2 = 1 << mipmapLevel;

--- a/Gui/ViewerGLPrivate.cpp
+++ b/Gui/ViewerGLPrivate.cpp
@@ -294,7 +294,8 @@ ViewerGL::Implementation::drawRenderingVAO(unsigned int mipmapLevel,
         {
             QMutexLocker l(&this->userRoIMutex);
             //if the userRoI isn't intersecting the rod, just don't render anything
-            if ( !rod.clipIfOverlaps(this->userRoI) ) {
+            rod.clip(this->userRoI);
+            if ( rod.isNull() ) {
                 return;
             }
         }


### PR DESCRIPTION

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

This change removes the return value for clipIfOverlaps() and updates all callers. This was done to address a comment made in https://github.com/NatronGitHub/Natron/pull/930#discussion_r1363398756

- Removed return value from RectI::clipIfOverlaps() and RectD::clipIfOverlaps()
- Introduced clip() that updates a RectI or RectD with the intersection of itself and another rectangle.
- Reworked several clipIfOverlaps() callers to use clip() or intersect() instead of clipIfOverlaps().


**Have you tested your changes (if applicable)? If so, how?**

Yes. I verified all the tests still pass on Windows and Linux (https://github.com/acolwell/Natron/actions/runs/7944427820). I also did some testing on Windows using an installer build including these changes (https://github.com/acolwell/Natron/actions/runs/7944419132). I did not notice any issues associated with these changes.

**Futher details of this pull request**

The vast majority of the changes do not change the existing behavior. The only case where there is technically a behavior change is in Image::halveRoIForDepth() where a clipIfOverlaps() is changed to an intersect(). I've determined that this is safe though because it appears that the roi is verified to be contained within the bounds of the image by the downscaleMipmap() call that eventually invokes halveRoIForDepth(). This guarantees that roi and srcBounds, in halveRoIForDepth(), should always overlap which means clipIfOverlaps() is equivalent to an intersect(). This was not immediately obvious when looking at the code, so I added assert(bounds_.contains(roi)) calls to the function levels between downscaleMipmap() and halveRoIForDepth() to help make it clear this precondition is expected to be maintained at each of these levels.

I suspect many/all of the remaining clipIfOverlap() calls that remain can likely be replaced with clip() or intersect(), but I have not sufficiently proved the safety of those transformations to myself. What I have in this PR I believe are perfectly safe and fulfill my previous commitment to remove the clipIfOverlaps() return value. I'll look into replacing the other calls to clipIfOverlap() as time permits and I have figured out how to prove they are safe.
