### PR TITLE
Fix Windows build failure caused by missing dependency.

### DIFF
--- a/.github/workflows/build_installer.yml
+++ b/.github/workflows/build_installer.yml
@@ -67,6 +67,12 @@ jobs:
         run: |
           pacman -Rs --noconfirm mingw-w64-x86_64-natron-build-deps-qt5
 
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name:  ${{ steps.build.outputs.INSTALLER_NAME }}
+          path:  ${{ steps.build.outputs.INSTALLER_DIR }}
+
       - name: Verify plugin loading
         run: |
           INSTALLER_DIR=$(cygpath -u '${{ steps.build.outputs.INSTALLER_DIR }}')/${{ steps.build.outputs.INSTALLER_NAME }}
@@ -75,11 +81,6 @@ jobs:
             PATH=${INSTALLER_DIR}/bin ./verify_plugin_loads.exe "${x}"
           done
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4.3.1
-        with:
-          name:  ${{ steps.build.outputs.INSTALLER_NAME }}
-          path:  ${{ steps.build.outputs.INSTALLER_DIR }}
 
   win-installer-breakpad:
     name: Windows Installer (with Breakpad crash reporting)
@@ -149,14 +150,6 @@ jobs:
         run: |
           pacman -Rs --noconfirm mingw-w64-x86_64-natron-build-deps-qt5
 
-      - name: Verify plugin loading
-        run: |
-          INSTALLER_DIR=$(cygpath -u '${{ steps.build.outputs.INSTALLER_DIR }}')/${{ steps.build.outputs.INSTALLER_NAME }}
-          for x in $(find ${INSTALLER_DIR}/Plugins -name *.ofx); do
-            echo "Testing $(basename ${x}) ..."
-            PATH=${INSTALLER_DIR}/bin ./verify_plugin_loads.exe "${x}"
-          done
-
       - name: Upload installer
         uses: actions/upload-artifact@v4.3.1
         with:
@@ -168,3 +161,11 @@ jobs:
         with:
           name:  ${{ steps.build.outputs.SYMBOLS_NAME }}
           path:  ${{ steps.build.outputs.SYMBOLS_DIR }}
+
+      - name: Verify plugin loading
+        run: |
+          INSTALLER_DIR=$(cygpath -u '${{ steps.build.outputs.INSTALLER_DIR }}')/${{ steps.build.outputs.INSTALLER_NAME }}
+          for x in $(find ${INSTALLER_DIR}/Plugins -name *.ofx); do
+            echo "Testing $(basename ${x}) ..."
+            PATH=${INSTALLER_DIR}/bin ./verify_plugin_loads.exe "${x}"
+          done

--- a/tools/jenkins/genDllVersions.sh
+++ b/tools/jenkins/genDllVersions.sh
@@ -169,6 +169,7 @@ catDll libmodplug-
 catDll libmp3lame-
 catDll libnettle-
 catDll libnghttp2-
+catDll libnghttp3-
 catDll libogg-
 catDll libopenal-
 catDll libOpenColorIO


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Msys2's libcurl package was recently updated to enable HTTP/3 support which means it now also depends on libnghttp3. genDllVersions.sh was updated to include this new dependency.

The Windows installer build action was also changed to upload its build artifacts before it tests to make sure the plugins load. This makes it possible to look at the generated artifacts for missing dependencies if the plugin load verification fails.

**Have you tested your changes (if applicable)? If so, how?**

Yes. The [build installer action works](https://github.com/acolwell/Natron/actions/runs/9306530285) again and the plugin load verification step now passes on GMIC plugin again. Before this change the GMIC plugin was causing the plugin load verification step to fail because of the missing dependency.


