### PR TITLE
Fix more QMutexLocker usage.

### DIFF
--- a/Gui/ViewerGL.cpp
+++ b/Gui/ViewerGL.cpp
@@ -203,7 +203,7 @@ ViewerGL::resizeGL(int w,
     bool zoomSinceLastFit;
     double oldWidth, oldHeight;
     {
-        QMutexLocker(&_imp->zoomCtxMutex);
+        QMutexLocker l(&_imp->zoomCtxMutex);
         oldWidth = _imp->zoomCtx.screenWidth();
         oldHeight = _imp->zoomCtx.screenHeight();
         _imp->zoomCtx.setScreenSize(zoomWidth, zoomHeight, /*alignTop=*/ true, /*alignRight=*/ false);
@@ -2911,7 +2911,7 @@ ViewerGL::fitImageToFormat()
     double zoomFactor;
     unsigned int oldMipmapLevel, newMipmapLevel;
     {
-        QMutexLocker(&_imp->zoomCtxMutex);
+        QMutexLocker l(&_imp->zoomCtxMutex);
         old_zoomFactor = _imp->zoomCtx.factor();
         //oldMipmapLevel = std::log( old_zoomFactor >= 1 ? 1 :
         //                           std::pow( 2, -std::ceil(std::log(old_zoomFactor) / M_LN2) ) ) / M_LN2;
@@ -3467,7 +3467,7 @@ ViewerGL::setUserRoIEnabled(bool b)
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );
     {
-        QMutexLocker(&_imp->userRoIMutex);
+        QMutexLocker l(&_imp->userRoIMutex);
         _imp->userRoIEnabled = b;
     }
     if (!b) {
@@ -3568,7 +3568,7 @@ bool
 ViewerGL::isUserRegionOfInterestEnabled() const
 {
     // MT-SAFE
-    QMutexLocker(&_imp->userRoIMutex);
+    QMutexLocker l(&_imp->userRoIMutex);
 
     return _imp->userRoIEnabled;
 }
@@ -3577,7 +3577,7 @@ RectD
 ViewerGL::getUserRegionOfInterest() const
 {
     // MT-SAFE
-    QMutexLocker(&_imp->userRoIMutex);
+    QMutexLocker l(&_imp->userRoIMutex);
 
     return _imp->userRoI;
 }
@@ -3586,7 +3586,7 @@ void
 ViewerGL::setUserRoI(const RectD & r)
 {
     // MT-SAFE
-    QMutexLocker(&_imp->userRoIMutex);
+    QMutexLocker l(&_imp->userRoIMutex);
     _imp->userRoI = r;
 }
 


### PR DESCRIPTION

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Fixes more instances of unnamed QMutexLocker objects that were not holding the lock for the duration of the containing scope.

**Have you tested your changes (if applicable)? If so, how?**

Yes. Built locally and tested with by doing a bunch of zoom and userRoi changes. I didn't notice any issues like deadlocking or odd behavior. This is a pretty low risk fix since all the logic covered by the locks are simple member variable updates.

