### PR TITLE
Fix Windows installer build by adding missing Arena.ofx dependency

### DIFF
--- a/tools/jenkins/genDllVersions.sh
+++ b/tools/jenkins/genDllVersions.sh
@@ -178,6 +178,7 @@ catDll libOpenEXRCore
 catDll libOpenImageIO
 catDll libOpenImageIO_Util
 catDll libopenjp2-
+catDll libopenjph-
 catDll libopus-
 catDll libp11-kit-
 catDll libpango-


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

libheif was recently updated in MSYS2 to depend on libopenjph. This change simply adds this dependency so that the installer will build again and pass its dependency checks.


**Have you tested your changes (if applicable)? If so, how?**

Yes. I verified the Windows installer [builds successfully](https://github.com/acolwell/Natron/actions/runs/9921688369) again.


