### PR TITLE
Gui: Qt5 fixes for MessageBox

### DIFF
--- a/Gui/Gui30.cpp
+++ b/Gui/Gui30.cpp
@@ -358,21 +358,10 @@ Gui::onDoDialog(int type,
             info.setWindowFlags(info.windowFlags() | Qt::WindowStaysOnTopHint);
             ignore_result( info.exec() );
         } else {
-            // text may be very long: use resizable QMessageBox
-            ResizableMessageBox info(QMessageBox::Information, title, msg.left(1000), QMessageBox::NoButton, this, Qt::Dialog | Qt::WindowStaysOnTopHint);
-            info.setTextFormat(Qt::RichText);
+            // text may be very long: use Natron MessageBox
+            StandardButtons buttons(eStandardButtonOk);
+            MessageBox info(title, msg, MessageBox::eMessageBoxTypeInformation, buttons, eStandardButtonOk, this);
             info.setWindowFlags(info.windowFlags() | Qt::WindowStaysOnTopHint);
-            QGridLayout *layout = qobject_cast<QGridLayout *>( info.layout() );
-            if (layout) {
-                QTextEdit *edit = new QTextEdit;
-                edit->setFocusPolicy(Qt::NoFocus);
-                edit->setReadOnly(true);
-                edit->setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
-                edit->setAcceptRichText(true);
-                edit->setHtml(msg);
-                layout->setRowStretch(1, 0);
-                layout->addWidget(edit, 0, 1);
-            }
             ignore_result( info.exec() );
         }
     } else { // question dialog

--- a/Gui/MessageBox.cpp
+++ b/Gui/MessageBox.cpp
@@ -98,11 +98,13 @@ MessageBox::init(const QString & title,
                  const StandardButtons& buttons,
                  StandardButtonEnum defaultButton)
 {
+    setMinimumSize(400, 150);
     if (message.size() < 1000) {
         _imp->label = new Label(message);
         _imp->label->setTextInteractionFlags( Qt::TextInteractionFlags( style()->styleHint(QStyle::SH_MessageBox_TextInteractionFlags, 0, this) ) );
         _imp->label->setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
         _imp->label->setOpenExternalLinks(true);
+        _imp->label->setWordWrap(true);
 #if defined(Q_WS_MAC)
         _imp->label->setContentsMargins(16, 0, 0, 0);
 #elif !defined(Q_WS_QWS)
@@ -112,11 +114,13 @@ MessageBox::init(const QString & title,
         //QFont f(appFont,appFontSize);
         //_imp->label->setFont(f);
     } else {
+        setSizeGripEnabled(true);
         _imp->infoEdit = new QTextEdit;
         _imp->infoEdit->setFocusPolicy(Qt::NoFocus);
         _imp->infoEdit->setReadOnly(true);
         _imp->infoEdit->setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
-        _imp->infoEdit->append(message);
+        _imp->infoEdit->setWordWrapMode(QTextOption::WordWrap);
+        _imp->infoEdit->setHtml(message);
         //QFont f(appFont,appFontSize);
         //_imp->infoEdit->setFont(f);
     }
@@ -133,7 +137,7 @@ MessageBox::init(const QString & title,
             pixType = QStyle::SP_MessageBoxWarning;
             break;
         case eMessageBoxTypeInformation:
-            pixType = QStyle::SP_MessageBoxWarning;
+            pixType = QStyle::SP_MessageBoxInformation;
             break;
         case eMessageBoxTypeQuestion:
             pixType = QStyle::SP_MessageBoxQuestion;
@@ -170,7 +174,7 @@ MessageBox::init(const QString & title,
     if (_imp->label) {
         grid->addWidget(_imp->label, 0, preferredTextColumn, 1, 1);
     } else if (_imp->infoEdit) {
-        grid->addWidget(_imp->label, 0, preferredTextColumn, 1, 1);
+        grid->addWidget(_imp->infoEdit, 0, preferredTextColumn, 1, 1);
     }
     // -- leave space for information label --
     grid->addWidget(_imp->buttonBox, 2, 0, 1, 2);
@@ -208,82 +212,11 @@ MessageBox::init(const QString & title,
     //retranslateStrings();
 
     _imp->grid = grid;
-    updateSize();
 } // MessageBox::init
 
 MessageBox::~MessageBox()
 {
 }
-
-void
-MessageBox::updateSize()
-{
-    if (_imp->label) {
-        _imp->label->setWordWrap(true);
-    } else if (_imp->infoEdit) {
-        _imp->infoEdit->setWordWrapMode(QTextOption::WordWrap);
-    }
-
-    setFixedSize(400, 150);
-//    if (!isVisible())
-//        return;
-//
-//    QSize screenSize = QApplication::desktop()->availableGeometry(QCursor::pos()).size();
-//#if defined(Q_WS_QWS) || defined(Q_WS_WINCE) || defined(Q_OS_SYMBIAN)
-//    // the width of the screen, less the window border.
-//    int hardLimit = screenSize.width() - (q->frameGeometry().width() - q->geometry().width());
-//#else
-//    int hardLimit = qMin(screenSize.width() - 480, 1000); // can never get bigger than this
-//    // on small screens allows the messagebox be the same size as the screen
-//    if (screenSize.width() <= 1024)
-//        hardLimit = screenSize.width();
-//#endif
-//#ifdef Q_WS_MAC
-//    int softLimit = qMin(screenSize.width()/2, 420);
-//#elif defined(Q_WS_QWS)
-//    int softLimit = qMin(hardLimit, 500);
-//#else
-//    // note: ideally on windows, hard and soft limits but it breaks compat
-//#ifndef Q_WS_WINCE
-//    int softLimit = qMin(screenSize.width()/2, 500);
-//#else
-//    int softLimit = qMin(screenSize.width() * 3 / 4, 500);
-//#endif //Q_WS_WINCE
-//#endif
-//
-//
-//    _imp->label->setWordWrap(false); // makes the label return min size
-//    int width = _imp->layoutMinimumWidth();
-//    _imp->label->setWordWrap(true);
-//
-//    if (width > softLimit) {
-//        width = qMax(softLimit, _imp->layoutMinimumWidth());
-//
-////        if (width > hardLimit) {
-////            _imp->label->d_func()->ensureTextControl();
-////            if (QTextControl *control = label->d_func()->control) {
-////                QTextOption opt = control->document()->defaultTextOption();
-////                opt.setWrapMode(QTextOption::WrapAnywhere);
-////                control->document()->setDefaultTextOption(opt);
-////            }
-////            width = hardLimit;
-////        }
-//    }
-//
-//    QFontMetrics fm(QApplication::font("QWorkspaceTitleBar"));
-//    int windowTitleWidth = qMin(fm.width(windowTitle()) + 50, hardLimit);
-//    if (windowTitleWidth > width)
-//        width = windowTitleWidth;
-//
-//    _imp->grid->activate();
-//    int height = (_imp->grid->hasHeightForWidth())
-//    ? _imp->grid->totalHeightForWidth(width)
-//    : _imp->grid->totalMinimumSize().height();
-//
-//
-//    setFixedSize(width, height);
-//    QCoreApplication::removePostedEvents(this, QEvent::LayoutRequest);
-} // MessageBox::updateSize
 
 StandardButtonEnum
 MessageBox::getReply() const
@@ -324,22 +257,6 @@ MessageBox::onButtonClicked(QAbstractButton* button)
 {
     _imp->clickedButton = button;
     accept();
-}
-
-bool
-MessageBox::event(QEvent* e)
-{
-    bool result = QDialog::event(e);
-
-    switch ( e->type() ) {
-    case QEvent::LayoutRequest:
-        updateSize();
-        break;
-    default:
-        break;
-    }
-
-    return result;
 }
 
 NATRON_NAMESPACE_EXIT

--- a/Gui/MessageBox.cpp
+++ b/Gui/MessageBox.cpp
@@ -120,7 +120,11 @@ MessageBox::init(const QString & title,
         _imp->infoEdit->setReadOnly(true);
         _imp->infoEdit->setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
         _imp->infoEdit->setWordWrapMode(QTextOption::WordWrap);
-        _imp->infoEdit->setHtml(message);
+        if ( Qt::mightBeRichText(message) ) {
+            _imp->infoEdit->setHtml(message);
+        } else {
+            _imp->infoEdit->setPlainText(message);
+        }
         //QFont f(appFont,appFontSize);
         //_imp->infoEdit->setFont(f);
     }

--- a/Gui/MessageBox.h
+++ b/Gui/MessageBox.h
@@ -80,14 +80,11 @@ public Q_SLOTS:
 
 private:
 
-    void updateSize();
-
     void init(const QString & title,
               const QString & message,
               const StandardButtons& buttons,
               StandardButtonEnum defaultButton);
 
-    virtual bool event(QEvent* e) OVERRIDE FINAL;
     std::unique_ptr<MessageBoxPrivate> _imp;
 };
 

--- a/Gui/Resources/Stylesheets/mainstyle.qss
+++ b/Gui/Resources/Stylesheets/mainstyle.qss
@@ -757,6 +757,8 @@ QPlainTextEdit {
     selection-background-color: %1;
 }
 
+QTextEdit[html],
+QTextEdit[plainText],
 QTextBrowser[html],
 QTextBrowser[plainText] {
     color: %5;


### PR DESCRIPTION
QTextEdit in QMessageBox workaround only works in Qt4. Instead use the Natron MessageBox (after some fixes).

Tested on Windows 10 with Qt 5.15.13.

![natron-26-mbox](https://github.com/NatronGitHub/Natron/assets/34516798/1d2a68df-42b3-4cc7-9e92-0983b41db34f)
