### PR TITLE
Fix Windows cmake debug build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,15 @@ set(CMAKE_CXX_STANDARD 14)
 option(NATRON_SYSTEM_LIBS "use system versions of dependencies instead of bundled ones" OFF)
 option(NATRON_BUILD_TESTS "build the Natron test suite" ON)
 
+set(IS_DEBUG_BUILD OFF)
 if(CMAKE_BUILD_TYPE MATCHES "^(debug|Debug|DEBUG)$")
+    set(IS_DEBUG_BUILD ON)
     add_definitions(-DDEBUG)
+
+    if(WIN32)
+        # Debug builds need minimal optimizations to avoid excessive link times and link errors related to Eigen.
+        add_compile_options(-O)
+    endif()
 else()
     add_definitions(-DQT_NO_DEBUG_OUTPUT)
 endif()
@@ -49,7 +56,21 @@ if(WIN32)
 endif()
 find_package(Python3 COMPONENTS Interpreter Development)
 find_package(Qt5 5.15 CONFIG REQUIRED COMPONENTS Core Gui Network Widgets Concurrent)
+
+if(IS_DEBUG_BUILD AND WIN32)
+    # Explicitly setting SHIBOKEN_PYTHON_LIBRARIES variable to avoid PYTHON_DEBUG_LIBRARY-NOTFOUND
+    # link errors on Windows debug builds.
+    set(SHIBOKEN_PYTHON_LIBRARIES ${Python3_LIBRARIES})
+endif()
 find_package(Shiboken2 5.15 CONFIG REQUIRED COMPONENTS libshiboken2 shiboken2)
+
+if(IS_DEBUG_BUILD AND WIN32)
+    # Remove NDEBUG from Shiboken2 INTERFACE_COMPILE_DEFINITIONS so it is not inherited in debug builds.
+    get_property(ShibokenInterfaceDefs TARGET Shiboken2::libshiboken PROPERTY INTERFACE_COMPILE_DEFINITIONS)
+    list(REMOVE_ITEM ShibokenInterfaceDefs NDEBUG)
+    set_property(TARGET Shiboken2::libshiboken PROPERTY INTERFACE_COMPILE_DEFINITIONS ShibokenInterfaceDefs)
+endif()
+
 find_package(PySide2 5.15 CONFIG REQUIRED COMPONENTS pyside2)
 set(QT_VERSION_MAJOR 5)
 get_target_property(PYSIDE_INCLUDE_DIRS PySide2::pyside2 INTERFACE_INCLUDE_DIRECTORIES)

--- a/Engine/OSGLContext_win.h
+++ b/Engine/OSGLContext_win.h
@@ -91,6 +91,7 @@ typedef PROC (WINAPI * WGLGETPROCADDRESS_T)(LPCSTR);
 typedef BOOL (WINAPI * WGLMAKECURRENT_T)(HDC, HGLRC);
 typedef BOOL (WINAPI * WGLSHARELISTS_T)(HGLRC, HGLRC);
 typedef HGLRC (WINAPI * WGLGETCURRENTCONTEXT_T)();
+typedef HDC (WINAPI * WGLGETCURRENTDC_T)();
 
 ////////// https://www.opengl.org/registry/specs/NV/gpu_affinity.txt
 
@@ -157,6 +158,7 @@ struct OSGLContext_wgl_data
     WGLCREATECONTEXT_T CreateContext;
     WGLDELETECONTEXT_T DeleteContext;
     WGLGETCURRENTCONTEXT_T GetCurrentContext;
+    WGLGETCURRENTDC_T GetCurrentDC;
     WGLGETPROCADDRESS_T GetProcAddress;
     WGLMAKECURRENT_T MakeCurrent;
     WGLSHARELISTS_T ShareLists;


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Fixing Windows debug builds built with cmake.
- Fixed several issues caused by Shiboken's cmake helper and added the -O flag to fix link errors and match the qmake build.
- Fixed an assert that was firing in debug builds because Qt's GL context was active in cases where the code assumed it would not be. The assert was removed and code was added to capture and restore Qt's GL context so that our own GL context code doesn't accidentally violate some assumption Qt might be making about its GL context being active.

**Have you tested your changes (if applicable)? If so, how?**

Yes. I've verified that everything still builds and runs. I've tested a debug build with a few projects and have not observed any issues or asserts. I also ran Natron-Tests with the debug build and all the tests that passed with the 2.5.0 build also pass with this build.
