### PR TITLE
Fix documentation CSS.

### DIFF
--- a/Documentation/source/conf.py
+++ b/Documentation/source/conf.py
@@ -136,12 +136,7 @@ html_logo = "_static/logo.png"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-# https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # override wide tables in RTD theme
-        ],
-     }
+html_css_files = ['theme_overrides.css']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

This change fixes the documentation generation so that the CSS styles start working again.

**Show a few screenshots (if this is a visual change)**

Documentation before change:
<img width="763" alt="DocumentationBefore" src="https://github.com/NatronGitHub/Natron/assets/300262/ee409a6e-2b90-4540-9a33-b39ee488c7da">

Documentation after change:
<img width="814" alt="DocumentationAfter" src="https://github.com/NatronGitHub/Natron/assets/300262/e7c01ed9-9fab-40c6-911b-462160e42e52">

**Have you tested your changes (if applicable)? If so, how?**

Yes. I rebuilt the documentation locally.

**Futher details of this pull request**

The fix essentially came from [this StackOverflow article](https://stackoverflow.com/questions/73220398/sphinx-rtd-theme-not-formatting-correctly-missing-theme-css). Our documentation config matched the situation in that article, and the suggested solution also worked for us.
