### PR TITLE
Fix QMutexLocker bug

### DIFF
--- a/Engine/GenericSchedulerThreadWatcher.cpp
+++ b/Engine/GenericSchedulerThreadWatcher.cpp
@@ -180,7 +180,7 @@ GenericWatcher::scheduleBlockingTask(int taskID,
     }
 
     {
-        QMutexLocker(&_imp->tasksMutex);
+        QMutexLocker k(&_imp->tasksMutex);
         GenericWatcherPrivate::Task t;
         t.id = taskID;
         t.args = args;


### PR DESCRIPTION


Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Fixing GenericWatcher::scheduleBlockingTask() so that it actually holds the tasksMutex when it is pushing new task information.

**Have you tested your changes (if applicable)? If so, how?**

Yes. I basically just did simple tests that make sure when the function gets called everything still seems to work. I did not notice any problems caused by this change.

**Futher details of this pull request**

I suspect it could fix potential race conditions, but I didn't ever actually encounter any issues like that. I just happened to come across this code and realized that the queue was not being protected like the original author probably intended.

