### PR TITLE
Windows: Set proper window title bar color

### DIFF
--- a/App/NatronApp_main.cpp
+++ b/App/NatronApp_main.cpp
@@ -94,6 +94,14 @@ int main(int argc, char *argv[])
             freopen("CONOUT$", "w", stderr);
         }
     }
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
+    // Set proper window title bar color (https://www.qt.io/blog/dark-mode-on-windows-11-with-qt-6.5)
+    QSettings registry(QString::fromUtf8("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"),
+                       QSettings::NativeFormat);
+    if (registry.value(QString::fromUtf8("AppsUseLightTheme"), 0).toInt() == 0) {
+        qputenv("QT_QPA_PLATFORM", "windows:darkmode=1");
+    }
+#endif
 #endif
 
 #if defined(Q_OS_UNIX) && defined(RLIMIT_NOFILE)

--- a/App/NatronApp_main.cpp
+++ b/App/NatronApp_main.cpp
@@ -95,7 +95,9 @@ int main(int argc, char *argv[])
         }
     }
 #if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
-    // Set proper window title bar color (https://www.qt.io/blog/dark-mode-on-windows-11-with-qt-6.5)
+    // Set window title bar color based on dark/light theme
+    // https://www.qt.io/blog/dark-mode-on-windows-11-with-qt-6.5
+    // https://learn.microsoft.com/en-us/answers/questions/1161597/how-to-detect-windows-application-dark-mode
     QSettings registry(QString::fromUtf8("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"),
                        QSettings::NativeFormat);
     if (registry.value(QString::fromUtf8("AppsUseLightTheme"), 0).toInt() == 0) {


### PR DESCRIPTION
Set proper window title bar color based on dark/light theme on Windows 10+ and Qt 5.15+
![proper-titlebar-color](https://github.com/NatronGitHub/Natron/assets/34516798/e8d793ef-b666-4708-8ec8-833d5c85e01d)
