### PR TITLE
Fix crashing on startup with AMD GPUs

### DIFF
--- a/Engine/OSGLContext_win.cpp
+++ b/Engine/OSGLContext_win.cpp
@@ -693,7 +693,6 @@ static std::string GetGPUInfoAMDInternal_string(const OSGLContext_wgl_data* wglI
 
 static bool GetGPUInfoAMDInternal_int(const OSGLContext_wgl_data* wglInfo, UINT gpuID, int info, int* value)
 {
-
     std::vector<unsigned int> data;
     int totalSize = 0;
 
@@ -718,6 +717,36 @@ static bool GetGPUInfoAMDInternal_int(const OSGLContext_wgl_data* wglInfo, UINT 
     *value = (int)data[0];
     return true;
 }
+
+namespace {
+class ScopedGLContext {
+public:
+    ScopedGLContext(const GLRendererID& gid) {
+        assert(!OSGLContext_win::threadHasACurrentContext());
+        try {
+            _context = std::make_unique<OSGLContext_win>(FramebufferConfig(), GLVersion.major, GLVersion.minor, false, gid, nullptr);
+        } catch (const std::exception& e) {
+            std::cerr << "Failed to create GL context : " << e.what() << std::endl;
+            return;
+        }
+
+        if (!OSGLContext_win::makeContextCurrent(_context.get())) {
+            _context.reset();
+        }
+    }
+
+    ~ScopedGLContext() {
+        if (_context) {
+            OSGLContext_win::makeContextCurrent(nullptr);
+        }
+    }
+
+    explicit operator bool() const { return (bool)_context; }
+
+private:
+    std::unique_ptr<OSGLContext_win> _context;
+};
+} // namespace
 
 void
 OSGLContext_win::getGPUInfos(std::list<OpenGLRendererInfo>& renderers)
@@ -749,37 +778,27 @@ OSGLContext_win::getGPUInfos(std::list<OpenGLRendererInfo>& renderers)
         for (std::size_t i = 0; i < gpuHandles.size(); ++i) {
             OpenGLRendererInfo info;
             info.rendererID.rendererHandle = (void*)gpuHandles[i];
+            {
+                ScopedGLContext scopedContext(info.rendererID);
+                if (!scopedContext) {
+                    continue;
+                }
 
-            std::unique_ptr<OSGLContext_win> context;
-            try {
-                GLRendererID gid;
-                gid.rendererHandle = info.rendererID.rendererHandle;
-                context.reset( new OSGLContext_win(FramebufferConfig(), GLVersion.major, GLVersion.minor, false, gid, 0) );
-            } catch (const std::exception& e) {
-                continue;
+                try {
+                    OSGLContext::checkOpenGLVersion();
+                } catch (const std::exception& e) {
+                    std::cerr << e.what() << std::endl;
+                    continue;
+                }
+
+                info.vendorName = std::string( (const char *) glGetString(GL_VENDOR) );
+                info.rendererName = std::string( (const char *) glGetString(GL_RENDERER) );
+                info.glVersionString = std::string( (const char *) glGetString(GL_VERSION) );
+                info.glslVersionString = std::string( (const char*)glGetString (GL_SHADING_LANGUAGE_VERSION) );
+                info.maxMemBytes = nvx_get_GPU_mem_info();
+                glGetIntegerv(GL_MAX_TEXTURE_SIZE, &info.maxTextureSize);
+                renderers.push_back(info);
             }
-
-            if ( !makeContextCurrent( context.get() ) ) {
-                continue;
-            }
-
-            try {
-                OSGLContext::checkOpenGLVersion();
-            } catch (const std::exception& e) {
-                std::cerr << e.what() << std::endl;
-                makeContextCurrent(nullptr);
-                continue;
-            }
-
-            info.vendorName = std::string( (const char *) glGetString(GL_VENDOR) );
-            info.rendererName = std::string( (const char *) glGetString(GL_RENDERER) );
-            info.glVersionString = std::string( (const char *) glGetString(GL_VERSION) );
-            info.glslVersionString = std::string( (const char*)glGetString (GL_SHADING_LANGUAGE_VERSION) );
-            info.maxMemBytes = nvx_get_GPU_mem_info();
-            glGetIntegerv(GL_MAX_TEXTURE_SIZE, &info.maxTextureSize);
-            renderers.push_back(info);
-
-            makeContextCurrent(nullptr);
         }
     } else if (wglInfo->AMD_gpu_association && !isApplication32Bits()) {
         //https://www.opengl.org/registry/specs/AMD/wgl_gpu_association.txt
@@ -827,33 +846,23 @@ OSGLContext_win::getGPUInfos(std::list<OpenGLRendererInfo>& renderers)
                 }
 
                 info.rendererID.renderID = gpuID;
-                
-                std::unique_ptr<OSGLContext_win> context;
 
-                GLRendererID gid;
-                gid.renderID = info.rendererID.renderID;
-                try {
-                    context.reset( new OSGLContext_win(FramebufferConfig(), GLVersion.major, GLVersion.minor, false, gid, 0) );
-                } catch (const std::exception& e) {
-                    continue;
+                {
+                    ScopedGLContext scopedContext(info.rendererID);
+                    if (!scopedContext) {
+                        continue;
+                    }
+
+                    try {
+                        OSGLContext::checkOpenGLVersion();
+                    } catch (const std::exception& e) {
+                        std::cerr << e.what() << std::endl;
+                        continue;
+                    }
+
+                    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &info.maxTextureSize);
+                    renderers.push_back(info);
                 }
-
-                if ( !makeContextCurrent( context.get() ) ) {
-                    continue;
-                }
-
-                try {
-                    OSGLContext::checkOpenGLVersion();
-                } catch (const std::exception& e) {
-                    std::cerr << e.what() << std::endl;
-                    makeContextCurrent(nullptr);
-                    continue;
-                }
-
-                glGetIntegerv(GL_MAX_TEXTURE_SIZE, &info.maxTextureSize);
-                renderers.push_back(info);
-                
-                makeContextCurrent(nullptr);
             }
         }
     }
@@ -863,38 +872,29 @@ OSGLContext_win::getGPUInfos(std::list<OpenGLRendererInfo>& renderers)
     }
     if (defaultFallback) {
         // No extension, use default
-        std::unique_ptr<OSGLContext_win> context;
-        try {
-            context.reset( new OSGLContext_win(FramebufferConfig(), GLVersion.major, GLVersion.minor, false, GLRendererID(), 0) );
-        } catch (const std::exception& e) {
-            std::cerr << e.what() << std::endl;
+        {
+            ScopedGLContext scopedContext{GLRendererID()};
+            if (!scopedContext) {
+                return;
+            }
 
-            return;
+            try {
+                OSGLContext::checkOpenGLVersion();
+            } catch (const std::exception& e) {
+                std::cerr << e.what() << std::endl;
+                return;
+            }
+
+            OpenGLRendererInfo info;
+            info.vendorName = std::string( (const char *) glGetString(GL_VENDOR) );
+            info.rendererName = std::string( (const char *) glGetString(GL_RENDERER) );
+            info.glVersionString = std::string( (const char *) glGetString(GL_VERSION) );
+            info.glslVersionString = std::string( (const char *) glGetString (GL_SHADING_LANGUAGE_VERSION) );
+            glGetIntegerv(GL_MAX_TEXTURE_SIZE, &info.maxTextureSize);
+            // We don't have any way to get memory size, set it to 0
+            info.maxMemBytes = nvx_get_GPU_mem_info();
+            renderers.push_back(info);
         }
-
-        if ( !makeContextCurrent( context.get() ) ) {
-            return;
-        }
-
-        try {
-            OSGLContext::checkOpenGLVersion();
-        } catch (const std::exception& e) {
-            std::cerr << e.what() << std::endl;
-            makeContextCurrent(nullptr);
-            return;
-        }
-
-        OpenGLRendererInfo info;
-        info.vendorName = std::string( (const char *) glGetString(GL_VENDOR) );
-        info.rendererName = std::string( (const char *) glGetString(GL_RENDERER) );
-        info.glVersionString = std::string( (const char *) glGetString(GL_VERSION) );
-        info.glslVersionString = std::string( (const char *) glGetString (GL_SHADING_LANGUAGE_VERSION) );
-        glGetIntegerv(GL_MAX_TEXTURE_SIZE, &info.maxTextureSize);
-        // We don't have any way to get memory size, set it to 0
-        info.maxMemBytes = nvx_get_GPU_mem_info();
-        renderers.push_back(info);
-
-        makeContextCurrent(nullptr);
     }
 } // OSGLContext_win::getGPUInfos
 

--- a/Engine/OSGLContext_win.cpp
+++ b/Engine/OSGLContext_win.cpp
@@ -817,40 +817,40 @@ OSGLContext_win::getGPUInfos(std::list<OpenGLRendererInfo>& renderers)
                 UINT gpuID = gpuIDs[index];
 
                 OpenGLRendererInfo info;
-                info.rendererName = GetGPUInfoAMDInternal_string(wglInfo, gpuID, WGL_GPU_RENDERER_STRING_AMD);
-                if (info.rendererName.empty()) {
-                    continue;
-                }
-
-                info.vendorName = GetGPUInfoAMDInternal_string(wglInfo, gpuID, WGL_GPU_VENDOR_AMD);
-                if (info.vendorName.empty()) {
-                    continue;
-                }
-
-                info.glVersionString = GetGPUInfoAMDInternal_string(wglInfo, gpuID, WGL_GPU_OPENGL_VERSION_STRING_AMD);
-                if (info.glVersionString.empty()) {
-                    continue;
-                }
-
-                // note: cannot retrieve GL_SHADING_LANGUAGE_VERSION
-
-                info.maxMemBytes = 0;
-                if (!isApplication32Bits()) {
-                    int ramMB = 0;
-                    // AMD drivers are f*** up in 32 bits, they read a wrong buffer size.
-                    // It works fine in 64 bits mode
-                    if (!GetGPUInfoAMDInternal_int(wglInfo, gpuID, WGL_GPU_RAM_AMD, &ramMB)) {
-                        continue;
-                    }
-                    info.maxMemBytes = ramMB * 1e6;
-                }
-
                 info.rendererID.renderID = gpuID;
 
                 {
                     ScopedGLContext scopedContext(info.rendererID);
                     if (!scopedContext) {
                         continue;
+                    }
+
+                    info.rendererName = GetGPUInfoAMDInternal_string(wglInfo, gpuID, WGL_GPU_RENDERER_STRING_AMD);
+                    if (info.rendererName.empty()) {
+                        continue;
+                    }
+
+                    info.vendorName = GetGPUInfoAMDInternal_string(wglInfo, gpuID, WGL_GPU_VENDOR_AMD);
+                    if (info.vendorName.empty()) {
+                        continue;
+                    }
+
+                    info.glVersionString = GetGPUInfoAMDInternal_string(wglInfo, gpuID, WGL_GPU_OPENGL_VERSION_STRING_AMD);
+                    if (info.glVersionString.empty()) {
+                        continue;
+                    }
+
+                    // note: cannot retrieve GL_SHADING_LANGUAGE_VERSION
+
+                    info.maxMemBytes = 0;
+                    if (!isApplication32Bits()) {
+                        int ramMB = 0;
+                        // AMD drivers are f*** up in 32 bits, they read a wrong buffer size.
+                        // It works fine in 64 bits mode
+                        if (!GetGPUInfoAMDInternal_int(wglInfo, gpuID, WGL_GPU_RAM_AMD, &ramMB)) {
+                            continue;
+                        }
+                        info.maxMemBytes = ramMB * 1e6;
                     }
 
                     try {


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

This change fixes the crashes on startup when running Natron on Windows with a AMD GPU. The fix primarily just moves GL context creation earlier in the AMD logic so that we have an active context when the AMD extension functions are called. 


**Have you tested your changes (if applicable)? If so, how?**

Yes. I tested this on a machine with an AMD GPU and verified that the old code crashed, and this new logic does not. I also verified that the code still works on a Windows machine with an NVIDIA GPU and a different machine with an Intel integrated GPU. All of these appear to work fine.

**Futher details of this pull request**

While it seems bad form that the AMD driver crashes the process when there was a null context, I do believe Natron's code was incorrect. Functions returned from wglGetProcAddress() are technically specific to the context that is current when the method is called. Different contexts can return different functions according to the Windows docs, so calling one of these functions without an active context seems to be in undefine behavior territory. I believe that the caching of extension pointers in the OSGLContext_wgl_data struct and reusing them for all contexts is in undefined behavior territory as well, but it seems to work. I've left fixing that out of this PR for now since the focus of this change is simply to fix the crashes.