### PR TITLE
Partial merge of rb 2.5

### DIFF
--- a/Engine/RotoPaint.cpp
+++ b/Engine/RotoPaint.cpp
@@ -2727,6 +2727,22 @@ RotoPaint::onOverlayPenMotion(double time,
         cursorSet = true;
     }
 
+    switch (_imp->ui->selectedTool) {
+    case eRotoToolSolidBrush:
+    case eRotoToolEraserBrush:
+    case eRotoToolClone:
+    case eRotoToolReveal:
+    case eRotoToolBlur:
+    case eRotoToolSharpen:
+    case eRotoToolSmear:
+    case eRotoToolDodge:
+    case eRotoToolBurn: {
+        redraw = true; // Those tools use the overlay to draw the tool
+    }
+    default:
+        break;
+    } // switch
+
     if ( !cursorSet && _imp->ui->showCpsBbox && (_imp->ui->state != eEventStateDraggingControlPoint) && (_imp->ui->state != eEventStateDraggingSelectedControlPoints)
          && ( _imp->ui->state != eEventStateDraggingLeftTangent) &&
          ( _imp->ui->state != eEventStateDraggingRightTangent) ) {
@@ -2751,8 +2767,10 @@ RotoPaint::onOverlayPenMotion(double time,
         } else if (lastHoverState != eHoverStateNothing) {
             newState = eHoverStateNothing;
         }
-        redraw = _imp->ui->hoverState != newState;
-        _imp->ui->hoverState = newState;
+        if (_imp->ui->hoverState != newState) {
+            redraw = true;
+            _imp->ui->hoverState = newState;
+        }
     }
     const bool featherVisible = _imp->ui->isFeatherVisible();
 
@@ -3161,7 +3179,15 @@ RotoPaint::onOverlayPenUp(double /*time*/,
          **/
         setCurrentCursor(eCursorBusy);
         context->evaluateNeatStrokeRender();
-        setCurrentCursor(eCursorDefault);
+        if ( context->isRotoPaint() &&
+         ( ( _imp->ui->selectedRole == eRotoRoleMergeBrush) ||
+           ( _imp->ui->selectedRole == eRotoRoleCloneBrush) ||
+           ( _imp->ui->selectedRole == eRotoRolePaintBrush) ||
+           ( _imp->ui->selectedRole == eRotoRoleEffectBrush) ) ) {
+            setCurrentCursor(eCursorCross);
+        } else {
+            setCurrentCursor(eCursorDefault);
+        }
         _imp->ui->strokeBeingPaint->setStrokeFinished();
         ret = true;
     }

--- a/config-macports.pri
+++ b/config-macports.pri
@@ -1,6 +1,7 @@
 boost {
-  INCLUDEPATH += /opt/local/include
-  LIBS += -lboost_serialization-mt
+  BOOST_VERSION = 1.76
+  INCLUDEPATH += /opt/local/libexec/boost/$$BOOST_VERSION/include
+  LIBS += -L/opt/local/libexec/boost/$$BOOST_VERSION/lib -lboost_serialization-mt
 }
 equals(QT_MAJOR_VERSION, 5) {
   shiboken:  SHIBOKEN=shiboken2-$$PYVER
@@ -17,11 +18,13 @@ equals(QT_MAJOR_VERSION, 5) {
 }
 
 macx:openmp {
-  # clang 12+ is OK to build Natron, but libomp 12+ has a bug on macOS when
-  # lanching tasks from a background thread, see https://bugs.llvm.org/show_bug.cgi?id=50579
+  # libomp 12+ has a bug on macOS when lanching tasks from a background thread,
+  # see tools/MacPorts/lang/libomp/README.md
   LIBS += -L/opt/local/lib  -L/opt/local/lib/libomp -liomp5
-  QMAKE_CC = /opt/local/bin/clang-mp-15
-  QMAKE_CXX = /opt/local/bin/clang++-mp-15
+  # clang 17 and 18 with -fopenmp links with @rpath/libc++.1.dylib instead
+  # of /usr/lib/libc++.1.dylib, so let's use clang 16 for now.
+  QMAKE_CC = /opt/local/bin/clang-mp-16
+  QMAKE_CXX = /opt/local/bin/clang++-mp-16
   # Recent clang cannot compile QtMac.mm
   QMAKE_OBJECTIVE_CC = clang
   QMAKE_OBJECTIVE_CXX = clang++

--- a/tools/MacPorts/devel/gnutls/Portfile
+++ b/tools/MacPorts/devel/gnutls/Portfile
@@ -9,7 +9,7 @@ PortGroup       legacysupport 1.0
 PortGroup       muniversal 1.0
 
 name            gnutls
-version         3.7.10
+version         3.7.11
 revision        0
 categories      devel security
 # yes, some of the libs are GPL only
@@ -23,27 +23,27 @@ long_description \
                 Lesser General Public License (LGPL).
 homepage        http://www.gnutls.org/
 
-checksums       rmd160  e221dc4200d30b8644cfe1f2c8d5e7bccac8aca0 \
-                sha256  b6e4e8bac3a950a3a1b7bdb0904979d4ab420a81e74de8636dd50b467d36f5a9 \
-                size    6407852
+checksums       rmd160  b8a3b948b2cfd504f72e04a31fce31a79b4316b1 \
+                sha256  90e337504031ef7d3077ab1a52ca8bac9b2f72bc454c95365a1cd1e0e81e06e9 \
+                size    6406420
 
 subport ${name} {
     conflicts   ${name}-devel
 
-    patchfiles      patch-lib-system-certs.c.old.diff
+    patchfiles  patch-lib-system-certs.c.old.diff
 }
 
 subport ${name}-devel {
     conflicts   ${name}
     
-    version     3.8.4
+    version     3.8.6
     revision    0
 
-    checksums   rmd160  42eea662a17b646f78f3dd423200c9d17f9e3943 \
-                sha256  2bea4e154794f3f00180fa2a5c51fe8b005ac7a31cd58bd44cdfa7f36ebc3a9b \
-                size    6487520
+    checksums   rmd160  fa7d5faf5359e6de786eacb369b8c4077b15fd99 \
+                sha256  2e1588aae53cb32d43937f1f4eca28febd9c0c7aa1734fc5dd61a7e81e0ebcdd \
+                size    6517476
 
-    patchfiles      patch-lib-system-certs.c.diff
+    patchfiles  patch-lib-system-certs.c.diff
 }
 
 if {${build_arch} ne "ppc" || ${build_arch} ne "ppc64"} {

--- a/tools/MacPorts/devel/gnutls/Portfile.orig
+++ b/tools/MacPorts/devel/gnutls/Portfile.orig
@@ -9,7 +9,7 @@ PortGroup       legacysupport 1.0
 PortGroup       muniversal 1.0
 
 name            gnutls
-version         3.7.10
+version         3.7.11
 revision        0
 categories      devel security
 # yes, some of the libs are GPL only
@@ -23,27 +23,27 @@ long_description \
                 Lesser General Public License (LGPL).
 homepage        http://www.gnutls.org/
 
-checksums       rmd160  e221dc4200d30b8644cfe1f2c8d5e7bccac8aca0 \
-                sha256  b6e4e8bac3a950a3a1b7bdb0904979d4ab420a81e74de8636dd50b467d36f5a9 \
-                size    6407852
+checksums       rmd160  b8a3b948b2cfd504f72e04a31fce31a79b4316b1 \
+                sha256  90e337504031ef7d3077ab1a52ca8bac9b2f72bc454c95365a1cd1e0e81e06e9 \
+                size    6406420
 
 subport ${name} {
     conflicts   ${name}-devel
 
-    patchfiles      patch-lib-system-certs.c.old.diff
+    patchfiles  patch-lib-system-certs.c.old.diff
 }
 
 subport ${name}-devel {
     conflicts   ${name}
     
-    version     3.8.4
+    version     3.8.6
     revision    0
 
-    checksums   rmd160  42eea662a17b646f78f3dd423200c9d17f9e3943 \
-                sha256  2bea4e154794f3f00180fa2a5c51fe8b005ac7a31cd58bd44cdfa7f36ebc3a9b \
-                size    6487520
+    checksums   rmd160  fa7d5faf5359e6de786eacb369b8c4077b15fd99 \
+                sha256  2e1588aae53cb32d43937f1f4eca28febd9c0c7aa1734fc5dd61a7e81e0ebcdd \
+                size    6517476
 
-    patchfiles      patch-lib-system-certs.c.diff
+    patchfiles  patch-lib-system-certs.c.diff
 }
 
 if {${build_arch} ne "ppc" || ${build_arch} ne "ppc64"} {

--- a/tools/MacPorts/graphics/ImageMagick/Portfile
+++ b/tools/MacPorts/graphics/ImageMagick/Portfile
@@ -14,11 +14,11 @@ legacysupport.newest_darwin_requires_legacy 10
 # PHP Warning:  Version warning: Imagick was compiled against Image Magick version XXXX but version YYYY is loaded. Imagick will run but may behave surprisingly in Unknown on line 0
 
 name                        ImageMagick
-version                     6.9.13-7
+version                     6.9.13-12
 revision                    0
-checksums                   rmd160  9025e38a212d8cfe5706f07c4f900a96b708c016 \
-                            sha256  2a521f7992b3dd32469b7b7254a81df8a0045cb0b963372e3ba6404b0a4efeae \
-                            size    9604796
+checksums                   rmd160  b3696f5a09d6a89ee66fd128abb95f83401bca1c \
+                            sha256  cc6189a5999c00f2fb8a0cdd2cddd8207c64bac5146639b8106e56e277c763bf \
+                            size    9617108
 
 categories                  graphics devel
 maintainers                 {ryandesign @ryandesign}
@@ -27,7 +27,11 @@ use_xz                      yes
 
 description                 Tools and libraries to manipulate images in many formats
 
-long_description            ImageMagick is a robust collection of tools and \
+long_description            This is the legacy ImageMagick version 6.  For the \
+                            modern ImageMagick version 7, please go to port \
+                            ImageMagick7. \
+                            \
+                            ImageMagick is a robust collection of tools and \
                             libraries to create, edit and compose bitmap images \
                             in a wide variety of formats. You can crop, resize, \
                             rotate, sharpen, color reduce or add effects or text \
@@ -109,6 +113,7 @@ configure.args              --enable-shared \
                             --without-rsvg \
                             --without-lqr \
                             --without-pango \
+                            --without-raqm \
                             --without-x \
                             --without-zstd \
                             --with-gs-font-dir=${prefix}/share/fonts/urw-fonts \
@@ -124,6 +129,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
         conflicts_build         cryptlib
     }
 }
+
+# https://trac.macports.org/wiki/WimplicitFunctionDeclaration#strchr
+configure.checks.implicit_function_declaration.whitelist-append strchr
 
 variant natron conflicts x11 requires pango rsvg q32 hdri description {Natron version} {
     # libc++-based build

--- a/tools/MacPorts/graphics/ImageMagick/Portfile.orig
+++ b/tools/MacPorts/graphics/ImageMagick/Portfile.orig
@@ -13,11 +13,11 @@ legacysupport.newest_darwin_requires_legacy 10
 # PHP Warning:  Version warning: Imagick was compiled against Image Magick version XXXX but version YYYY is loaded. Imagick will run but may behave surprisingly in Unknown on line 0
 
 name                        ImageMagick
-version                     6.9.13-7
+version                     6.9.13-12
 revision                    0
-checksums                   rmd160  9025e38a212d8cfe5706f07c4f900a96b708c016 \
-                            sha256  2a521f7992b3dd32469b7b7254a81df8a0045cb0b963372e3ba6404b0a4efeae \
-                            size    9604796
+checksums                   rmd160  b3696f5a09d6a89ee66fd128abb95f83401bca1c \
+                            sha256  cc6189a5999c00f2fb8a0cdd2cddd8207c64bac5146639b8106e56e277c763bf \
+                            size    9617108
 
 categories                  graphics devel
 maintainers                 {ryandesign @ryandesign}
@@ -26,7 +26,11 @@ use_xz                      yes
 
 description                 Tools and libraries to manipulate images in many formats
 
-long_description            ImageMagick is a robust collection of tools and \
+long_description            This is the legacy ImageMagick version 6.  For the \
+                            modern ImageMagick version 7, please go to port \
+                            ImageMagick7. \
+                            \
+                            ImageMagick is a robust collection of tools and \
                             libraries to create, edit and compose bitmap images \
                             in a wide variety of formats. You can crop, resize, \
                             rotate, sharpen, color reduce or add effects or text \
@@ -106,6 +110,7 @@ configure.args              --enable-shared \
                             --without-rsvg \
                             --without-lqr \
                             --without-pango \
+                            --without-raqm \
                             --without-x \
                             --without-zstd \
                             --with-gs-font-dir=${prefix}/share/fonts/urw-fonts \
@@ -121,6 +126,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
         conflicts_build         cryptlib
     }
 }
+
+# https://trac.macports.org/wiki/WimplicitFunctionDeclaration#strchr
+configure.checks.implicit_function_declaration.whitelist-append strchr
 
 test.run                    yes
 test.target                 check

--- a/tools/MacPorts/graphics/ImageMagick/files/Color.cpp.patch
+++ b/tools/MacPorts/graphics/ImageMagick/files/Color.cpp.patch
@@ -1,0 +1,14 @@
+Avoid using the C++11-specific nullptr.
+https://github.com/ImageMagick/ImageMagick6/issues/319
+https://github.com/ImageMagick/ImageMagick6/commit/945a51944874548efee9de2370b164cf797ab012
+--- Magick++/lib/Color.cpp
++++ Magick++/lib/Color.cpp
+@@ -223,7 +223,7 @@ const Magick::Color& Magick::Color::operator=(const std::string &x11color_)
+       _isValid = false;
+       _pixelOwn = false;
+       delete _pixel;
+-      _pixel = nullptr;
++      _pixel = (PixelPacket *)NULL;
+     }
+   ThrowPPException(false);
+ 

--- a/tools/MacPorts/graphics/giflib/Portfile.orig
+++ b/tools/MacPorts/graphics/giflib/Portfile.orig
@@ -1,46 +1,38 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem                      1.0
-PortGroup                       makefile 1.0
 
 name                            giflib
-version                         5.2.1
+version                         4.2.3
+revision                        1
 set major                       [lindex [split ${version} .] 0]
 categories                      graphics
 maintainers                     {ryandesign @ryandesign} openmaintainer
 license                         MIT
-platforms                       darwin
 homepage                        https://sourceforge.net/projects/giflib/
-master_sites                    sourceforge:project/giflib
+master_sites                    sourceforge:project/giflib/giflib-${major}.x
+use_bzip2                       yes
 
 description                     GIF library using patented LZW algorithm
 
 long_description                GIF loading and saving shared library. \
                                 Uses the LZW algorithm.
 
-checksums           rmd160  bc4be3ddaef877e4fd546b1240fe94dec8ef3e27 \
-                    sha256  31da5562f44c5f15d63340a09a4fd62b48c45620cd302f77a6d9acf0077879bd \
-                    size    444187
+checksums                       rmd160  34c30ace20155a61446d1561af44e3ad6329b49a \
+                                sha256  0ac8d56726f77c8bc9648c93bbb4d6185d32b15ba7bdb702415990f96f3cb766 \
+                                size    560968
 
-patchfiles                      Makefile.patch
+patchfiles                      patch-gif_lib.h.diff \
+                                patch-lib-gif_hash.c.diff
 
-build.args		PREFIX="${prefix}"  CC="${configure.cc}" \
-                CFLAGS="${configure.cppflags} ${configure.cflags} [get_canonical_archflags cc]" \
-                LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]"
-
-destroot.args	PREFIX="${prefix}"
-
-variant universal {
-    build.args-append   "CFLAGS+=\"${configure.universal_cflags}\"" \
-                        "LDFLAGS+=\"${configure.universal_ldflags}\""
-}
+configure.args                  --disable-x11
 
 use_parallel_build              yes
 
 set docdir ${prefix}/share/doc/${name}
 post-destroot {
     xinstall -d ${destroot}${docdir}
-    xinstall -W ${worksrcpath}-m 0644 COPYING NEWS README TODO history.adoc ${destroot}${docdir}
+    xinstall -W ${worksrcpath} -m 0644 AUTHORS BUGS COPYING NEWS README TODO api.txt history.txt ${destroot}${docdir}
     xinstall -m 0444 {*}[glob ${worksrcpath}/doc/*.1] ${destroot}${prefix}/share/man/man1
 }
 
@@ -50,6 +42,17 @@ variant doc description {Install HTML documentation} {
         xinstall -d ${destroot}${docdir}/html
         xinstall -m 0644 {*}[glob ${worksrcpath}/doc/*.html] ${destroot}${docdir}/html
     }
+}
+
+if {![variant_isset doc]} {
+    patchfiles-append           patch-no-docs.diff
+}
+
+variant x11 description {Include gif2x11 tool for displaying GIF files in an X window} {
+    depends_lib-append          port:xorg-libsm \
+                                port:xorg-libX11
+    
+    configure.args-delete       --disable-x11
 }
 
 livecheck.regex                 /${name}-(${major}\\.\[0-9.\]+)${extract.suffix}

--- a/tools/MacPorts/graphics/giflib/Portfile.patch
+++ b/tools/MacPorts/graphics/giflib/Portfile.patch
@@ -1,0 +1,76 @@
+--- Portfile.orig	2024-07-19 16:46:49
++++ Portfile	2024-07-19 16:48:39
+@@ -1,38 +1,46 @@
+ # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+ 
+ PortSystem                      1.0
++PortGroup                       makefile 1.0
+ 
+ name                            giflib
+-version                         4.2.3
+-revision                        1
++version                         5.2.1
+ set major                       [lindex [split ${version} .] 0]
+ categories                      graphics
+ maintainers                     {ryandesign @ryandesign} openmaintainer
+ license                         MIT
++platforms                       darwin
+ homepage                        https://sourceforge.net/projects/giflib/
+-master_sites                    sourceforge:project/giflib/giflib-${major}.x
+-use_bzip2                       yes
++master_sites                    sourceforge:project/giflib
+ 
+ description                     GIF library using patented LZW algorithm
+ 
+ long_description                GIF loading and saving shared library. \
+                                 Uses the LZW algorithm.
+ 
+-checksums                       rmd160  34c30ace20155a61446d1561af44e3ad6329b49a \
+-                                sha256  0ac8d56726f77c8bc9648c93bbb4d6185d32b15ba7bdb702415990f96f3cb766 \
+-                                size    560968
++checksums           rmd160  bc4be3ddaef877e4fd546b1240fe94dec8ef3e27 \
++                    sha256  31da5562f44c5f15d63340a09a4fd62b48c45620cd302f77a6d9acf0077879bd \
++                    size    444187
+ 
+-patchfiles                      patch-gif_lib.h.diff \
+-                                patch-lib-gif_hash.c.diff
++patchfiles                      Makefile.patch
+ 
+-configure.args                  --disable-x11
++build.args		PREFIX="${prefix}"  CC="${configure.cc}" \
++                CFLAGS="${configure.cppflags} ${configure.cflags} [get_canonical_archflags cc]" \
++                LDFLAGS="${configure.ldflags} [get_canonical_archflags ld]"
+ 
++destroot.args	PREFIX="${prefix}"
++
++variant universal {
++    build.args-append   "CFLAGS+=\"${configure.universal_cflags}\"" \
++                        "LDFLAGS+=\"${configure.universal_ldflags}\""
++}
++
+ use_parallel_build              yes
+ 
+ set docdir ${prefix}/share/doc/${name}
+ post-destroot {
+     xinstall -d ${destroot}${docdir}
+-    xinstall -W ${worksrcpath} -m 0644 AUTHORS BUGS COPYING NEWS README TODO api.txt history.txt ${destroot}${docdir}
++    xinstall -W ${worksrcpath}-m 0644 COPYING NEWS README TODO history.adoc ${destroot}${docdir}
+     xinstall -m 0444 {*}[glob ${worksrcpath}/doc/*.1] ${destroot}${prefix}/share/man/man1
+ }
+ 
+@@ -44,15 +52,4 @@
+     }
+ }
+ 
+-if {![variant_isset doc]} {
+-    patchfiles-append           patch-no-docs.diff
+-}
+-
+-variant x11 description {Include gif2x11 tool for displaying GIF files in an X window} {
+-    depends_lib-append          port:xorg-libsm \
+-                                port:xorg-libX11
+-    
+-    configure.args-delete       --disable-x11
+-}
+-
+ livecheck.regex                 /${name}-(${major}\\.\[0-9.\]+)${extract.suffix}

--- a/tools/MacPorts/graphics/opencolorio/Portfile
+++ b/tools/MacPorts/graphics/opencolorio/Portfile
@@ -20,8 +20,6 @@ long_description    OpenColorIO (OCIO) is a complete color management solution \
                     geared towards motion picture production with an emphasis on \
                     visual effects and computer animation.
 
-# please remove "stealth update" workaround on next version update
-dist_subdir         ${name}/${version}_1
 checksums           rmd160  297c061816895bd4d02a9450c0415d8769e188ab \
                     sha256  6e437aa8c09f5d870212847af7788d92c3a5c34c739b212a9947a4ef3e8542b8 \
                     size    11444813
@@ -32,17 +30,47 @@ github.livecheck.regex  {([0-9.]+)}
 configure.args-append \
     -DCMAKE_CONFIGURATION_TYPES=MacPorts
 
+# Keep this condition the same in the opencolorio, openimageio, and osl ports.
+set port_latest [expr {${os.platform} ne "darwin" || ${os.major} >= 20}]
+set port_latest 1
+
+if {!${port_latest}} {
+    github.setup        AcademySoftwareFoundation OpenColorIO 1.1.1 v
+    revision            4
+
+    checksums           rmd160  81534822cb8350e1b7ba171c91226de996494d02 \
+                        sha256  b7def3b5383c9b35dc9c0bdd26da74e2199c2b283d52bb84847aa307f70a0bc4 \
+                        size    13830493
+
+    # workaround for stealth update
+    dist_subdir         ${name}/${version}_1
+
+    # see https://github.com/imageworks/OpenColorIO/commit/c43cc918c3e79e324f11ca47e95bfe36e9e0dd15
+    patchfiles-append   patch-upstream.diff
+
+    # see https://gitweb.gentoo.org/repo/gentoo.git/tree/media-libs/opencolorio/files/opencolorio-1.1.0-yaml-cpp-0.6.patch
+    patchfiles-append   patch-yaml-cpp.diff
+
+    patchfiles-append   patch-yaml-cpp-0.7.diff
+
+    patchfiles-append   patch-fix-endianness.diff
+
+    patchfiles-append   patch-CMakeLists.txt.diff
+
+    livecheck.type      none
+
+    # see https://github.com/imageworks/OpenColorIO/issues/563
+    # https://trac.macports.org/ticket/67904
+    if {[string match *clang* ${configure.compiler}]} {
+        configure.cxxflags-append \
+            -Wno-error=self-assign-field
+    }
+}
+
 # source assumes C++11 compiler
 compiler.cxx_standard 2011
 configure.cxxflags-append \
     -std=c++11
-
-# see https://github.com/imageworks/OpenColorIO/issues/563
-# https://trac.macports.org/ticket/67904
-if {[string match *clang* ${configure.compiler}]} {
-    configure.cxxflags-append \
-        -Wno-error=self-assign-field
-}
 
 # src/core/ExponentOps.cpp: error: 'OpenColorIO::v1::{anonymous}::ExponentOp::~ExponentOp()'
 # defined but not used [-Werror=unused-function]
@@ -82,24 +110,10 @@ if {${configure.build_arch} in [list ppc ppc64]} {
         -DOCIO_USE_SSE=OFF
 }
 
-# OpenColorIO intentially installs Python module in lib
+# OpenColorIO intentionally installs Python module in lib
 # see https://github.com/imageworks/OpenColorIO/blob/15e96c1f579d3640947a5fcb5ec831383cc3956e/src/pyglue/CMakeLists.txt#L85
 
-variant python27 description {Build the Python 2.7 bindings} conflicts python38 python39 python310 python311 {
-    depends_lib-append port:python27 port:py27-pybind11
-    configure.args-append \
-        -DOCIO_PYTHON_VERSION=2.7 \
-        -DPYTHON=${prefix}/bin/python2.7
-    post-destroot {
-        xinstall -d -m 0755 \
-            ${destroot}${frameworks_dir}/Python.framework/Versions/2.7/lib/python2.7/site-packages
-        ln -s \
-            ${prefix}/lib/python2.7/site-packages/PyOpenColorIO.so \
-            ${destroot}${frameworks_dir}/Python.framework/Versions/2.7/lib/python2.7/site-packages/
-    }
-}
-
-variant python38 description {Build the Python 3.8 bindings} conflicts python27 python39 python310 python311 {
+variant python38 description {Build the Python 3.8 bindings} conflicts python39 python310 python311 python312 {
     depends_lib-append port:python38 port:py38-pybind11
     configure.args-append \
         -DOCIO_PYTHON_VERSION=3.8 \
@@ -113,7 +127,7 @@ variant python38 description {Build the Python 3.8 bindings} conflicts python27 
     }
 }
 
-variant python39 description {Build the Python 3.9 bindings} conflicts python27 python38 python310 python311 {
+variant python39 description {Build the Python 3.9 bindings} conflicts python38 python310 python311 python312 {
     depends_lib-append port:python39 port:py39-pybind11
     configure.args-append \
         -DOCIO_PYTHON_VERSION=3.9 \
@@ -127,7 +141,7 @@ variant python39 description {Build the Python 3.9 bindings} conflicts python27 
     }
 }
 
-variant python310 description {Build the Python 3.10 bindings} conflicts python27 python38 python39 python311 {
+variant python310 description {Build the Python 3.10 bindings} conflicts python38 python39 python311 python312 {
     depends_lib-append port:python310 port:py310-pybind11
     configure.args-append \
         -DOCIO_PYTHON_VERSION=3.10 \
@@ -142,7 +156,7 @@ variant python310 description {Build the Python 3.10 bindings} conflicts python2
 }
 
 
-variant python311 description {Build the Python 3.11 bindings} conflicts python27 python38 python39 python310 {
+variant python311 description {Build the Python 3.11 bindings} conflicts python38 python39 python310 python312 {
     depends_lib-append port:python311 port:py311-pybind11
     configure.args-append \
         -DOCIO_PYTHON_VERSION=3.11 \
@@ -156,11 +170,24 @@ variant python311 description {Build the Python 3.11 bindings} conflicts python2
     }
 }
 
-if {![variant_isset python27] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
-    default_variants +python311
+variant python312 description {Build the Python 3.12 bindings} conflicts python38 python39 python310 python311 {
+    depends_lib-append port:python312 port:py312-pybind11
+    configure.args-append \
+        -DPYTHON=${prefix}/bin/python3.12
+    post-destroot {
+        xinstall -d -m 0755 \
+            ${destroot}${frameworks_dir}/Python.framework/Versions/3.12/lib/python3.12/site-packages
+        ln -s \
+            ${prefix}/lib/python3.12/site-packages/PyOpenColorIO.so \
+            ${destroot}${frameworks_dir}/Python.framework/Versions/3.12/lib/python3.12/site-packages/
+    }
 }
 
-if {![variant_isset python27] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311] && ![variant_isset python312]} {
+    default_variants +python312
+}
+
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311] && ![variant_isset python312]} {
     configure.args-append \
         -DOCIO_BUILD_PYTHON=OFF \
         -DOCIO_BUILD_PYGLUE=OFF
@@ -169,9 +196,14 @@ if {![variant_isset python27] && ![variant_isset python38] && ![variant_isset py
 # make neither x11 nor quartz default since openimageio depends on opencolorio
 
 variant x11 {
+    if {${port_latest}} {
+        depends_lib-append  port:openexr
+    } else {
+        depends_lib-append  port:openimageio
+    }
+
     depends_lib-append \
         port:lcms2 \
-        port:openimageio \
         port:mesa \
         port:libGLU \
         port:freeglut \
@@ -189,9 +221,14 @@ variant x11 {
 }
 
 variant quartz {
+    if {${port_latest}} {
+        depends_lib-append  port:openexr
+    } else {
+        depends_lib-append  port:openimageio
+    }
+
     depends_lib-append \
         port:lcms2 \
-        port:openimageio \
         port:glew
     configure.args-append \
         -DGLUT_glut_LIBRARY=/System/Library/Frameworks/GLUT.framework

--- a/tools/MacPorts/graphics/opencolorio/Portfile.orig
+++ b/tools/MacPorts/graphics/opencolorio/Portfile.orig
@@ -7,8 +7,8 @@ PortGroup           boost 1.0
 
 boost.depends_type  build
 
-github.setup        AcademySoftwareFoundation OpenColorIO 2.2.0 v
-revision            1
+github.setup        AcademySoftwareFoundation OpenColorIO 2.3.2 v
+revision            0
 name                opencolorio
 categories          graphics
 maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
@@ -20,11 +20,9 @@ long_description    OpenColorIO (OCIO) is a complete color management solution \
                     geared towards motion picture production with an emphasis on \
                     visual effects and computer animation.
 
-# please remove "stealth update" workaround on next version update
-dist_subdir         ${name}/${version}_1
-checksums           rmd160  3f2ab794c6f4df2e8cec24f8d04478f2fe590c73 \
-                    sha256  646171b8c9d3941da2bf59fcab99f979626f908b6c6fa4d8fe95bda9eec0407b \
-                    size    11314927
+checksums           rmd160  297c061816895bd4d02a9450c0415d8769e188ab \
+                    sha256  6e437aa8c09f5d870212847af7788d92c3a5c34c739b212a9947a4ef3e8542b8 \
+                    size    11444813
 
 # Exclude pre-releases from livecheck
 github.livecheck.regex  {([0-9.]+)}
@@ -32,15 +30,19 @@ github.livecheck.regex  {([0-9.]+)}
 configure.args-append \
     -DCMAKE_CONFIGURATION_TYPES=MacPorts
 
-# pin the used version before macOS 11
-# keep in mind that openimageio had the same pin
-if {${os.platform} eq "darwin" && ${os.major} < 20} {
+# Keep this condition the same in the opencolorio, openimageio, and osl ports.
+set port_latest [expr {${os.platform} ne "darwin" || ${os.major} >= 20}]
+
+if {!${port_latest}} {
     github.setup        AcademySoftwareFoundation OpenColorIO 1.1.1 v
     revision            4
 
     checksums           rmd160  81534822cb8350e1b7ba171c91226de996494d02 \
                         sha256  b7def3b5383c9b35dc9c0bdd26da74e2199c2b283d52bb84847aa307f70a0bc4 \
                         size    13830493
+
+    # workaround for stealth update
+    dist_subdir         ${name}/${version}_1
 
     # see https://github.com/imageworks/OpenColorIO/commit/c43cc918c3e79e324f11ca47e95bfe36e9e0dd15
     patchfiles-append   patch-upstream.diff
@@ -55,19 +57,19 @@ if {${os.platform} eq "darwin" && ${os.major} < 20} {
     patchfiles-append   patch-CMakeLists.txt.diff
 
     livecheck.type      none
+
+    # see https://github.com/imageworks/OpenColorIO/issues/563
+    # https://trac.macports.org/ticket/67904
+    if {[string match *clang* ${configure.compiler}]} {
+        configure.cxxflags-append \
+            -Wno-error=self-assign-field
+    }
 }
 
 # source assumes C++11 compiler
 compiler.cxx_standard 2011
 configure.cxxflags-append \
     -std=c++11
-
-# see https://github.com/imageworks/OpenColorIO/issues/563
-# https://trac.macports.org/ticket/67904
-if {[string match *clang* ${configure.compiler}]} {
-    configure.cxxflags-append \
-        -Wno-error=self-assign-field
-}
 
 # src/core/ExponentOps.cpp: error: 'OpenColorIO::v1::{anonymous}::ExponentOp::~ExponentOp()'
 # defined but not used [-Werror=unused-function]
@@ -104,23 +106,10 @@ if {${configure.build_arch} in [list ppc ppc64]} {
         -DOCIO_USE_SSE=OFF
 }
 
-# OpenColorIO intentially installs Python module in lib
+# OpenColorIO intentionally installs Python module in lib
 # see https://github.com/imageworks/OpenColorIO/blob/15e96c1f579d3640947a5fcb5ec831383cc3956e/src/pyglue/CMakeLists.txt#L85
 
-variant python27 description {Build the Python 2.7 bindings} conflicts python38 python39 python310 python311 {
-    depends_lib-append port:python27
-    configure.args-append \
-        -DPYTHON=${prefix}/bin/python2.7
-    post-destroot {
-        xinstall -d -m 0755 \
-            ${destroot}${frameworks_dir}/Python.framework/Versions/2.7/lib/python2.7/site-packages
-        ln -s \
-            ${prefix}/lib/python2.7/site-packages/PyOpenColorIO.so \
-            ${destroot}${frameworks_dir}/Python.framework/Versions/2.7/lib/python2.7/site-packages/
-    }
-}
-
-variant python38 description {Build the Python 3.8 bindings} conflicts python27 python39 python310 python311 {
+variant python38 description {Build the Python 3.8 bindings} conflicts python39 python310 python311 python312 {
     depends_lib-append port:python38
     configure.args-append \
         -DPYTHON=${prefix}/bin/python3.8
@@ -133,7 +122,7 @@ variant python38 description {Build the Python 3.8 bindings} conflicts python27 
     }
 }
 
-variant python39 description {Build the Python 3.9 bindings} conflicts python27 python38 python310 python311 {
+variant python39 description {Build the Python 3.9 bindings} conflicts python38 python310 python311 python312 {
     depends_lib-append port:python39
     configure.args-append \
         -DPYTHON=${prefix}/bin/python3.9
@@ -146,7 +135,7 @@ variant python39 description {Build the Python 3.9 bindings} conflicts python27 
     }
 }
 
-variant python310 description {Build the Python 3.10 bindings} conflicts python27 python38 python39 python311 {
+variant python310 description {Build the Python 3.10 bindings} conflicts python38 python39 python311 python312 {
     depends_lib-append port:python310
     configure.args-append \
         -DPYTHON=${prefix}/bin/python3.10
@@ -154,13 +143,13 @@ variant python310 description {Build the Python 3.10 bindings} conflicts python2
         xinstall -d -m 0755 \
             ${destroot}${frameworks_dir}/Python.framework/Versions/3.10/lib/python3.10/site-packages
         ln -s \
-            ${prefix}/lib/python3.9/site-packages/PyOpenColorIO.so \
+            ${prefix}/lib/python3.10/site-packages/PyOpenColorIO.so \
             ${destroot}${frameworks_dir}/Python.framework/Versions/3.10/lib/python3.10/site-packages/
     }
 }
 
 
-variant python311 description {Build the Python 3.11 bindings} conflicts python27 python38 python39 python310 {
+variant python311 description {Build the Python 3.11 bindings} conflicts python38 python39 python310 python312 {
     depends_lib-append port:python311
     configure.args-append \
         -DPYTHON=${prefix}/bin/python3.11
@@ -168,16 +157,29 @@ variant python311 description {Build the Python 3.11 bindings} conflicts python2
         xinstall -d -m 0755 \
             ${destroot}${frameworks_dir}/Python.framework/Versions/3.11/lib/python3.11/site-packages
         ln -s \
-            ${prefix}/lib/python3.9/site-packages/PyOpenColorIO.so \
+            ${prefix}/lib/python3.11/site-packages/PyOpenColorIO.so \
             ${destroot}${frameworks_dir}/Python.framework/Versions/3.11/lib/python3.11/site-packages/
     }
 }
 
-if {![variant_isset python27] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
-    default_variants +python311
+variant python312 description {Build the Python 3.12 bindings} conflicts python38 python39 python310 python311 {
+    depends_lib-append port:python312
+    configure.args-append \
+        -DPYTHON=${prefix}/bin/python3.12
+    post-destroot {
+        xinstall -d -m 0755 \
+            ${destroot}${frameworks_dir}/Python.framework/Versions/3.12/lib/python3.12/site-packages
+        ln -s \
+            ${prefix}/lib/python3.12/site-packages/PyOpenColorIO.so \
+            ${destroot}${frameworks_dir}/Python.framework/Versions/3.12/lib/python3.12/site-packages/
+    }
 }
 
-if {![variant_isset python27] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311] && ![variant_isset python312]} {
+    default_variants +python312
+}
+
+if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311] && ![variant_isset python312]} {
     configure.args-append \
         -DOCIO_BUILD_PYGLUE=OFF
 }
@@ -185,9 +187,14 @@ if {![variant_isset python27] && ![variant_isset python38] && ![variant_isset py
 # make neither x11 nor quartz default since openimageio depends on opencolorio
 
 variant x11 {
+    if {${port_latest}} {
+        depends_lib-append  port:openexr
+    } else {
+        depends_lib-append  port:openimageio
+    }
+
     depends_lib-append \
         port:lcms2 \
-        port:openimageio \
         port:mesa \
         port:libGLU \
         port:freeglut \
@@ -205,9 +212,14 @@ variant x11 {
 }
 
 variant quartz {
+    if {${port_latest}} {
+        depends_lib-append  port:openexr
+    } else {
+        depends_lib-append  port:openimageio
+    }
+
     depends_lib-append \
         port:lcms2 \
-        port:openimageio \
         port:glew
     configure.args-append \
         -DGLUT_glut_LIBRARY=/System/Library/Frameworks/GLUT.framework

--- a/tools/MacPorts/graphics/opencolorio/Portfile.patch
+++ b/tools/MacPorts/graphics/opencolorio/Portfile.patch
@@ -1,61 +1,14 @@
---- Portfile.orig	2023-11-28 15:59:17.000000000 +0100
-+++ Portfile	2023-11-28 16:02:49.000000000 +0100
-@@ -7,7 +7,7 @@
+--- Portfile.orig	2024-05-07 15:29:13
++++ Portfile	2024-05-07 15:34:19
+@@ -32,6 +32,7 @@
  
- boost.depends_type  build
+ # Keep this condition the same in the opencolorio, openimageio, and osl ports.
+ set port_latest [expr {${os.platform} ne "darwin" || ${os.major} >= 20}]
++set port_latest 1
  
--github.setup        AcademySoftwareFoundation OpenColorIO 2.2.0 v
-+github.setup        AcademySoftwareFoundation OpenColorIO 2.2.1 v
- name                opencolorio
- categories          graphics
- maintainers         {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
-@@ -21,9 +21,9 @@
- 
- # please remove "stealth update" workaround on next version update
- dist_subdir         ${name}/${version}_1
--checksums           rmd160  3f2ab794c6f4df2e8cec24f8d04478f2fe590c73 \
--                    sha256  646171b8c9d3941da2bf59fcab99f979626f908b6c6fa4d8fe95bda9eec0407b \
--                    size    11314927
-+checksums           rmd160  f9369157eeeca1bbce00594b82d00118924816bc \
-+                    sha256  daf215acddf1c3ed443e6c159e369f2c623b015fa07f11fcc76aae9ede665084 \
-+                    size    11342273
- 
- # Exclude pre-releases from livecheck
- github.livecheck.regex  {([0-9.]+)}
-@@ -31,30 +31,8 @@
- configure.args-append \
-     -DCMAKE_CONFIGURATION_TYPES=MacPorts
- 
--# pin the used version before macOS 11
--# keep in mind that openimageio had the same pin
--if {${os.platform} eq "darwin" && ${os.major} < 20} {
--    github.setup        AcademySoftwareFoundation OpenColorIO 1.1.1 v
--    revision            3
--
--    checksums           rmd160  81534822cb8350e1b7ba171c91226de996494d02 \
--                        sha256  b7def3b5383c9b35dc9c0bdd26da74e2199c2b283d52bb84847aa307f70a0bc4 \
--                        size    13830493
--
--    # see https://github.com/imageworks/OpenColorIO/commit/c43cc918c3e79e324f11ca47e95bfe36e9e0dd15
--    patchfiles-append   patch-upstream.diff
--
--    # see https://gitweb.gentoo.org/repo/gentoo.git/tree/media-libs/opencolorio/files/opencolorio-1.1.0-yaml-cpp-0.6.patch
--    patchfiles-append   patch-yaml-cpp.diff
--
--    patchfiles-append   patch-yaml-cpp-0.7.diff
--
--    patchfiles-append   patch-fix-endianness.diff
--
--    patchfiles-append   patch-CMakeLists.txt.diff
--
--    livecheck.type      none
--}
-+patchfiles-append \
-+    patch-OCIOZArchive.diff
- 
- # source assumes C++11 compiler
- compiler.cxx_standard 2011
-@@ -93,6 +71,9 @@
+ if {!${port_latest}} {
+     github.setup        AcademySoftwareFoundation OpenColorIO 1.1.1 v
+@@ -96,6 +97,9 @@
      port:tinyxml
  
  configure.args-append \
@@ -65,21 +18,10 @@
      -DUSE_EXTERNAL_YAML=ON \
      -DUSE_EXTERNAL_TINYXML=ON \
      -DUSE_EXTERNAL_LCMS=ON
-@@ -107,8 +88,9 @@
+@@ -110,8 +114,9 @@
  # see https://github.com/imageworks/OpenColorIO/blob/15e96c1f579d3640947a5fcb5ec831383cc3956e/src/pyglue/CMakeLists.txt#L85
  
- variant python27 description {Build the Python 2.7 bindings} conflicts python38 python39 python310 python311 {
--    depends_lib-append port:python27
-+    depends_lib-append port:python27 port:py27-pybind11
-     configure.args-append \
-+        -DOCIO_PYTHON_VERSION=2.7 \
-         -DPYTHON=${prefix}/bin/python2.7
-     post-destroot {
-         xinstall -d -m 0755 \
-@@ -120,8 +102,9 @@
- }
- 
- variant python38 description {Build the Python 3.8 bindings} conflicts python27 python39 python310 python311 {
+ variant python38 description {Build the Python 3.8 bindings} conflicts python39 python310 python311 python312 {
 -    depends_lib-append port:python38
 +    depends_lib-append port:python38 port:py38-pybind11
      configure.args-append \
@@ -87,10 +29,10 @@
          -DPYTHON=${prefix}/bin/python3.8
      post-destroot {
          xinstall -d -m 0755 \
-@@ -133,8 +116,9 @@
+@@ -123,8 +128,9 @@
  }
  
- variant python39 description {Build the Python 3.9 bindings} conflicts python27 python38 python310 python311 {
+ variant python39 description {Build the Python 3.9 bindings} conflicts python38 python310 python311 python312 {
 -    depends_lib-append port:python39
 +    depends_lib-append port:python39 port:py39-pybind11
      configure.args-append \
@@ -98,10 +40,10 @@
          -DPYTHON=${prefix}/bin/python3.9
      post-destroot {
          xinstall -d -m 0755 \
-@@ -146,8 +130,9 @@
+@@ -136,34 +142,36 @@
  }
  
- variant python310 description {Build the Python 3.10 bindings} conflicts python27 python38 python39 python311 {
+ variant python310 description {Build the Python 3.10 bindings} conflicts python38 python39 python311 python312 {
 -    depends_lib-append port:python310
 +    depends_lib-append port:python310 port:py310-pybind11
      configure.args-append \
@@ -109,10 +51,16 @@
          -DPYTHON=${prefix}/bin/python3.10
      post-destroot {
          xinstall -d -m 0755 \
-@@ -160,8 +145,9 @@
+             ${destroot}${frameworks_dir}/Python.framework/Versions/3.10/lib/python3.10/site-packages
+         ln -s \
+-            ${prefix}/lib/python3.10/site-packages/PyOpenColorIO.so \
++            ${prefix}/lib/python3.9/site-packages/PyOpenColorIO.so \
+             ${destroot}${frameworks_dir}/Python.framework/Versions/3.10/lib/python3.10/site-packages/
+     }
+ }
  
  
- variant python311 description {Build the Python 3.11 bindings} conflicts python27 python38 python39 python310 {
+ variant python311 description {Build the Python 3.11 bindings} conflicts python38 python39 python310 python312 {
 -    depends_lib-append port:python311
 +    depends_lib-append port:python311 port:py311-pybind11
      configure.args-append \
@@ -120,9 +68,23 @@
          -DPYTHON=${prefix}/bin/python3.11
      post-destroot {
          xinstall -d -m 0755 \
-@@ -178,6 +164,7 @@
+             ${destroot}${frameworks_dir}/Python.framework/Versions/3.11/lib/python3.11/site-packages
+         ln -s \
+-            ${prefix}/lib/python3.11/site-packages/PyOpenColorIO.so \
++            ${prefix}/lib/python3.9/site-packages/PyOpenColorIO.so \
+             ${destroot}${frameworks_dir}/Python.framework/Versions/3.11/lib/python3.11/site-packages/
+     }
+ }
  
- if {![variant_isset python27] && ![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311]} {
+ variant python312 description {Build the Python 3.12 bindings} conflicts python38 python39 python310 python311 {
+-    depends_lib-append port:python312
++    depends_lib-append port:python312 port:py312-pybind11
+     configure.args-append \
+         -DPYTHON=${prefix}/bin/python3.12
+     post-destroot {
+@@ -181,6 +189,7 @@
+ 
+ if {![variant_isset python38] && ![variant_isset python39] && ![variant_isset python310] && ![variant_isset python311] && ![variant_isset python312]} {
      configure.args-append \
 +        -DOCIO_BUILD_PYTHON=OFF \
          -DOCIO_BUILD_PYGLUE=OFF

--- a/tools/MacPorts/graphics/openimageio/Portfile
+++ b/tools/MacPorts/graphics/openimageio/Portfile
@@ -15,11 +15,25 @@ description             a library for reading and writing images
 long_description        OpenImageIO is a library for reading and writing images, and a bunch of \
                         related classes, utilities, and applications.
 
-github.setup        OpenImageIO oiio 2.4.17.0 v
-revision            100
-checksums           rmd160  e593d35b8a4d62c0277622267c43911836eebd61 \
-                    sha256  7fe81d8e5bce30cc4a212f020ac3cc4344e6b7c1c0842475e3a048515099c65c \
-                    size    47900800
+# Keep this condition the same in the opencolorio, openimageio, and osl ports.
+set port_latest [expr {${os.platform} ne "darwin" || ${os.major} >= 20}]
+set port_latest 1
+
+if {${port_latest}} {
+    github.setup        AcademySoftwareFoundation OpenImageIO 2.5.10.1 v
+    revision            1
+    checksums           rmd160  acca3794870850f6d39e41e62e9370bf6ff9565b \
+                        sha256  8f6a547f6a5d510737ba436f867043db537def65f0fdb14ec30e5a185b619f93 \
+                        size    52061055
+} else {
+    github.setup        AcademySoftwareFoundation OpenImageIO 2.1.20.0 v
+    revision            15
+    checksums           rmd160  7f241baddcc6e731a29fb37090e4582953560f38 \
+                        sha256  0ad46bda55d6357a3c474b8c8ccbb41d9732313247cffaf4a65fc50e6aad9e78 \
+                        size    29116032
+
+    livecheck.type      none
+}
 
 github.tarball_from     archive
 
@@ -31,9 +45,20 @@ patchfiles-append oiio-2.4.6-filesystem.patch
 
 patchfiles-append   patch-2.4.5-cmake-disable-wall-werror.diff
 
-depends_lib-append  port:imath \
-                    port:openexr
- 
+if {${port_latest}} {
+    depends_lib-append  port:imath \
+                        port:openexr
+} else {
+    patchfiles-append   patch-FindOpenJpeg.cmake.diff
+    patchfiles-append   patch-libraw-0.21.0.diff
+    patchfiles-append   patch-2.1.20-cmake-disable-wall-werror.diff
+
+    depends_lib-append  port:field3d \
+                        port:openexr2
+
+    configure.pkg_config_path-prepend \
+                        ${prefix}/libexec/openexr2/lib/pkgconfig
+}
 
 # error: multiple overloads of 'address' instantiate to the same signature 'const_pointer (const_reference) const noexcept'
 # http://lists.llvm.org/pipermail/llvm-bugs/2013-November/031552.html
@@ -48,8 +73,13 @@ compiler.thread_local_storage yes
 
 configure.cxxflags-append \
                         -Wno-deprecated-declarations \
-                        -Wno-error=unknown-warning-option \
                         -Wno-unknown-warning-option
+
+if {[string match *clang* ${configure.compiler}]} {
+    # This is a clang-specific flag:
+    configure.cxxflags-append \
+                        -Wno-error=unknown-warning-option
+}
 
 # NOTE: Ensure we prepend 'libfmt9', to include it before 'openexr2'
 set port_libfmt         libfmt9
@@ -137,21 +167,34 @@ configure.args-append \
     -DUSE_LIBRAW:BOOL=TRUE \
     -DUSE_OPENGL:BOOL=FALSE \
     -DUSE_WEBP:BOOL=TRUE \
+    -DUSE_JXL:BOOL=FALSE \
     -DBUILD_FMT_FORCE:BOOL=TRUE \
     -DSTOP_ON_WARNING:BOOL=FALSE
-
+ 
 # optional components
+
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    configure.args-append \
+                        -DUSE_QT=OFF
+    # configure.args-append -DUSE_OPENGL=OFF
+}
+
+if {[string match *gcc* ${configure.compiler}] \
+    && ${configure.build_arch} in [list i386 ppc]} {
+    configure.ldflags-append \
+                        -latomic
+}
 
 default_variants    +opencolorio +openjpeg +freetype
 
-variant natron conflicts ffmpeg qt5 dicom openvdb ptex dicom requires opencolorio openjpeg freetype description {Natron version} {
+variant natron conflicts ffmpeg qt5 dicom openvdb ptex dicom requires opencolorio openjpeg freetype jxl description {Natron version} {
     if {${configure.cxx_stdlib} eq "libstdc++"} {
     }
 }
 
 configure.args-append   -DUSE_PYTHON=OFF
 
-set pythons_suffixes    {27 36 37 38 39 310 311}
+set pythons_suffixes    {38 39 310 311 312}
 
 set pythons_ports       {}
 foreach s ${pythons_suffixes} {
@@ -185,15 +228,27 @@ foreach s ${pythons_suffixes} {
 # this default version should stay synchronized with python_get_default_version
 #    in the python PortGroup
 if {${set_python_default}} {
-    default_variants        +python311
+    default_variants        +python312
 }
 
 #configure.args-append       -DUSE_FFMPEG=OFF
 variant ffmpeg description {Add FFmpeg support.} {
-depends_lib-append          path:lib/libavcodec.dylib:ffmpeg
     configure.args-delete       -DUSE_FFMPEG:BOOL=FALSE
     configure.args-append       -DUSE_FFMPEG:BOOL=TRUE
+if {${port_latest}} {
+    set ffmpeg_ver 6
+
+    #configure.args-append       -DUSE_FFMPEG=OFF
+    depends_lib-append          port:ffmpeg${ffmpeg_ver}
+
+    configure.pkg_config_path-prepend \
+                        ${prefix}/libexec/ffmpeg${ffmpeg_ver}/lib/pkgconfig
+} else {
+    #configure.args-append       -DUSE_FFMPEG=OFF
+    depends_lib-append          path:lib/libavcodec.dylib:ffmpeg
 }
+}
+
 
 #configure.args-append       -DUSE_JPEGTURBO=OFF
 depends_lib-append          path:include/turbojpeg.h:libjpeg-turbo \
@@ -213,12 +268,16 @@ depends_lib-append          port:opencolorio
     configure.args-append       -DUSE_OCIO:BOOL=TRUE
 }
 
-#configure.args-append       -DUSE_OPENCV=OFF
 variant opencv description {Use OpenCV.} {
 set opencv_ver 4
-depends_lib-append          path:lib/opencv${opencv_ver}/libopencv_core.dylib:opencv${opencv_ver}
-configure.args-append       -DOpenCV_INCLUDE_DIR=${prefix}/include/opencv${opencv_ver} \
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # opencv4 does not build on 10.6 and earlier.
+    configure.args-append   -DUSE_OPENCV=OFF
+} else {
+    depends_lib-append      path:lib/opencv${opencv_ver}/libopencv_core.dylib:opencv${opencv_ver}
+    configure.args-append   -DOpenCV_INCLUDE_DIR=${prefix}/include/opencv${opencv_ver} \
                             -DOpenCV_ROOT=${prefix}/lib/opencv${opencv_ver}
+}
     configure.args-delete -DUSE_OPENCV:BOOL=FALSE
     configure.args-append -DUSE_OPENCV:BOOL=TRUE
 }
@@ -246,18 +305,30 @@ depends_lib-append          port:ptex
 #configure.args-append       -DUSE_LIBRAW=OFF
 depends_lib-append          port:libraw
 
-#configure.args-append       -DUSE_TBB=OFF \
-#                            -DUSE_OPENVDB=OFF
 variant openvdb description {Use OpenVDB.} {
-depends_lib-append          port:tbb \
-                            port:openvdb
+    if {${port_latest}} {
+        depends_lib-append          port:openvdb \
+                                    port:onetbb
+        configure.args-append       -DTBB_ROOT=${prefix}/libexec/onetbb
+        configure.args-delete -DUSE_OPENVDB:BOOL=FALSE
+        configure.args-append -DUSE_OPENVDB:BOOL=TRUE
+    } else {
+        depends_lib-append          port:openvdb \
+                                    port:tbb
+        # https://trac.macports.org/ticket/69842
+        #configure.args-append       -DUSE_OPENVDB=OFF
+
+        configure.args-append       -DTBB_ROOT=${prefix}/libexec/tbb
+    }
     configure.args-delete -DUSE_TBB:BOOL=FALSE
     configure.args-append -DUSE_TBB:BOOL=TRUE
-    configure.args-delete -DUSE_OPENVDB:BOOL=FALSE
-    configure.args-append -DUSE_OPENVDB:BOOL=TRUE
 }
 
-configure.args-append       -DTBB_ROOT=${prefix}/libexec/tbb
+variant jxl description {Use JPEG-XL.} {
+depends_lib-append          port:libjxl
+    configure.args-delete -DUSE_JXL:BOOL=FALSE
+    configure.args-append -DUSE_JXL:BOOL=TRUE
+}
 
 # not in MacPorts
 configure.args-append       -DUSE_NUKE=OFF

--- a/tools/MacPorts/graphics/openimageio/Portfile
+++ b/tools/MacPorts/graphics/openimageio/Portfile
@@ -29,7 +29,6 @@ patchfiles-append oiio-2.3.20-strnlen.patch
 patchfiles-append oiio-2.4.6-sysutil.patch
 patchfiles-append oiio-2.4.6-filesystem.patch
 
-patchfiles-append   patch-enforce-clang14.diff
 patchfiles-append   patch-2.4.5-cmake-disable-wall-werror.diff
 
 depends_lib-append  port:imath \

--- a/tools/MacPorts/graphics/openimageio/Portfile
+++ b/tools/MacPorts/graphics/openimageio/Portfile
@@ -29,6 +29,7 @@ patchfiles-append oiio-2.3.20-strnlen.patch
 patchfiles-append oiio-2.4.6-sysutil.patch
 patchfiles-append oiio-2.4.6-filesystem.patch
 
+patchfiles-append   patch-enforce-clang14.diff
 patchfiles-append   patch-2.4.5-cmake-disable-wall-werror.diff
 
 depends_lib-append  port:imath \

--- a/tools/MacPorts/graphics/openimageio/Portfile.orig
+++ b/tools/MacPorts/graphics/openimageio/Portfile.orig
@@ -2,7 +2,6 @@
 
 PortSystem              1.0
 PortGroup               github 1.0
-PortGroup               qt5 1.0
 PortGroup               cmake 1.1
 PortGroup               active_variants 1.1
 PortGroup               compiler_blacklist_versions 1.0
@@ -16,26 +15,21 @@ description             a library for reading and writing images
 long_description        OpenImageIO is a library for reading and writing images, and a bunch of \
                         related classes, utilities, and applications.
 
-# Pin the used version before macOS 11, which is required by pinned versions
-# of opencolorio and osl.
-if {${os.platform} eq "darwin" && ${os.major} >= 20} {
-    set port_latest     yes
-} else {
-    set port_latest     no
-}
+# Keep this condition the same in the opencolorio, openimageio, and osl ports.
+set port_latest [expr {${os.platform} ne "darwin" || ${os.major} >= 20}]
 
 if {${port_latest}} {
-    github.setup        OpenImageIO oiio 2.4.5.0 v
-    revision            9
-    checksums           rmd160  32b2b0f0b01268a91fc98cfca948a71e89d8e54b \
-                        sha256  21177a9665021a99123885cd8383116d15013b6610b4b09bcf209612423fedc5 \
-                        size    31938357
+    github.setup        AcademySoftwareFoundation OpenImageIO 2.5.10.1 v
+    revision            1
+    checksums           rmd160  acca3794870850f6d39e41e62e9370bf6ff9565b \
+                        sha256  8f6a547f6a5d510737ba436f867043db537def65f0fdb14ec30e5a185b619f93 \
+                        size    52061055
 } else {
-    github.setup        OpenImageIO oiio 2.1.20.0 v
-    revision            14
-    checksums           rmd160  d10c488b93ab2335d53545d8a1b35ba4c1babb98 \
-                        sha256  75222543286d3a12473aa03fdb4e6c9f98760c5ad1ad89d3cf82a5da41385ae0 \
-                        size    29115990
+    github.setup        AcademySoftwareFoundation OpenImageIO 2.1.20.0 v
+    revision            15
+    checksums           rmd160  7f241baddcc6e731a29fb37090e4582953560f38 \
+                        sha256  0ad46bda55d6357a3c474b8c8ccbb41d9732313247cffaf4a65fc50e6aad9e78 \
+                        size    29116032
 
     livecheck.type      none
 }
@@ -43,21 +37,40 @@ if {${port_latest}} {
 github.tarball_from     archive
 
 if {${port_latest}} {
-    patchfiles-append   patch-enforce-clang14.diff
-    patchfiles-append   patch-2.4.5-cmake-disable-wall-werror.diff
-
     depends_lib-append  port:imath \
-                        port:openexr
+                        port:openexr \
+                        port:openvdb \
+                        port:onetbb
+    #configure.args-append       -DUSE_TBB=OFF
+    configure.args-append       -DTBB_ROOT=${prefix}/libexec/onetbb
+
+    set ffmpeg_ver 6
+
+    #configure.args-append       -DUSE_FFMPEG=OFF
+    depends_lib-append          port:ffmpeg${ffmpeg_ver}
+
+    configure.pkg_config_path-prepend \
+                        ${prefix}/libexec/ffmpeg${ffmpeg_ver}/lib/pkgconfig
 } else {
     patchfiles-append   patch-FindOpenJpeg.cmake.diff
     patchfiles-append   patch-libraw-0.21.0.diff
     patchfiles-append   patch-2.1.20-cmake-disable-wall-werror.diff
 
     depends_lib-append  port:field3d \
-                        port:openexr2
+                        port:openexr2 \
+                        port:tbb
 
     configure.pkg_config_path-prepend \
                         ${prefix}/libexec/openexr2/lib/pkgconfig
+
+    # https://trac.macports.org/ticket/69842
+    configure.args-append       -DUSE_OPENVDB=OFF
+
+    #configure.args-append       -DUSE_TBB=OFF
+    configure.args-append       -DTBB_ROOT=${prefix}/libexec/tbb
+
+    #configure.args-append       -DUSE_FFMPEG=OFF
+    depends_lib-append          path:lib/libavcodec.dylib:ffmpeg
 }
 
 # error: multiple overloads of 'address' instantiate to the same signature 'const_pointer (const_reference) const noexcept'
@@ -73,8 +86,13 @@ compiler.thread_local_storage yes
 
 configure.cxxflags-append \
                         -Wno-deprecated-declarations \
-                        -Wno-error=unknown-warning-option \
                         -Wno-unknown-warning-option
+
+if {[string match *clang* ${configure.compiler}]} {
+    # This is a clang-specific flag:
+    configure.cxxflags-append \
+                        -Wno-error=unknown-warning-option
+}
 
 # NOTE: Ensure we prepend 'libfmt9', to include it before 'openexr2'
 set port_libfmt         libfmt9
@@ -103,13 +121,25 @@ depends_lib-append      port:robin-map \
 
 # optional components
 
-#configure.args-append   -DUSE_OPENGL=OFF \
-#                        -DUSE_QT=OFF
-qt5.min_version         5.6
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    configure.args-append \
+                        -DUSE_QT=OFF
+    # configure.args-append -DUSE_OPENGL=OFF
+} else {
+    PortGroup           qt5 1.0
+
+    qt5.min_version     5.6
+}
+
+if {[string match *gcc* ${configure.compiler}] \
+    && ${configure.build_arch} in [list i386 ppc]} {
+    configure.ldflags-append \
+                        -latomic
+}
 
 configure.args-append   -DUSE_PYTHON=OFF
 
-set pythons_suffixes    {27 36 37 38 39 310 311}
+set pythons_suffixes    {38 39 310 311 312}
 
 set pythons_ports       {}
 foreach s ${pythons_suffixes} {
@@ -143,11 +173,8 @@ foreach s ${pythons_suffixes} {
 # this default version should stay synchronized with python_get_default_version
 #    in the python PortGroup
 if {${set_python_default}} {
-    default_variants        +python311
+    default_variants        +python312
 }
-
-#configure.args-append       -DUSE_FFMPEG=OFF
-depends_lib-append          path:lib/libavcodec.dylib:ffmpeg
 
 #configure.args-append       -DUSE_JPEGTURBO=OFF
 depends_lib-append          path:include/turbojpeg.h:libjpeg-turbo \
@@ -159,11 +186,15 @@ configure.args-append       -DOpenJpeg_ROOT=${prefix}
 #configure.args-append       -DUSE_OCIO=OFF
 depends_lib-append          port:opencolorio
 
-#configure.args-append       -DUSE_OPENCV=OFF
 set opencv_ver 4
-depends_lib-append          path:lib/opencv${opencv_ver}/libopencv_core.dylib:opencv${opencv_ver}
-configure.args-append       -DOpenCV_INCLUDE_DIR=${prefix}/include/opencv${opencv_ver} \
+if {${os.platform} eq "darwin" && ${os.major} < 11} {
+    # opencv4 does not build on 10.6 and earlier.
+    configure.args-append   -DUSE_OPENCV=OFF
+} else {
+    depends_lib-append      path:lib/opencv${opencv_ver}/libopencv_core.dylib:opencv${opencv_ver}
+    configure.args-append   -DOpenCV_INCLUDE_DIR=${prefix}/include/opencv${opencv_ver} \
                             -DOpenCV_ROOT=${prefix}/lib/opencv${opencv_ver}
+}
 
 #configure.args-append       -DUSE_FREETYPE=OFF
 depends_lib-append          port:freetype
@@ -179,13 +210,6 @@ depends_lib-append          port:ptex
 
 #configure.args-append       -DUSE_LIBRAW=OFF
 depends_lib-append          port:libraw
-
-#configure.args-append       -DUSE_TBB=OFF \
-#                            -DUSE_OPENVDB=OFF
-depends_lib-append          port:tbb \
-                            port:openvdb
-
-configure.args-append       -DTBB_ROOT=${prefix}/libexec/tbb
 
 # not in MacPorts
 configure.args-append       -DUSE_NUKE=OFF

--- a/tools/MacPorts/graphics/openimageio/Portfile.rej
+++ b/tools/MacPorts/graphics/openimageio/Portfile.rej
@@ -1,6 +1,12 @@
---- Portfile.orig	2024-07-19 15:40:09
-+++ Portfile	2024-07-19 16:50:43
-@@ -17,6 +17,7 @@
+@@ -2,7 +2,6 @@
+ 
+ PortSystem              1.0
+ PortGroup               github 1.0
+-PortGroup               qt5 1.0
+ PortGroup               cmake 1.1
+ PortGroup               active_variants 1.1
+ PortGroup               compiler_blacklist_versions 1.0
+@@ -18,6 +17,7 @@
  
  # Keep this condition the same in the opencolorio, openimageio, and osl ports.
  set port_latest [expr {${os.platform} ne "darwin" || ${os.major} >= 20}]
@@ -8,62 +14,50 @@
  
  if {${port_latest}} {
      github.setup        AcademySoftwareFoundation OpenImageIO 2.5.10.1 v
-@@ -36,41 +37,27 @@
+@@ -37,20 +37,20 @@
  
  github.tarball_from     archive
  
--if {${port_latest}} {
--    depends_lib-append  port:imath \
--                        port:openexr \
--                        port:openvdb \
--                        port:onetbb
--    #configure.args-append       -DUSE_TBB=OFF
--    configure.args-append       -DTBB_ROOT=${prefix}/libexec/onetbb
 +patchfiles-append oiio-2.0.8-invalidatespec.patch
 +patchfiles-append oiio-2.0.8-atomic-load.patch
 +patchfiles-append oiio-2.3.20-strnlen.patch
 +patchfiles-append oiio-2.4.6-sysutil.patch
 +patchfiles-append oiio-2.4.6-filesystem.patch
- 
--    set ffmpeg_ver 6
++
 +patchfiles-append   patch-2.4.5-cmake-disable-wall-werror.diff
- 
++
+ if {${port_latest}} {
+     depends_lib-append  port:imath \
+                         port:openexr \
+                         port:onetbb
+     #configure.args-append       -DUSE_TBB=OFF
+     configure.args-append       -DTBB_ROOT=${prefix}/libexec/onetbb
+-
+-    set ffmpeg_ver 6
+-
 -    #configure.args-append       -DUSE_FFMPEG=OFF
 -    depends_lib-append          port:ffmpeg${ffmpeg_ver}
 -
 -    configure.pkg_config_path-prepend \
 -                        ${prefix}/libexec/ffmpeg${ffmpeg_ver}/lib/pkgconfig
-+if {${port_latest}} {
-+    depends_lib-append  port:imath \
-+                        port:openexr
  } else {
      patchfiles-append   patch-FindOpenJpeg.cmake.diff
      patchfiles-append   patch-libraw-0.21.0.diff
-     patchfiles-append   patch-2.1.20-cmake-disable-wall-werror.diff
- 
-     depends_lib-append  port:field3d \
--                        port:openexr2 \
--                        port:tbb
-+                        port:openexr2
- 
-     configure.pkg_config_path-prepend \
+@@ -64,9 +64,6 @@
                          ${prefix}/libexec/openexr2/lib/pkgconfig
--
--    # https://trac.macports.org/ticket/69842
--    configure.args-append       -DUSE_OPENVDB=OFF
--
--    #configure.args-append       -DUSE_TBB=OFF
--    configure.args-append       -DTBB_ROOT=${prefix}/libexec/tbb
+     #configure.args-append       -DUSE_TBB=OFF
+     configure.args-append       -DTBB_ROOT=${prefix}/libexec/tbb
 -
 -    #configure.args-append       -DUSE_FFMPEG=OFF
 -    depends_lib-append          path:lib/libavcodec.dylib:ffmpeg
  }
  
  # error: multiple overloads of 'address' instantiate to the same signature 'const_pointer (const_reference) const noexcept'
-@@ -119,16 +106,77 @@
+@@ -109,16 +106,83 @@
+                         port:tiff \
                          port:squish \
                          port:${port_libfmt}
- 
++
 +# we need gcc atomics (clang >= 3.5 maybe?, gcc >= 4.8 works)
 +# tested with openimageio 1.4.6rc1:
 +# macports-clang-3.3 and later work
@@ -125,38 +119,29 @@
 +    -DUSE_LIBRAW:BOOL=TRUE \
 +    -DUSE_OPENGL:BOOL=FALSE \
 +    -DUSE_WEBP:BOOL=TRUE \
-+    -DUSE_JXL:BOOL=FALSE \
 +    -DBUILD_FMT_FORCE:BOOL=TRUE \
 +    -DSTOP_ON_WARNING:BOOL=FALSE
-+ 
+ 
  # optional components
  
- if {${os.platform} eq "darwin" && ${os.major} < 11} {
-     configure.args-append \
-                         -DUSE_QT=OFF
-     # configure.args-append -DUSE_OPENGL=OFF
--} else {
--    PortGroup           qt5 1.0
--
--    qt5.min_version     5.6
- }
- 
- if {[string match *gcc* ${configure.compiler}] \
-@@ -137,6 +185,13 @@
-                         -latomic
- }
- 
+-#configure.args-append   -DUSE_OPENGL=OFF \
+-#                        -DUSE_QT=OFF
+-qt5.min_version         5.6
 +default_variants    +opencolorio +openjpeg +freetype
-+
-+variant natron conflicts ffmpeg qt5 dicom openvdb ptex dicom requires opencolorio openjpeg freetype jxl description {Natron version} {
+ 
++variant natron conflicts ffmpeg qt5 dicom openvdb ptex dicom requires opencolorio openjpeg freetype description {Natron version} {
 +    if {${configure.cxx_stdlib} eq "libstdc++"} {
 +    }
 +}
 +
  configure.args-append   -DUSE_PYTHON=OFF
  
- set pythons_suffixes    {38 39 310 311 312}
-@@ -176,16 +231,44 @@
+-set pythons_suffixes    {38 39 310 311 312}
++set pythons_suffixes    {27 36 37 38 39 310 311}
+ 
+ set pythons_ports       {}
+ foreach s ${pythons_suffixes} {
+@@ -155,24 +219,58 @@
      default_variants        +python312
  }
  
@@ -178,7 +163,6 @@
 +}
 +}
 +
-+
  #configure.args-append       -DUSE_JPEGTURBO=OFF
  depends_lib-append          path:include/turbojpeg.h:libjpeg-turbo \
  
@@ -197,14 +181,12 @@
 +    configure.args-append       -DUSE_OCIO:BOOL=TRUE
 +}
  
+ #configure.args-append       -DUSE_OPENCV=OFF
 +variant opencv description {Use OpenCV.} {
  set opencv_ver 4
- if {${os.platform} eq "darwin" && ${os.major} < 11} {
-     # opencv4 does not build on 10.6 and earlier.
-@@ -195,9 +278,16 @@
-     configure.args-append   -DOpenCV_INCLUDE_DIR=${prefix}/include/opencv${opencv_ver} \
+ depends_lib-append          path:lib/opencv${opencv_ver}/libopencv_core.dylib:opencv${opencv_ver}
+ configure.args-append       -DOpenCV_INCLUDE_DIR=${prefix}/include/opencv${opencv_ver} \
                              -DOpenCV_ROOT=${prefix}/lib/opencv${opencv_ver}
- }
 +    configure.args-delete -DUSE_OPENCV:BOOL=FALSE
 +    configure.args-append -DUSE_OPENCV:BOOL=TRUE
 +}
@@ -218,7 +200,7 @@
  
  #configure.args-append       -DUSE_GIF=OFF
  depends_lib-append          port:giflib
-@@ -206,16 +296,49 @@
+@@ -181,19 +279,37 @@
  depends_lib-append          port:libheif
  
  #configure.args-append       -DUSE_PTEX=OFF
@@ -231,30 +213,20 @@
  #configure.args-append       -DUSE_LIBRAW=OFF
  depends_lib-append          port:libraw
  
+-#configure.args-append       -DUSE_OPENVDB=OFF
+-depends_lib-append          port:openvdb
++#configure.args-append       -DUSE_TBB=OFF \
++#                            -DUSE_OPENVDB=OFF
 +variant openvdb description {Use OpenVDB.} {
-+    if {${port_latest}} {
-+        depends_lib-append          port:openvdb \
-+                                    port:onetbb
-+        configure.args-append       -DTBB_ROOT=${prefix}/libexec/onetbb
-+        configure.args-delete -DUSE_OPENVDB:BOOL=FALSE
-+        configure.args-append -DUSE_OPENVDB:BOOL=TRUE
-+    } else {
-+        depends_lib-append          port:openvdb \
-+                                    port:tbb
-+        # https://trac.macports.org/ticket/69842
-+        #configure.args-append       -DUSE_OPENVDB=OFF
-+
-+        configure.args-append       -DTBB_ROOT=${prefix}/libexec/tbb
-+    }
++depends_lib-append          port:tbb \
++                            port:openvdb
 +    configure.args-delete -DUSE_TBB:BOOL=FALSE
 +    configure.args-append -DUSE_TBB:BOOL=TRUE
++    configure.args-delete -DUSE_OPENVDB:BOOL=FALSE
++    configure.args-append -DUSE_OPENVDB:BOOL=TRUE
 +}
-+
-+variant jxl description {Use JPEG-XL.} {
-+depends_lib-append          port:libjxl
-+    configure.args-delete -DUSE_JXL:BOOL=FALSE
-+    configure.args-append -DUSE_JXL:BOOL=TRUE
-+}
+ 
++configure.args-append       -DTBB_ROOT=${prefix}/libexec/tbb
 +
  # not in MacPorts
  configure.args-append       -DUSE_NUKE=OFF

--- a/tools/MacPorts/graphics/openimageio/Portfile.rej.orig
+++ b/tools/MacPorts/graphics/openimageio/Portfile.rej.orig
@@ -1,0 +1,234 @@
+@@ -17,7 +18,6 @@
+ 
+ # Keep this condition the same in the opencolorio, openimageio, and osl ports.
+ set port_latest [expr {${os.platform} ne "darwin" || ${os.major} >= 20}]
+-set port_latest 1
+ 
+ if {${port_latest}} {
+     github.setup        AcademySoftwareFoundation OpenImageIO 2.5.10.1 v
+@@ -37,20 +37,20 @@
+ 
+ github.tarball_from     archive
+ 
+-patchfiles-append oiio-2.0.8-invalidatespec.patch
+-patchfiles-append oiio-2.0.8-atomic-load.patch
+-patchfiles-append oiio-2.3.20-strnlen.patch
+-patchfiles-append oiio-2.4.6-sysutil.patch
+-patchfiles-append oiio-2.4.6-filesystem.patch
+-
+-patchfiles-append   patch-2.4.5-cmake-disable-wall-werror.diff
+-
+ if {${port_latest}} {
+     depends_lib-append  port:imath \
+                         port:openexr \
+                         port:onetbb
+     #configure.args-append       -DUSE_TBB=OFF
+     configure.args-append       -DTBB_ROOT=${prefix}/libexec/onetbb
++
++    set ffmpeg_ver 6
++
++    #configure.args-append       -DUSE_FFMPEG=OFF
++    depends_lib-append          port:ffmpeg${ffmpeg_ver}
++
++    configure.pkg_config_path-prepend \
++                        ${prefix}/libexec/ffmpeg${ffmpeg_ver}/lib/pkgconfig
+ } else {
+     patchfiles-append   patch-FindOpenJpeg.cmake.diff
+     patchfiles-append   patch-libraw-0.21.0.diff
+@@ -64,6 +64,9 @@
+                         ${prefix}/libexec/openexr2/lib/pkgconfig
+     #configure.args-append       -DUSE_TBB=OFF
+     configure.args-append       -DTBB_ROOT=${prefix}/libexec/tbb
++
++    #configure.args-append       -DUSE_FFMPEG=OFF
++    depends_lib-append          path:lib/libavcodec.dylib:ffmpeg
+ }
+ 
+ # error: multiple overloads of 'address' instantiate to the same signature 'const_pointer (const_reference) const noexcept'
+@@ -106,83 +109,16 @@
+                         port:tiff \
+                         port:squish \
+                         port:${port_libfmt}
+-
+-# we need gcc atomics (clang >= 3.5 maybe?, gcc >= 4.8 works)
+-# tested with openimageio 1.4.6rc1:
+-# macports-clang-3.3 and later work
+-# gcc-4.2 doesn't work
+-# llvm-gcc-4.2 doesn't work
+-# macports-clang < 3.3 untested
+-# clang < 300 doesn't work
+-# see also https://github.com/OpenImageIO/oiio/issues/1363
+-compiler.blacklist-append {*gcc-3*} {*gcc-4.[0-1]} {macports-gcc-4.[2-7]} {gcc-4.[2-7]} {apple-gcc-4.[2-7]} cc {clang < 300}
+-
+-# for some reason, if we compile oiio with gcc 4.9 and boost with gcc 4.2, idiff a.png b.png crashes
+-if {${configure.cxx_stdlib} eq "libstdc++"} {
+-    if {[vercmp $xcodeversion 3.0] >= 0} {
+-        compiler.fallback-append macports-clang-3.4
+-    } else {
+-        compiler.fallback-append macports-clang-3.3
+-    }
+-}
+-
+-# GCC < 4.9 does not have proper GCC intrinsics support
+-compiler.blacklist-append {*gcc-4.8}
+-#compiler.whitelist-append macports-clang-9.0 macports-clang-8.0 macports-clang-7.0 macports-clang-6.0 macports-clang-5.0 macports-clang-4.0 macports-gcc-7 macports-gcc-6 macports-gcc-5 {*gcc-4.9}
+-
+-# The PowerPC build requires GCC >= 4.9, which doesn't recognize the -arch flag, and requires libatomic
+-# Unfortunately, the resulting binaries don't work (at least on PPC), so we build without threads
+-if {${configure.build_arch} eq "ppc" || ${configure.build_arch} eq "ppc64"} {
+-    # there is no known working clang compiler for ppc
+-    compiler.blacklist-append {macports-clang*}
+-#    # the following removes the flag "-arch ppc" put by cmake-1.0 portgroup in the pre-configure phase
+-#    pre-configure {
+-#        configure.args-delete -DCMAKE_OSX_ARCHITECTURES="${configure.build_arch}"
+-#    }
+-#    ## -latomic is necessary on ppc for __atomic_fetch_add_8 and __atomic_exchange_8
+-#    configure.args-append -DCMAKE_SHARED_LINKER_FLAGS=-latomic -DCMAKE_EXE_LINKER_FLAGS=-latomic
+-    # env PATH=/opt/local/libexec/qt4/bin:$PATH cmake .. -DNOTHREADS=ON -DCMAKE_BUILD_TYPE=Debug -DSTOP_ON_WARNING=OFF
+-    configure.args-append -DNOTHREADS=ON -DSTOP_ON_WARNING=OFF
+-    ## uncomment the following to compile with buggy thread support
+-    # env PATH=/opt/local/libexec/qt4/bin:$PATH cmake .. -DCMAKE_C_COMPILER=gcc-mp-4.9 -DCMAKE_CXX_COMPILER=g++-mp-4.9 -DCMAKE_SHARED_LINKER_FLAGS=-latomic -DCMAKE_EXE_LINKER_FLAGS=-latomic -DCMAKE_BUILD_TYPE=Debug -DSTOP_ON_WARNING=OFF
+-    ## -latomic is necessary on ppc for __atomic_fetch_add_8 and __atomic_exchange_8
+-    #configure.args-append -DCMAKE_SHARED_LINKER_FLAGS=-latomic -DCMAKE_EXE_LINKER_FLAGS=-latomic
+-}
+-
+-configure.args-append \
+-    -DOIIO_BUILD_TESTS:BOOL=FALSE \
+-    -DBOOST_ROOT=${prefix} \
+-    -DUSE_QT:BOOL=FALSE \
+-    -DUSE_PYTHON:BOOL=FALSE \
+-    -DUSE_PYTHON3:BOOL=FALSE \
+-    -DUSE_FIELD3D:BOOL=FALSE \
+-    -DUSE_FFMPEG:BOOL=FALSE \
+-    -DUSE_OPENJPEG:BOOL=FALSE \
+-    -DUSE_OCIO:BOOL=FALSE \
+-    -DUSE_OPENCV:BOOL=FALSE \
+-    -DUSE_OPENSSL:BOOL=FALSE \
+-    -DUSE_FREETYPE:BOOL=FALSE \
+-    -DUSE_GIF:BOOL=TRUE \
+-    -DUSE_HEIF:BOOL=TRUE \
+-    -DUSE_PTEX:BOOL=FALSE \
+-    -DUSE_LIBRAW:BOOL=TRUE \
+-    -DUSE_OPENGL:BOOL=FALSE \
+-    -DUSE_WEBP:BOOL=TRUE \
+-    -DBUILD_FMT_FORCE:BOOL=TRUE \
+-    -DSTOP_ON_WARNING:BOOL=FALSE
+ 
+ # optional components
+ 
+-default_variants    +opencolorio +openjpeg +freetype
++#configure.args-append   -DUSE_OPENGL=OFF \
++#                        -DUSE_QT=OFF
++qt5.min_version         5.6
+ 
+-variant natron conflicts ffmpeg qt5 dicom openvdb ptex dicom requires opencolorio openjpeg freetype description {Natron version} {
+-    if {${configure.cxx_stdlib} eq "libstdc++"} {
+-    }
+-}
+-
+ configure.args-append   -DUSE_PYTHON=OFF
+ 
+-set pythons_suffixes    {27 36 37 38 39 310 311}
++set pythons_suffixes    {38 39 310 311 312}
+ 
+ set pythons_ports       {}
+ foreach s ${pythons_suffixes} {
+@@ -219,58 +155,24 @@
+     default_variants        +python312
+ }
+ 
+-#configure.args-append       -DUSE_FFMPEG=OFF
+-variant ffmpeg description {Add FFmpeg support.} {
+-    configure.args-delete       -DUSE_FFMPEG:BOOL=FALSE
+-    configure.args-append       -DUSE_FFMPEG:BOOL=TRUE
+-if {${port_latest}} {
+-    set ffmpeg_ver 6
+-
+-    #configure.args-append       -DUSE_FFMPEG=OFF
+-    depends_lib-append          port:ffmpeg${ffmpeg_ver}
+-
+-    configure.pkg_config_path-prepend \
+-                        ${prefix}/libexec/ffmpeg${ffmpeg_ver}/lib/pkgconfig
+-} else {
+-    #configure.args-append       -DUSE_FFMPEG=OFF
+-    depends_lib-append          path:lib/libavcodec.dylib:ffmpeg
+-}
+-}
+-
+ #configure.args-append       -DUSE_JPEGTURBO=OFF
+ depends_lib-append          path:include/turbojpeg.h:libjpeg-turbo \
+ 
+ #configure.args-append       -DUSE_OPENJPEG=OFF
+-variant openjpeg description {Add OpenJPEG support.} {
+ depends_lib-append          port:openjpeg
+ configure.args-append       -DOpenJpeg_ROOT=${prefix}
+-    configure.args-delete       -DUSE_OPENJPEG:BOOL=FALSE
+-    configure.args-append       -DUSE_OPENJPEG:BOOL=TRUE -DOPENJPEG_HOME=${prefix} -DOPENJPEG_INCLUDE_DIR=`pkg-config --variable=includedir libopenjp2`
+-}
+ 
+ #configure.args-append       -DUSE_OCIO=OFF
+-variant opencolorio description {Add OpenColorIO support.} {
+ depends_lib-append          port:opencolorio
+-    configure.args-delete       -DUSE_OCIO:BOOL=FALSE
+-    configure.args-append       -DUSE_OCIO:BOOL=TRUE
+-}
+ 
+ #configure.args-append       -DUSE_OPENCV=OFF
+-variant opencv description {Use OpenCV.} {
+ set opencv_ver 4
+ depends_lib-append          path:lib/opencv${opencv_ver}/libopencv_core.dylib:opencv${opencv_ver}
+ configure.args-append       -DOpenCV_INCLUDE_DIR=${prefix}/include/opencv${opencv_ver} \
+                             -DOpenCV_ROOT=${prefix}/lib/opencv${opencv_ver}
+-    configure.args-delete -DUSE_OPENCV:BOOL=FALSE
+-    configure.args-append -DUSE_OPENCV:BOOL=TRUE
+-}
+ 
+ #configure.args-append       -DUSE_FREETYPE=OFF
+-variant freetype description {Use FreeType.} {
+ depends_lib-append          port:freetype
+-    configure.args-delete -DUSE_FREETYPE:BOOL=FALSE
+-    configure.args-append -DUSE_FREETYPE:BOOL=TRUE -DFREETYPE_INCLUDE_DIRS=${prefix}/include/freetype2
+-}
+ 
+ #configure.args-append       -DUSE_GIF=OFF
+ depends_lib-append          port:giflib
+@@ -279,37 +181,19 @@
+ depends_lib-append          port:libheif
+ 
+ #configure.args-append       -DUSE_PTEX=OFF
+-variant ptex description {Use PTex.} {
+ depends_lib-append          port:ptex
+-    configure.args-delete -DUSE_PTEX:BOOL=FALSE
+-    configure.args-append -DUSE_PTEX:BOOL=TRUE
+-}
+ 
+ #configure.args-append       -DUSE_LIBRAW=OFF
+ depends_lib-append          port:libraw
+ 
+-#configure.args-append       -DUSE_TBB=OFF \
+-#                            -DUSE_OPENVDB=OFF
+-variant openvdb description {Use OpenVDB.} {
+-depends_lib-append          port:tbb \
+-                            port:openvdb
+-    configure.args-delete -DUSE_TBB:BOOL=FALSE
+-    configure.args-append -DUSE_TBB:BOOL=TRUE
+-    configure.args-delete -DUSE_OPENVDB:BOOL=FALSE
+-    configure.args-append -DUSE_OPENVDB:BOOL=TRUE
+-}
++#configure.args-append       -DUSE_OPENVDB=OFF
++depends_lib-append          port:openvdb
+ 
+-configure.args-append       -DTBB_ROOT=${prefix}/libexec/tbb
+-
+ # not in MacPorts
+ configure.args-append       -DUSE_NUKE=OFF
+ 
+ #configure.args-append       -DUSE_DICOM=OFF
+-variant dicom description {Use DICOM from dcmtk.} {
+ depends_lib-append          port:dcmtk
+-    configure.args-delete -DUSE_DICOM:BOOL=FALSE
+-    configure.args-append -DUSE_DICOM:BOOL=TRUE
+-}
+ 
+ #configure.args-append       -DUSE_WEBP=OFF
+ depends_lib-append          port:webp

--- a/tools/MacPorts/lang/libomp/Portfile.orig
+++ b/tools/MacPorts/lang/libomp/Portfile.orig
@@ -30,8 +30,8 @@ subport                 libomp-devel {}
 
 if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
 
-    version             18.1.2
-    revision            1
+    version             18.1.8
+    revision            0
 
     if { ${subport} eq "libomp-devel" } {
         # Marked obsolete 10/25/2022
@@ -46,13 +46,13 @@ if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
 
     checksums \
         openmp-${version}.src.tar.xz \
-                    rmd160  f2cb436ddf5fef965cab48b28f44c3899b9a713e \
-                    sha256  742dce34394d26f0916b5d3041cc737d4e41f5ee821d9fb054057f6f71cf9a2b \
-                    size    1318944 \
+                    rmd160  91b09cda3e4761a97d03468462dbb385d8b407c4 \
+                    sha256  60ed57245e73894e4a2a89b15889f367bd906abfe6d3f92e1718223d4b496150 \
+                    size    1320200 \
         cmake-${version}.src.tar.xz \
-                    rmd160  ab9ff8018440bc7c494813e231c65c9ae470c6ac \
-                    sha256  b55a1eed9fe9c5d86c9f73c8aabde3e2407e603e737e1555545c3d136655955b \
-                    size    8704
+                    rmd160  dcadde4be6110d1753e88cc0c9d5f452203355c2 \
+                    sha256  59badef592dd34893cd319d42b323aaa990b452d05c7180ff20f23ab1b41e837 \
+                    size    8708
 
     if {${os.major} <= 12} {
         # kmp_alloc.c includes <atomic> but libc++ is not the default on

--- a/tools/MacPorts/lang/libomp/Portfile.patch
+++ b/tools/MacPorts/lang/libomp/Portfile.patch
@@ -1,5 +1,5 @@
---- Portfile.orig	2024-04-03 11:44:59
-+++ Portfile	2023-10-31 23:51:09
+--- Portfile.orig	2024-07-19 15:38:48
++++ Portfile	2024-05-07 15:19:22
 @@ -1,7 +1,7 @@
  # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
  
@@ -23,8 +23,8 @@
  
  if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libstdc++"} {
 -
--    version             18.1.2
--    revision            1
+-    version             18.1.8
+-    revision            0
 -
      if { ${subport} eq "libomp-devel" } {
 -        # Marked obsolete 10/25/2022
@@ -49,13 +49,13 @@
  
 -    checksums \
 -        openmp-${version}.src.tar.xz \
--                    rmd160  f2cb436ddf5fef965cab48b28f44c3899b9a713e \
--                    sha256  742dce34394d26f0916b5d3041cc737d4e41f5ee821d9fb054057f6f71cf9a2b \
--                    size    1318944 \
+-                    rmd160  91b09cda3e4761a97d03468462dbb385d8b407c4 \
+-                    sha256  60ed57245e73894e4a2a89b15889f367bd906abfe6d3f92e1718223d4b496150 \
+-                    size    1320200 \
 -        cmake-${version}.src.tar.xz \
--                    rmd160  ab9ff8018440bc7c494813e231c65c9ae470c6ac \
--                    sha256  b55a1eed9fe9c5d86c9f73c8aabde3e2407e603e737e1555545c3d136655955b \
--                    size    8704
+-                    rmd160  dcadde4be6110d1753e88cc0c9d5f452203355c2 \
+-                    sha256  59badef592dd34893cd319d42b323aaa990b452d05c7180ff20f23ab1b41e837 \
+-                    size    8708
 -
      if {${os.major} <= 12} {
          # kmp_alloc.c includes <atomic> but libc++ is not the default on

--- a/tools/MacPorts/multimedia/ffmpeg/Portfile
+++ b/tools/MacPorts/multimedia/ffmpeg/Portfile
@@ -19,7 +19,7 @@ conflicts           ffmpeg-devel
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 version             4.4.4
-revision            6
+revision            8
 epoch               1
 
 license             LGPL-2.1+
@@ -329,6 +329,13 @@ platform darwin {
         configure.ldflags-append \
                     -Wl,-ld_classic
     }
+}
+
+# libavcodec/pcm-bluray.c:172:45: error: passing argument 2 of 'bytestream2_get_buffer' from incompatible pointer type [-Wincompatible-pointer-types]
+# libavcodec/pcm-dvd.c:155:37: error: passing argument 2 of 'bytestream2_get_buffer' from incompatible pointer type [-Wincompatible-pointer-types]
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.cflags-append \
+                    -Wno-error=incompatible-pointer-types
 }
 
 platform powerpc {

--- a/tools/MacPorts/multimedia/ffmpeg/Portfile.orig
+++ b/tools/MacPorts/multimedia/ffmpeg/Portfile.orig
@@ -19,7 +19,7 @@ conflicts           ffmpeg-devel
 
 # Please increase the revision of mpv whenever ffmpeg's version is updated.
 version             4.4.4
-revision            6
+revision            8
 epoch               1
 
 license             LGPL-2.1+
@@ -317,6 +317,13 @@ platform darwin {
         configure.ldflags-append \
                     -Wl,-ld_classic
     }
+}
+
+# libavcodec/pcm-bluray.c:172:45: error: passing argument 2 of 'bytestream2_get_buffer' from incompatible pointer type [-Wincompatible-pointer-types]
+# libavcodec/pcm-dvd.c:155:37: error: passing argument 2 of 'bytestream2_get_buffer' from incompatible pointer type [-Wincompatible-pointer-types]
+if {[string match *gcc* ${configure.compiler}]} {
+    configure.cflags-append \
+                    -Wno-error=incompatible-pointer-types
 }
 
 platform powerpc {

--- a/tools/MacPorts/net/curl/Portfile
+++ b/tools/MacPorts/net/curl/Portfile
@@ -6,10 +6,10 @@ PortGroup                       clang_dependency 1.0
 # Increase the revision of p5-www-curl whenever the version of curl gets updated.
 
 name                            curl
-version                         8.7.1
-checksums                       rmd160  9744fc15c2e9f903a845f960ba3f32acd3aaadca \
-                                sha256  6fea2aac6a4610fbd0400afb0bcddbe7258a64c63f1f68e5855ebc0c659710cd \
-                                size    2707016
+version                         8.8.0
+checksums                       rmd160  d8494c0468d2a775d45ecb9f1e7c260d085689f3 \
+                                sha256  0f58bb95fc330c8a46eeb3df5701b0d90c9d9bfcc42bd1cd08791d12551d4400 \
+                                size    2748860
 
 categories                      net www
 platforms                       darwin freebsd
@@ -35,15 +35,19 @@ checksums-prepend               ${curl_distfile}
 if {${name} eq ${subport}} {
     PortGroup                   muniversal 1.0
 
-    revision                    0
+    revision                    1
 
     depends_build               path:bin/pkg-config:pkgconfig
 
     depends_lib                 port:brotli \
                                 port:libidn2 \
                                 port:libpsl \
+                                port:nghttp2 \
                                 port:zlib \
                                 port:zstd
+
+    patchfiles-append           patch-docs-Makefile.in.diff
+    patchfiles-append           x509asn1.patch
 
     configure.args              --disable-silent-rules \
                                 --enable-ipv6 \
@@ -53,7 +57,6 @@ if {${name} eq ${subport}} {
                                 --without-librtmp \
                                 --without-libssh2 \
                                 --without-mbedtls \
-                                --without-nghttp2 \
                                 --without-nghttp3 \
                                 --without-ngtcp2 \
                                 --without-openssl \
@@ -65,6 +68,7 @@ if {${name} eq ${subport}} {
                                 --disable-ldaps \
                                 --with-brotli \
                                 --with-libidn2=${prefix} \
+                                --with-nghttp2=${prefix} \
                                 --with-zlib=${prefix} \
                                 --with-zstd \
                                 ac_cv_prog_AWK=/usr/bin/awk
@@ -142,7 +146,7 @@ if {${name} eq ${subport}} {
             HTTP-COOKIES.md \
             INTERNALS.md \
             KNOWN_BUGS \
-            MAIL-ETIQUETTE \
+            MAIL-ETIQUETTE.md \
             PARALLEL-TRANSFERS.md \
             ROADMAP.md \
             SECURITY-ADVISORY.md \
@@ -214,22 +218,6 @@ if {${name} eq ${subport}} {
         # This needs to use the system's Kerberos, not MacPorts' gss or kerberos5.
         conflicts-append        gss kerberos5
         configure.args-replace  --without-gssapi --with-gssapi
-    }
-
-    variant http2 description {Support HTTP/2 with nghttp2} {
-        depends_lib-append      port:nghttp2
-        configure.args-replace  --without-nghttp2 --with-nghttp2=${prefix}
-    }
-
-    # HTTP/2 support is desirable but nghttp2 requires C++14. Some users
-    # use a bootstrap MacPorts installation to provide a newer curl for
-    # a primary MacPorts installation and requiring those users to build
-    # a C++14 compiler for that is undesirable. Also, newer clangs use
-    # cmake, which uses curl, so it would introduce a dependency cycle.
-    # So enable this variant by default only on systems that have a
-    # suitable compiler in Xcode.
-    if {${os.platform} ne "darwin" || ${os.major} >= 14} {
-        default_variants-append +http2
     }
 
     variant http3 requires gnutls description {Support HTTP/3 with nghttp3 and ngtcp2} {

--- a/tools/MacPorts/net/curl/Portfile.orig
+++ b/tools/MacPorts/net/curl/Portfile.orig
@@ -6,10 +6,10 @@ PortGroup                       clang_dependency 1.0
 # Increase the revision of p5-www-curl whenever the version of curl gets updated.
 
 name                            curl
-version                         8.7.1
-checksums                       rmd160  9744fc15c2e9f903a845f960ba3f32acd3aaadca \
-                                sha256  6fea2aac6a4610fbd0400afb0bcddbe7258a64c63f1f68e5855ebc0c659710cd \
-                                size    2707016
+version                         8.8.0
+checksums                       rmd160  d8494c0468d2a775d45ecb9f1e7c260d085689f3 \
+                                sha256  0f58bb95fc330c8a46eeb3df5701b0d90c9d9bfcc42bd1cd08791d12551d4400 \
+                                size    2748860
 
 categories                      net www
 platforms                       darwin freebsd
@@ -35,15 +35,19 @@ checksums-prepend               ${curl_distfile}
 if {${name} eq ${subport}} {
     PortGroup                   muniversal 1.0
 
-    revision                    0
+    revision                    1
 
     depends_build               path:bin/pkg-config:pkgconfig
 
     depends_lib                 port:brotli \
                                 port:libidn2 \
                                 port:libpsl \
+                                port:nghttp2 \
                                 port:zlib \
                                 port:zstd
+
+    patchfiles-append           patch-docs-Makefile.in.diff
+    patchfiles-append           x509asn1.patch
 
     configure.args              --disable-silent-rules \
                                 --enable-ipv6 \
@@ -53,7 +57,6 @@ if {${name} eq ${subport}} {
                                 --without-librtmp \
                                 --without-libssh2 \
                                 --without-mbedtls \
-                                --without-nghttp2 \
                                 --without-nghttp3 \
                                 --without-ngtcp2 \
                                 --without-openssl \
@@ -65,6 +68,7 @@ if {${name} eq ${subport}} {
                                 --disable-ldaps \
                                 --with-brotli \
                                 --with-libidn2=${prefix} \
+                                --with-nghttp2=${prefix} \
                                 --with-zlib=${prefix} \
                                 --with-zstd \
                                 ac_cv_prog_AWK=/usr/bin/awk
@@ -138,7 +142,7 @@ if {${name} eq ${subport}} {
             HTTP-COOKIES.md \
             INTERNALS.md \
             KNOWN_BUGS \
-            MAIL-ETIQUETTE \
+            MAIL-ETIQUETTE.md \
             PARALLEL-TRANSFERS.md \
             ROADMAP.md \
             SECURITY-ADVISORY.md \
@@ -210,22 +214,6 @@ if {${name} eq ${subport}} {
         # This needs to use the system's Kerberos, not MacPorts' gss or kerberos5.
         conflicts-append        gss kerberos5
         configure.args-replace  --without-gssapi --with-gssapi
-    }
-
-    variant http2 description {Support HTTP/2 with nghttp2} {
-        depends_lib-append      port:nghttp2
-        configure.args-replace  --without-nghttp2 --with-nghttp2=${prefix}
-    }
-
-    # HTTP/2 support is desirable but nghttp2 requires C++14. Some users
-    # use a bootstrap MacPorts installation to provide a newer curl for
-    # a primary MacPorts installation and requiring those users to build
-    # a C++14 compiler for that is undesirable. Also, newer clangs use
-    # cmake, which uses curl, so it would introduce a dependency cycle.
-    # So enable this variant by default only on systems that have a
-    # suitable compiler in Xcode.
-    if {${os.platform} ne "darwin" || ${os.major} >= 14} {
-        default_variants-append +http2
     }
 
     variant http3 requires gnutls description {Support HTTP/3 with nghttp3 and ngtcp2} {

--- a/tools/MacPorts/net/curl/files/patch-docs-Makefile.in.diff
+++ b/tools/MacPorts/net/curl/files/patch-docs-Makefile.in.diff
@@ -1,0 +1,162 @@
+Address https://github.com/curl/curl/pull/13741
+--- docs/Makefile.in	2024-06-05 12:04:23
++++ docs/Makefile.in	2024-06-05 12:04:53
+@@ -175,6 +175,37 @@
+     n|no|NO) false;; \
+     *) (install-info --version) >/dev/null 2>&1;; \
+   esac
++am__vpath_adj_setup = srcdirstrip=`echo "$(srcdir)" | sed 's|.|.|g'`;
++am__vpath_adj = case $$p in \
++    $(srcdir)/*) f=`echo "$$p" | sed "s|^$$srcdirstrip/||"`;; \
++    *) f=$$p;; \
++  esac;
++am__strip_dir = f=`echo $$p | sed -e 's|^.*/||'`;
++am__install_max = 40
++am__nobase_strip_setup = \
++  srcdirstrip=`echo "$(srcdir)" | sed 's/[].[^$$\\*|]/\\\\&/g'`
++am__nobase_strip = \
++  for p in $$list; do echo "$$p"; done | sed -e "s|$$srcdirstrip/||"
++am__nobase_list = $(am__nobase_strip_setup); \
++  for p in $$list; do echo "$$p $$p"; done | \
++  sed "s| $$srcdirstrip/| |;"' / .*\//!s/ .*/ ./; s,\( .*\)/[^/]*$$,\1,' | \
++  $(AWK) 'BEGIN { files["."] = "" } { files[$$2] = files[$$2] " " $$1; \
++    if (++n[$$2] == $(am__install_max)) \
++      { print $$2, files[$$2]; n[$$2] = 0; files[$$2] = "" } } \
++    END { for (dir in files) print dir, files[dir] }'
++am__base_list = \
++  sed '$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;$$!N;s/\n/ /g' | \
++  sed '$$!N;$$!N;$$!N;$$!N;s/\n/ /g'
++am__uninstall_files_from_dir = { \
++  test -z "$$files" \
++    || { test ! -d "$$dir" && test ! -f "$$dir" && test ! -r "$$dir"; } \
++    || { echo " ( cd '$$dir' && rm -f" $$files ")"; \
++         $(am__cd) "$$dir" && rm -f $$files; }; \
++  }
++man1dir = $(mandir)/man1
++am__installdirs = "$(DESTDIR)$(man1dir)"
++NROFF = nroff
++MANS = $(man_MANS)
+ RECURSIVE_CLEAN_TARGETS = mostlyclean-recursive clean-recursive	\
+   distclean-recursive maintainer-clean-recursive
+ am__recursive_targets = \
+@@ -456,6 +487,7 @@
+ # if we disable man page building, ignore these
+ @BUILD_DOCS_TRUE@MK_CA_DOCS = mk-ca-bundle.1
+ @BUILD_DOCS_TRUE@CURLCONF_DOCS = curl-config.1
++@BUILD_DOCS_TRUE@man_MANS = curl-config.1
+ CURLPAGES = curl-config.md mk-ca-bundle.md
+ SUBDIRS = . cmdline-opts libcurl
+ DIST_SUBDIRS = $(SUBDIRS) examples
+@@ -569,7 +601,50 @@
+ 
+ clean-libtool:
+ 	-rm -rf .libs _libs
++install-man1: $(man_MANS)
++	@$(NORMAL_INSTALL)
++	@list1=''; \
++	list2='$(man_MANS)'; \
++	test -n "$(man1dir)" \
++	  && test -n "`echo $$list1$$list2`" \
++	  || exit 0; \
++	echo " $(MKDIR_P) '$(DESTDIR)$(man1dir)'"; \
++	$(MKDIR_P) "$(DESTDIR)$(man1dir)" || exit 1; \
++	{ for i in $$list1; do echo "$$i"; done;  \
++	if test -n "$$list2"; then \
++	  for i in $$list2; do echo "$$i"; done \
++	    | sed -n '/\.1[a-z]*$$/p'; \
++	fi; \
++	} | while read p; do \
++	  if test -f $$p; then d=; else d="$(srcdir)/"; fi; \
++	  echo "$$d$$p"; echo "$$p"; \
++	done | \
++	sed -e 'n;s,.*/,,;p;h;s,.*\.,,;s,^[^1][0-9a-z]*$$,1,;x' \
++	      -e 's,\.[0-9a-z]*$$,,;$(transform);G;s,\n,.,' | \
++	sed 'N;N;s,\n, ,g' | { \
++	list=; while read file base inst; do \
++	  if test "$$base" = "$$inst"; then list="$$list $$file"; else \
++	    echo " $(INSTALL_DATA) '$$file' '$(DESTDIR)$(man1dir)/$$inst'"; \
++	    $(INSTALL_DATA) "$$file" "$(DESTDIR)$(man1dir)/$$inst" || exit $$?; \
++	  fi; \
++	done; \
++	for i in $$list; do echo "$$i"; done | $(am__base_list) | \
++	while read files; do \
++	  test -z "$$files" || { \
++	    echo " $(INSTALL_DATA) $$files '$(DESTDIR)$(man1dir)'"; \
++	    $(INSTALL_DATA) $$files "$(DESTDIR)$(man1dir)" || exit $$?; }; \
++	done; }
+ 
++uninstall-man1:
++	@$(NORMAL_UNINSTALL)
++	@list=''; test -n "$(man1dir)" || exit 0; \
++	files=`{ for i in $$list; do echo "$$i"; done; \
++	l2='$(man_MANS)'; for i in $$l2; do echo "$$i"; done | \
++	  sed -n '/\.1[a-z]*$$/p'; \
++	} | sed -e 's,.*/,,;h;s,.*\.,,;s,^[^1][0-9a-z]*$$,1,;x' \
++	      -e 's,\.[0-9a-z]*$$,,;$(transform);G;s,\n,.,'`; \
++	dir='$(DESTDIR)$(man1dir)'; $(am__uninstall_files_from_dir)
++
+ # This directory's subdirectories are mostly independent; you can cd
+ # into them and run 'make' without going through this Makefile.
+ # To change the values of 'make' variables: instead of editing Makefiles,
+@@ -728,9 +803,12 @@
+ 	done
+ check-am: all-am
+ check: check-recursive
+-all-am: Makefile
++all-am: Makefile $(MANS)
+ installdirs: installdirs-recursive
+ installdirs-am:
++	for dir in "$(DESTDIR)$(man1dir)"; do \
++	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
++	done
+ install: install-recursive
+ install-exec: install-exec-recursive
+ install-data: install-data-recursive
+@@ -780,7 +858,7 @@
+ 
+ info-am:
+ 
+-install-data-am:
++install-data-am: install-man
+ 
+ install-dvi: install-dvi-recursive
+ 
+@@ -796,7 +874,7 @@
+ 
+ install-info-am:
+ 
+-install-man:
++install-man: install-man1
+ 
+ install-pdf: install-pdf-recursive
+ 
+@@ -824,8 +902,10 @@
+ 
+ ps-am:
+ 
+-uninstall-am:
++uninstall-am: uninstall-man
+ 
++uninstall-man: uninstall-man1
++
+ .MAKE: $(am__recursive_targets) install-am install-strip
+ 
+ .PHONY: $(am__recursive_targets) CTAGS GTAGS TAGS all all-am check \
+@@ -835,11 +915,12 @@
+ 	install install-am install-data install-data-am install-dvi \
+ 	install-dvi-am install-exec install-exec-am install-html \
+ 	install-html-am install-info install-info-am install-man \
+-	install-pdf install-pdf-am install-ps install-ps-am \
+-	install-strip installcheck installcheck-am installdirs \
+-	installdirs-am maintainer-clean maintainer-clean-generic \
+-	mostlyclean mostlyclean-generic mostlyclean-libtool pdf pdf-am \
+-	ps ps-am tags tags-am uninstall uninstall-am
++	install-man1 install-pdf install-pdf-am install-ps \
++	install-ps-am install-strip installcheck installcheck-am \
++	installdirs installdirs-am maintainer-clean \
++	maintainer-clean-generic mostlyclean mostlyclean-generic \
++	mostlyclean-libtool pdf pdf-am ps ps-am tags tags-am uninstall \
++	uninstall-am uninstall-man uninstall-man1
+ 
+ .PRECIOUS: Makefile
+ 

--- a/tools/MacPorts/net/curl/files/x509asn1.patch
+++ b/tools/MacPorts/net/curl/files/x509asn1.patch
@@ -1,0 +1,15 @@
+x509asn1: fallback to dotted OID representation
+
+https://github.com/curl/curl/commit/9aa1d412b814a40868558da51a6ab28ce1384a58
+https://github.com/curl/curl/issues/13845
+--- lib/vtls/x509asn1.c.orig
++++ lib/vtls/x509asn1.c
+@@ -469,7 +469,7 @@ static CURLcode OID2str(struct dynbuf *store,
+         if(op)
+           result = Curl_dyn_add(store, op->textoid);
+         else
+-          result = CURLE_BAD_FUNCTION_ARGUMENT;
++          result = Curl_dyn_add(store, Curl_dyn_ptr(&buf));
+         Curl_dyn_free(&buf);
+       }
+     }

--- a/tools/MacPorts/print/ghostscript/Portfile
+++ b/tools/MacPorts/print/ghostscript/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                ghostscript
-version             10.03.0
+version             10.03.1
 revision            0
 
 categories          print
@@ -34,9 +34,9 @@ distfiles           ${distname}.tar.gz:source \
                     ${mappingresources_commit}.zip:misc
 
 checksums           ${distname}.tar.gz \
-                    rmd160  860ee86af90acf551b31244f8adebc0e4754c258 \
-                    sha256  10849e8039d526ea490f3ead1f2aba7b2b9d5d4f13bfdfc8b9fe654948e70a44 \
-                    size    98222723 \
+                    rmd160  56619c52c32237c97739d1830b0513cd6b17d2a8 \
+                    sha256  8ea9dd8768b64576bc4ee2d79611450c9e1edeb686f7824f3bf94b92457b882a \
+                    size    98222799 \
                     ghostscript-fonts-other-6.0.tar.gz \
                     rmd160  ab60dbf71e7d91283a106c3df381cadfe173082f \
                     sha256  4fa051e341167008d37fe34c19d241060cd17b13909932cd7ca7fe759243c2de \

--- a/tools/MacPorts/print/ghostscript/Portfile.orig
+++ b/tools/MacPorts/print/ghostscript/Portfile.orig
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 
 name                ghostscript
-version             10.03.0
+version             10.03.1
 revision            0
 
 categories          print
@@ -34,9 +34,9 @@ distfiles           ${distname}.tar.gz:source \
                     ${mappingresources_commit}.zip:misc
 
 checksums           ${distname}.tar.gz \
-                    rmd160  860ee86af90acf551b31244f8adebc0e4754c258 \
-                    sha256  10849e8039d526ea490f3ead1f2aba7b2b9d5d4f13bfdfc8b9fe654948e70a44 \
-                    size    98222723 \
+                    rmd160  56619c52c32237c97739d1830b0513cd6b17d2a8 \
+                    sha256  8ea9dd8768b64576bc4ee2d79611450c9e1edeb686f7824f3bf94b92457b882a \
+                    size    98222799 \
                     ghostscript-fonts-other-6.0.tar.gz \
                     rmd160  ab60dbf71e7d91283a106c3df381cadfe173082f \
                     sha256  4fa051e341167008d37fe34c19d241060cd17b13909932cd7ca7fe759243c2de \

--- a/tools/jenkins/build-OSX-installer.sh
+++ b/tools/jenkins/build-OSX-installer.sh
@@ -39,7 +39,7 @@ popd () {
 
 updateBuildOptions
 
-echo "*** macOS version:"
+echo "* macOS version:"
 macosx=$(uname -r | sed 's|\([0-9][0-9]*\)\.[0-9][0-9]*\.[0-9][0-9]*|\1|')
 case "${macosx}" in
 23) echo "macOS 14.x    Sonoma";;
@@ -149,36 +149,19 @@ fi
 DUMP_SYMS=/usr/local/bin/dump_syms
 DSYMUTIL=dsymutil
 if [ "${COMPILER}" = "clang" ] || [ "${COMPILER}" = "clang-omp" ]; then
-    if [ -x /opt/local/bin/llvm-dsymutil-mp-3.9 ]; then
-        DSYMUTIL=/opt/local/bin/llvm-dsymutil-mp-3.9
-    fi
-    if [ -x /opt/local/bin/llvm-dsymutil-mp-4.0 ]; then
-        DSYMUTIL=/opt/local/bin/llvm-dsymutil-mp-4.0
-    fi
-    if [ -x /opt/local/bin/llvm-dsymutil-mp-5.0 ]; then
-        DSYMUTIL=/opt/local/bin/llvm-dsymutil-mp-5.0
-    fi
-    if [ -x /opt/local/bin/llvm-dsymutil-mp-6.0 ]; then
-        DSYMUTIL=/opt/local/bin/llvm-dsymutil-mp-6.0
-    fi
-    if [ -x /opt/local/bin/dsymutil-mp-7.0 ]; then
-        DSYMUTIL=/opt/local/bin/dsymutil-mp-7.0
-    fi
-    if [ -x /opt/local/bin/dsymutil-mp-8.0 ]; then
-        DSYMUTIL=/opt/local/bin/dsymutil-mp-8.0
-    fi
-    if [ -x /opt/local/bin/dsymutil-mp-9.0 ]; then
-        DSYMUTIL=/opt/local/bin/dsymutil-mp-9.0
-    fi
-    if [ -x /opt/local/bin/dsymutil-mp-11 ]; then
-        DSYMUTIL=/opt/local/bin/dsymutil-mp-11
-    fi
-    if [ -x /opt/local/bin/dsymutil-mp-14 ]; then
-        DSYMUTIL=/opt/local/bin/dsymutil-mp-14
-    fi
-    if [ -x /opt/local/bin/dsymutil-mp-15 ]; then
-        DSYMUTIL=/opt/local/bin/dsymutil-mp-15
-    fi
+    for v in 6.0 5.0 4.0 3.9; do
+        if [ -x /opt/local/bin/llvm-dsymutil-mp-${v} ]; then
+            DSYMUTIL=/opt/local/bin/llvm-dsymutil-mp-${v}
+            break
+        fi
+    done
+    for v in 17 16 15 14 11 9.0 8.0 7.0; do
+        if [ -x /opt/local/bin/dsymutil-mp-${v} ]; then
+            DSYMUTIL=/opt/local/bin/dsymutil-mp-${v}
+            break
+        fi
+    done
+    echo "* Using ${DSYMUTIL}"
 fi
 
 # the list of libs in /opt/local/lib/libgcc
@@ -369,6 +352,7 @@ case "${QT_VERSION_MAJOR}" in
 5)
     qt_libs=( Qt3DAnimation Qt3DCore Qt3DExtras Qt3DInput Qt3DLogic Qt3DQuick Qt3DQuickAnimation Qt3DQuickExtras Qt3DQuickInput Qt3DQuickRender Qt3DQuickScene2D Qt3DRender QtBluetooth QtCharts QtConcurrent QtCore QtDBus QtDataVisualization QtDesigner QtDesignerComponents QtGamepad QtGui QtHelp QtLocation QtMacExtras QtMultimedia QtMultimediaQuick QtMultimediaWidgets QtNetwork QtNetworkAuth QtNfc QtOpenGL QtPdf QtPdfWidgets QtPositioning QtPositioningQuick QtPrintSupport QtQml QtQmlModels QtQmlWorkerScript QtQuick QtQuickControls2 QtQuickParticles QtQuickShapes QtQuickTemplates2 QtQuickTest QtQuickWidgets QtRemoteObjects QtRepParser QtScript QtScriptTools QtScxml QtSensors QtSerialBus QtSerialPort QtSql QtSvg QtTest QtTextToSpeech QtUiPlugin QtWebChannel QtWebEngine QtWebEngineCore QtWebEngineWidgets QtWebSockets QtWidgets QtXml QtXmlPatterns )
     qt_frameworks_dir="${QTDIR}/lib"
+    SBKVER="${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}"
     ;;
 esac
 STRIP=1
@@ -380,9 +364,10 @@ app_for_macdeployqt="$(dirname "${package}")/Natron.app"
 [ -e  "${app_for_macdeployqt}" ] && rm -rf "${app_for_macdeployqt}"
 # make a temporary link to Natron.app
 ln -sf "${package}" "${app_for_macdeployqt}"
-MACDEPLOYQT_OPTS=( -no-strip )
-MACDEPLOYQT_OPTS+=( -libpath="${SDK_HOME}/lib/nss" -libpath="${SDK_HOME}/lib/nspr" )
-
+MACDEPLOYQT_OPTS=( -verbose=2 -no-strip -libpath="${SDK_HOME}/libexec/onetbb/lib" )
+if [ "${QT_VERSION_MAJOR}" -ge 5 ]; then
+    MACDEPLOYQT_OPTS+=( -libpath="${SDK_HOME}/lib/nss" -libpath="${SDK_HOME}/lib/nspr" )
+fi
 for bin in "${natronbins[@]}" "${otherbins[@]}"; do
     binary="$app_for_macdeployqt/Contents/MacOS/${bin}"
     if [ ! -e "${binary}" ] && [ -e "${SDK_HOME}/bin/${bin}" ]; then
@@ -421,17 +406,39 @@ fi
 LIBGCC=0
 if otool -L "${natron_binary}" | grep -F -q "${SDK_HOME}/lib/libgcc"; then
     LIBGCC=1
+    echo "* Binaries use libgcc"
 fi
 COPY_LIBCXX=0
 if otool -L "${natron_binary}" | grep -F -q "/usr/lib/libc++"; then
     # libc++ appeared in on Lion 10.7 (osmajor=11)
     if [ "${macosx}" -lt 11 ]; then
         COPY_LIBCXX=1
+        COPY_LIBCXX_FROM="/usr/lib"
     fi
 fi
+if otool -L "${natron_binary}" | grep -F -q "@rpath/libc++"; then
+    rpath=( $(otool -l "${natron_binary}" | grep -A 3 LC_RPATH | grep path|awk '{ print $2 }') )
+    if [ ${#rpath[@]} -gt 0 ]; then
+        for r in "${rpath[@]}"; do
+            case "$r" in
+                "${SDK_HOME}"/libexec/llvm-*/lib)
+                    # compiled with LLVM and OpenMP: uses LLVM's libc++
+                    COPY_LIBCXX=1
+                    COPY_LIBCXX_FROM="$r"
+                    ;;
+            esac
+        done
+    fi
+fi
+if [ "${COPY_LIBCXX}" = 1 ]; then
+    echo "* Will copy lib++ from ${COPY_LIBCXX_FROM}"
+else
+    echo "* Will not copy lib++"
+fi
+
 if [ -f "${pkglib}/libc++.1.dylib" ] || [ -f "${pkglib}/libc++abi.1.dylib" ]; then
-    echo "Error: ${pkglib}/libc++.1.dylib or ${pkglib}/libc++abi.1.dylib was copied by macdeployqt"
-    exit 1
+    echo "Warning: ${pkglib}/libc++.1.dylib or ${pkglib}/libc++abi.1.dylib was copied by macdeployqt"
+    rm "${pkglib}/libc++.1.dylib" "${pkglib}/libc++abi.1.dylib" || true
 fi
 
 echo "*** Copy and change exec_path of the whole Python framework with libraries..."
@@ -646,9 +653,9 @@ if [ "${QT_VERSION_MAJOR}" = 5 ]; then
     cp -a "${SDK_HOME}/Library/Frameworks/${PYSHIBOKEN}" "${package}/Contents/Frameworks/${PYSHIBOKEN}"
     rm -rf "${package}/Contents/Frameworks/${PYSHIBOKEN}/docs"
     (cd "${package}/Contents/Frameworks" && ln -sf "${PYLIB}/site-packages/shiboken2/libshiboken2"*.dylib .)
-    #install_name_tool -rpath "${SDK_HOME}/Library/Frameworks/${PYSHIBOKEN}" "@executable_path/../Frameworks/${PYSHIBOKEN}" "${natron_binary}"
+    install_name_tool -rpath "${SDK_HOME}/Library/Frameworks/${PYSHIBOKEN}" "@executable_path/../Frameworks/${PYSHIBOKEN}" "${natron_binary}"
     (cd "${package}/Contents/Frameworks" && ln -sf "${PYSIDE}/libpyside2"*.dylib .)
-    #install_name_tool -rpath "${SDK_HOME}/Library/Frameworks/${PYSIDE}" "@executable_path/../Frameworks/${PYSIDE}" "${natron_binary}"
+    install_name_tool -rpath "${SDK_HOME}/Library/Frameworks/${PYSIDE}" "@executable_path/../Frameworks/${PYSIDE}" "${natron_binary}"
     for binary in  "${package}/Contents/Frameworks/${PYSHIBOKEN}"/lib*.dylib "${package}/Contents/Frameworks/${PYSIDE}"/lib*.dylib; do
         for f in "${qt_libs[@]}"; do
             install_name_tool -change "${qt_frameworks_dir}/${f}.framework/Versions/${QT_VERSION_MAJOR}/${f}" "@executable_path/../Frameworks/${f}.framework/Versions/${QT_VERSION_MAJOR}/${f}" "${binary}"
@@ -807,6 +814,7 @@ for deplib in "${pkglib}/"*.framework/Versions/*/* "${pkglib}/"lib*.dylib; do
 done
 
 for bin in "${natronbins[@]}" "${otherbins[@]}"; do
+    echo "*** Fixing rpath in ${bin}..."
     binary="${package}/Contents/MacOS/${bin}"
     if [ -f "${binary}" ]; then
         if otool -L "${binary}" | grep -F "${MACPORTS}"; then
@@ -831,9 +839,19 @@ for bin in "${natronbins[@]}" "${otherbins[@]}"; do
         # remove remnants of llvm path (libraries were copied already)
         if [ ${#rpath[@]} -gt 0 ]; then
             for r in "${rpath[@]}"; do
-                case "$r" in
-                    "${SDK_HOME}"/libexec/llvm-*/lib|"${SDK_HOME}"/lib)
-                        install_name_tool -delete_rpath "$r" "${binary}"
+                case "${r}" in
+                    "${SDK_HOME}"/libexec/llvm-*/lib)
+                        if [ "${COPY_LIBCXX}" = 1 ] && [ "${COPY_LIBCXX_FROM}" = "${r}" ]; then
+                            echo "* Changing rpath ${r} to @loader_path/../${libdir}/libcxx in ${binary}"
+                            install_name_tool -rpath "${r}" "@loader_path/../${libdir}/libcxx" "${binary}"
+                        else
+                            echo "* Removing rpath ${r} from ${binary}"
+                            install_name_tool -delete_rpath "${r}" "${binary}"
+                        fi
+                        ;;
+                    "${SDK_HOME}"/lib)
+                        echo "* Removing rpath ${r} from ${binary}"
+                        install_name_tool -delete_rpath "${r}" "${binary}"
                         ;;
                 esac
             done
@@ -1142,6 +1160,7 @@ fi
 
 # put links to the GCC libs in a separate directory, and compile the launcher which sets DYLD_LIBRARY_PATH to that directory
 if [ "${LIBGCC}" = 1 ]; then
+    echo "*** Linking GCC libraries to ${package}/Contents/Frameworks/libgcc"
     mkdir -p "${package}/Contents/Frameworks/libgcc"
     for l in ${gcclibs}; do
         lib="lib${l}.dylib"
@@ -1152,6 +1171,7 @@ if [ "${LIBGCC}" = 1 ]; then
     mv "${package}/Contents/MacOS/Natron" "${package}/Contents/MacOS/Natron-driver"
     mv "${package}/Contents/MacOS/NatronRenderer" "${package}/Contents/MacOS/NatronRenderer-driver"
     # MACOSX_DEPLOYMENT_TARGET set in common.sh
+    echo "*** Compiling and installing NatronDyLd.c -DLIBGCC"
     if [ "${BITS}" = "Universal" ]; then
         ${CC} -DLIBGCC -arch i386 -arch x86_64 -mmacosx-version-min=10.6 -isysroot /Developer/SDKs/MacOSX10.6.sdk "${INC_PATH}/natron/NatronDyLd.c" -s -o "${package}/Contents/MacOS/Natron"
     else
@@ -1163,19 +1183,23 @@ fi
 # copy libc++ if necessary (on OSX 10.6 Snow Leopard with libc++ only)
 # DYLD_LIBRARY_PATH should be set by NatronDyLd.c
 if [ "$COPY_LIBCXX" = 1 ]; then
+    echo "*** Copying libc++ and libc++abi from ${COPY_LIBCXX_FROM} to ${package}/Contents/Frameworks/libcxx"
     mkdir -p "${package}/Contents/Frameworks/libcxx"
-    cp /usr/lib/libc++.1.dylib "${package}/Contents/Frameworks/libcxx"
-    cp /usr/lib/libc++abi.dylib "${package}/Contents/Frameworks/libcxx"
-    mv "${package}/Contents/MacOS/Natron" "${package}/Contents/MacOS/Natron-driver"
-    mv "${package}/Contents/MacOS/NatronRenderer" "${package}/Contents/MacOS/NatronRenderer-driver"
-    # MACOSX_DEPLOYMENT_TARGET set in common.sh
-    if [ "${BITS}" = "Universal" ]; then
-        ${CC} -DLIBCXX -arch i386 -arch x86_64 -mmacosx-version-min=10.6 -isysroot /Developer/SDKs/MacOSX10.6.sdk "${INC_PATH}/natron/NatronDyLd.c" -o "${package}/Contents/MacOS/Natron"
-    else
-        ${CC} -DLIBCXX "${INC_PATH}/natron/NatronDyLd.c" -o "${package}/Contents/MacOS/Natron"
+    cp "${COPY_LIBCXX_FROM}/libc++.1.dylib" "${package}/Contents/Frameworks/libcxx"
+    cp "${COPY_LIBCXX_FROM}/libc++abi.1.dylib" "${package}/Contents/Frameworks/libcxx"
+    if [ "${COPY_LIBCXX_FROM}" = "/usr/lib" ]; then 
+        mv "${package}/Contents/MacOS/Natron" "${package}/Contents/MacOS/Natron-driver"
+        mv "${package}/Contents/MacOS/NatronRenderer" "${package}/Contents/MacOS/NatronRenderer-driver"
+        # MACOSX_DEPLOYMENT_TARGET set in common.sh
+        echo "*** Compiling and installing NatronDyLd.c -DLIBCXX"
+        if [ "${BITS}" = "Universal" ]; then
+            ${CC} -DLIBCXX -arch i386 -arch x86_64 -mmacosx-version-min=10.6 -isysroot /Developer/SDKs/MacOSX10.6.sdk "${INC_PATH}/natron/NatronDyLd.c" -o "${package}/Contents/MacOS/Natron"
+        else
+            ${CC} -DLIBCXX "${INC_PATH}/natron/NatronDyLd.c" -o "${package}/Contents/MacOS/Natron"
+        fi
+        strip "${package}/Contents/MacOS/Natron"
+        cp "${package}/Contents/MacOS/Natron" "${package}/Contents/MacOS/NatronRenderer"
     fi
-    strip "${package}/Contents/MacOS/Natron"
-    cp "${package}/Contents/MacOS/Natron" "${package}/Contents/MacOS/NatronRenderer"
 fi
 
 

--- a/tools/jenkins/build-natron.sh
+++ b/tools/jenkins/build-natron.sh
@@ -39,7 +39,6 @@ fi
 
 # Setup env
 if [ "$PKGOS" = "Linux" ]; then
-    export BOOST_ROOT="$SDK_HOME"
     #export PYTHONHOME="$SDK_HOME"
     export LD_LIBRARY_PATH="$SDK_HOME/lib:$SDK_HOME/qt${QT_VERSION_MAJOR}/lib"
     export PATH="$SDK_HOME/gcc/bin:$SDK_HOME/bin:$SDK_HOME/qt${QT_VERSION_MAJOR}/bin:$HOME/.cabal/bin:$PATH"

--- a/tools/jenkins/build-plugins.sh
+++ b/tools/jenkins/build-plugins.sh
@@ -63,7 +63,6 @@ fi
 # Setup env
 CXXFLAGS_EXTRA=
 if [ "$PKGOS" = "Linux" ]; then
-    export BOOST_ROOT="$SDK_HOME"
     export OPENJPEG_HOME="$SDK_HOME"
     export THIRD_PARTY_TOOLS_HOME="$SDK_HOME"
     export LD_LIBRARY_PATH="$SDK_HOME/lib:$FFMPEG_PATH/lib"
@@ -77,7 +76,6 @@ if [ "$PKGOS" = "Linux" ]; then
     export CPLUS_INCLUDE_PATH="${C_INCLUDE_PATH}"
 
 elif [ "$PKGOS" = "Windows" ]; then
-    export BOOST_ROOT="$SDK_HOME"
     export OPENJPEG_HOME="$SDK_HOME"
     export THIRD_PARTY_TOOLS_HOME="$SDK_HOME"
     export GIT_SSL_NO_VERIFY="true"

--- a/tools/jenkins/common.sh
+++ b/tools/jenkins/common.sh
@@ -62,7 +62,7 @@ Darwin)
     PKGOS=${PKGOS:-OSX}
     if [ "$(uname -m)" = "arm64" ]; then
         # No Qt4 on apple Silicon
-        QT_VERSION_MAJOR=${QT_MAJOR_VERSION:-5}
+        QT_VERSION_MAJOR=${QT_VERSION_MAJOR:-5}
     fi
     ;;
 *)
@@ -403,6 +403,8 @@ else
 fi
 export QTDIR
 
+BOOST_ROOT="$SDK_HOME"
+
 PKG_CONFIG_PATH=
 if [ "$PKGOS" = "Linux" ]; then
     PATH="$SDK_HOME/bin:$QTDIR/bin:$SDK_HOME/gcc/bin:$FFMPEG_PATH/bin:$LIBRAW_PATH/bin:$PATH"
@@ -415,7 +417,14 @@ elif [ "$PKGOS" = "Windows" ]; then
 elif [ "$PKGOS" = "OSX" ]; then
     PKG_CONFIG_PATH="$FFMPEG_PATH/lib/pkgconfig:$LIBRAW_PATH/lib/pkgconfig:$OSMESA_PATH/lib/pkgconfig:$PYTHON_HOME/lib/pkgconfig:$QTDIR/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
 fi
-export LD_LIBRARY_PATH LD_RUN_PATH DYLD_LIBRARY_PATH LIBRARY_PATH CPATH PKG_CONFIG_PATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH
+export LD_LIBRARY_PATH LD_RUN_PATH DYLD_LIBRARY_PATH LIBRARY_PATH CPATH PKG_CONFIG_PATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH BOOST_ROOT
+
+if [ "${QT_VERSION_MAJOR}" = 4 ]; then
+    QT_VERSION=$(pkg-config --modversion QtCore)
+else
+    QT_VERSION=$(pkg-config --modversion Qt${QT_VERSION_MAJOR}Core)
+fi
+QT_VERSION_MINOR=$(echo $QT_VERSION | cut -d. -f2)
 
 # Load compiler related stuff
 source $CWD/compiler-common.sh

--- a/tools/jenkins/compiler-common.sh
+++ b/tools/jenkins/compiler-common.sh
@@ -92,15 +92,18 @@ if [ "$PKGOS" = "OSX" ]; then
         #"___atomic_load", referenced from:
         #_.omp_outlined..468 in CImgExpression.o
         #_.omp_outlined..608 in CImgExpression.o
+        #
+        # clang 17 and 18 with -fopenmp links with @rpath/libc++.1.dylib instead
+        # of /usr/lib/libc++.1.dylib, so let's use clang 16 for now.
         case "$osxver" in
             #9.*|10.*)
             #    true;;
             *)
-                if command -v clang-mp-17 >/dev/null 2>&1; then
-                    CC=clang-mp-17
-                    CXX="clang++-mp-17 -stdlib=libc++ -std=c++14"
-                    CXX17="clang++-mp-17 -stdlib=libc++ -std=c++17"
-                elif command -v clang-mp-16 >/dev/null 2>&1; then
+                # if command -v clang-mp-17 >/dev/null 2>&1; then
+                #     CC=clang-mp-17
+                #     CXX="clang++-mp-17 -stdlib=libc++ -std=c++14"
+                #     CXX17="clang++-mp-17 -stdlib=libc++ -std=c++17"
+                if command -v clang-mp-16 >/dev/null 2>&1; then
                     CC=clang-mp-16
                     CXX="clang++-mp-16 -stdlib=libc++ -std=c++14"
                     CXX17="clang++-mp-16 -stdlib=libc++ -std=c++17"
@@ -137,7 +140,7 @@ if [ "$PKGOS" = "OSX" ]; then
         esac
         case "$osxver" in
         2[123].*)
-            # clangg-mp can't compile QtMac.mm on Monterey
+            # clang-mp can't compile QtMac.mm on Monterey
             OBJECTIVE_CC=clang
             OBJECTIVE_CXX=clang++
             ;;
@@ -188,7 +191,13 @@ if [ "$PKGOS" = "OSX" ]; then
         22.*)
             MACOSX_DEPLOYMENT_TARGET=13
             ;;
-    esac
+        23.*)
+            MACOSX_DEPLOYMENT_TARGET=14
+            ;;
+        24.*)
+            MACOSX_DEPLOYMENT_TARGET=15
+            ;;
+   esac
     export MACOSX_DEPLOYMENT_TARGET
     export MACOSX_SYSROOT="${MACOSX_SDK_ROOT}/MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk"
 

--- a/tools/jenkins/genDllVersions.sh
+++ b/tools/jenkins/genDllVersions.sh
@@ -116,7 +116,7 @@ if [ "$QT_VERSION_MAJOR" = "5" ]; then
     catDll libpcre2-16-
     catDll libmd4c
 else
-    echo "Unsupported QT_MAJOR_VERSION" ${QT_VERSION_MAJOR}
+    echo "Unsupported QT_VERSION_MAJOR" ${QT_VERSION_MAJOR}
     exit 1
 fi
 

--- a/tools/jenkins/include/natron/OSX.pri
+++ b/tools/jenkins/include/natron/OSX.pri
@@ -1,6 +1,7 @@
 boost {
-  INCLUDEPATH += /opt/local/include
-  LIBS += -lboost_serialization-mt
+  BOOST_VERSION = 1.76
+  INCLUDEPATH += /opt/local/libexec/boost/$$BOOST_VERSION/include
+  LIBS += -L/opt/local/libexec/boost/$$BOOST_VERSION/lib -lboost_serialization-mt
 }
 equals(QT_MAJOR_VERSION, 5) {
   shiboken:  SHIBOKEN=shiboken2-$$PYVER
@@ -17,13 +18,15 @@ equals(QT_MAJOR_VERSION, 5) {
 }
 
 macx:openmp {
-  # clang 12+ is OK to build Natron, but libomp 12+ has a bug on macOS when
-  # lanching tasks from a background thread, see https://bugs.llvm.org/show_bug.cgi?id=50579
+  # libomp 12+ has a bug on macOS when lanching tasks from a background thread,
+  # see tools/MacPorts/lang/libomp/README.md
   LIBS += -L/opt/local/lib  -L/opt/local/lib/libomp -liomp5
   # These are set on the command-line, do not try to override it
   # search for 'printStatusMessage "Building Natron..."' in build-natron.sh
-  #QMAKE_CC = /opt/local/bin/clang-mp-14
-  #QMAKE_CXX = /opt/local/bin/clang++-mp-14
+  # clang 17 and 18 with -fopenmp links with @rpath/libc++.1.dylib instead
+  # of /usr/lib/libc++.1.dylib, so let's use clang 16 for now.
+  #QMAKE_CC = /opt/local/bin/clang-mp-16
+  #QMAKE_CXX = /opt/local/bin/clang++-mp-16
   # Recent clang cannot compile QtMac.mm
   #QMAKE_OBJECTIVE_CC = clang
   #QMAKE_OBJECTIVE_CXX = clang++

--- a/tools/jenkins/include/natron/OSX_natron3.pri
+++ b/tools/jenkins/include/natron/OSX_natron3.pri
@@ -2,16 +2,16 @@ boost {
   INCLUDEPATH += /opt/local/include
   LIBS += -lboost_serialization-mt
 }
-equals(QT_MAJOR_VERSION, 5) {
+equals(QT_VERSION_MAJOR, 5) {
   shiboken:  SHIBOKEN=shiboken2-$$PYVER
   shiboken:  INCLUDEPATH += $$PYTHON_SITE_PACKAGES/shiboken2_generator/include
-  shiboken:  LIBS += -L$$PYTHON_SITE_PACKAGES/shiboken2 -lshiboken2.cpython-$$PYVERNODOT-darwin.$${QT_MAJOR_VERSION}.$${QT_MINOR_VERSION}
+  shiboken:  LIBS += -L$$PYTHON_SITE_PACKAGES/shiboken2 -lshiboken2.cpython-$$PYVERNODOT-darwin.$${QT_VERSION_MAJOR}.$${QT_MINOR_VERSION}
   shiboken:  QMAKE_RPATHDIR += $$PYTHON_SITE_PACKAGES/shiboken2
   pyside:    INCLUDEPATH += $$PYTHON_SITE_PACKAGES/PySide2/include
   pyside:    INCLUDEPATH += $$PYTHON_SITE_PACKAGES/PySide2/include/QtCore
   pyside:    INCLUDEPATH += $$PYTHON_SITE_PACKAGES/PySide2/include/QtGui
   pyside:    INCLUDEPATH += $$PYTHON_SITE_PACKAGES/PySide2/include/QtWidgets
-  pyside:    LIBS += -L$$PYTHON_SITE_PACKAGES/PySide2 -lpyside2.cpython-$$PYVERNODOT-darwin.$${QT_MAJOR_VERSION}.$${QT_MINOR_VERSION}
+  pyside:    LIBS += -L$$PYTHON_SITE_PACKAGES/PySide2 -lpyside2.cpython-$$PYVERNODOT-darwin.$${QT_VERSION_MAJOR}.$${QT_MINOR_VERSION}
   pyside:    QMAKE_RPATHDIR += $$PYTHON_SITE_PACKAGES/PySide2
   pyside:    TYPESYSTEMPATH *= $$PYTHON_SITE_PACKAGES/PySide2/typesystems
 }

--- a/tools/jenkins/launchBuildMain.sh
+++ b/tools/jenkins/launchBuildMain.sh
@@ -153,6 +153,13 @@ source common.sh
 source manageBuildOptions.sh
 source manageLog.sh
 
+echo "CC                                : \"${CC:-}\""
+echo "CXX                               : \"${CXX:-}\""
+echo "CXX17                             : \"${CXX17:-}\""
+echo "OBJECTIVE_CC                      : \"${OBJECTIVE_CC:-}\""
+echo "OBJECTIVE_CXX                     : \"${OBJECTIVE_CXX:-}\""
+echo "-----------------------------------------------------------------------"
+
 # Source known git repositories
 source gitRepositories.sh
 


### PR DESCRIPTION
There are conflicts when merging RB-2.5into RB-2.6, so I could not do a full merge.
This is just a cherrypick of some of the 18 commits, but those related to:
1. github actions
2. cmake
3. windows packages

were not merged. Here's the full list of missing commits:
- 7ddcfe8afd1f03e428ce6cbc4f7c7737d9923838 @rodlie
- d1c2659dda688459a7b2aeb675718c65880ffd1d @rodlie
- 1fe5e5281f0cb1933d099d192c8f7dc0f9b06acc reviewed by  @acolwell 
- c7767b15044297b52737e5878d395067434bb8d5 @acolwell 
- cc47b65670df85fc9ac5e49e9a3579a5b75bbaaa @acolwell 
- fddb2e75dd535ae8b791aa73678ffbea9446a642 @acolwell 
- 2d14d4e04c9277db728f19b2405e3b9c234a4ab0 @acolwell 

@acolwell or @rodlie could you check what needs to be merged and do a full merge of RB-2.5 into RB-2.6? We should always merge changes from RB-2.x into RB-2.y if x < y, so that RB-2.y is fully ahead of RB-2.x. Hopefully this will not be an issue anymore now that RB-2.6 is the default branch.
