### PR TITLE
Fix warnings and MSVC errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,11 @@ set(QTWIDGETS_INCLUDE_DIRS ${Qt5Widgets_INCLUDE_DIRS})
 #for QString(const char*) assumes ASCII strings, we may run into troubles
 add_compile_definitions(QT_NO_CAST_FROM_ASCII)
 
-if (NOT MSVC)
+if (MSVC)
+    # Allow __cplusplus to properly reflect the c++ standard version.
+    add_compile_options(/Zc:__cplusplus)
+    add_compile_definitions(__STDC_LIMIT_MACROS WIN32_LEAN_AND_MEAN _USE_MATH_DEFINES)
+else()
     SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-prototypes" )
     add_compile_options(-Wall -Wextra -Wmissing-declarations -Wno-multichar -Winit-self -Wno-long-long
                         -Wvla -Wdate-time -Wshift-overflow=2

--- a/Engine/CLArgs.cpp
+++ b/Engine/CLArgs.cpp
@@ -31,6 +31,10 @@
 #include <cassert>
 #include <stdexcept>
 
+#ifdef __NATRON_WIN32__
+#include <shellapi.h>  // CommandLineToArgvW
+#endif
+
 #include <QtCore/QCoreApplication>
 #include <QtCore/QDebug>
 #include <QtCore/QFile>

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -110,7 +110,7 @@ target_include_directories(NatronEngine
 )
 target_compile_definitions(NatronEngine
     PRIVATE
-        NATRON_CUSTOM_BUILD_USER_TOKEN=${BUILD_USER_NAME}
+        NATRON_CUSTOM_BUILD_USER_TOKEN="${BUILD_USER_NAME}"
         NATRON_BUILD_NUMBER=0
         ${XDG_DEFS}
 )

--- a/Engine/HostOverlaySupport.h
+++ b/Engine/HostOverlaySupport.h
@@ -26,6 +26,8 @@
 #include <Python.h>
 // ***** END PYTHON BLOCK *****
 
+#include <string>
+
 #include "Global/Macros.h"
 
 #include "Engine/EngineFwd.h"

--- a/Engine/Knob.h
+++ b/Engine/Knob.h
@@ -1938,12 +1938,6 @@ public:
                                                   ViewSpec view,
                                                   int dimension);
 
-    /**
-     * @brief This is called by the plugin when a set value call would happen during  an interact action.
-     **/
-    void requestSetValueOnUndoStack(const T & value,
-                                    ViewSpec view,
-                                    int dimension);
 
     /**
      * @brief Calls setValueAtTime with a reason of eValueChangedReasonNatronInternalEdited.
@@ -2146,8 +2140,6 @@ private:
     }
 
     void makeKeyFrame(Curve* curve, double time, ViewSpec view, const T& v, KeyFrame* key);
-
-    void queueSetValue(const T& v, ViewSpec view, int dimension);
 
     virtual void clearExpressionsResults(int dimension) OVERRIDE FINAL
     {

--- a/Engine/KnobImpl.h
+++ b/Engine/KnobImpl.h
@@ -2588,9 +2588,10 @@ Knob<T>::copyValueForTypeAndCheckIfChanged(Knob<OTHERTYPE>* other,
         int dimMin = std::min( getDimension(), other->getDimension() );
         std::vector<OTHERTYPE> v = other->getValueForEachDimension_mt_safe_vector();
         for (int i = 0; i < dimMin; ++i) {
-            if (_values[i] != v[i]) {
-                _values[i] = v[i];
-                _guiValues[i] = v[i];
+            const T convertedV = static_cast<T>(v[i]);
+            if (_values[i] != convertedV) {
+                _values[i] = convertedV;
+                _guiValues[i] = convertedV;
                 ret = true;
             }
         }

--- a/Engine/NodeGroup.cpp
+++ b/Engine/NodeGroup.cpp
@@ -2836,12 +2836,12 @@ NodeCollection::exportGroupToPython(const QString& pluginID,
     WRITE_STATIC_LINE(NATRON_PYPLUG_MAGIC);
     QString descline = QString( QString::fromUtf8(NATRON_PYPLUG_GENERATED "%1 PyPlug exporter version %2.") ).arg( QString::fromUtf8(NATRON_APPLICATION_NAME) ).arg(NATRON_PYPLUG_EXPORTER_VERSION);
     WRITE_STRING(descline);
-    WRITE_STATIC_LINE();
+    WRITE_STATIC_LINE("");
     QString handWrittenStr = QString::fromUtf8("# Hand-written code should be added in a separate file named %1.py").arg(extModule);
     WRITE_STRING(handWrittenStr);
     WRITE_STATIC_LINE("# See http://natron.readthedocs.org/en/master/devel/groups.html#adding-hand-written-code-callbacks-etc");
     WRITE_STATIC_LINE("# Note that Viewers are never exported");
-    WRITE_STATIC_LINE();
+    WRITE_STATIC_LINE("");
     WRITE_STATIC_LINE("import " NATRON_ENGINE_PYTHON_MODULE_NAME);
     WRITE_STATIC_LINE("import sys");
     WRITE_STATIC_LINE("");

--- a/Engine/NodePrivate.h
+++ b/Engine/NodePrivate.h
@@ -29,6 +29,7 @@
 #include "Global/Macros.h"
 
 #include "Node.h"
+#include "Timer.h" // gettimeofday()
 
 #include <QtCore/QWaitCondition>
 #include <QtCore/QReadWriteLock>

--- a/Engine/StandardPaths.cpp
+++ b/Engine/StandardPaths.cpp
@@ -37,7 +37,7 @@
 
 #include <QtCore/QtGlobal> // for Q_OS_*
 #if defined(Q_OS_WIN)
-#include <windows.h>
+#include <combaseapi.h>
 #include <IntShCut.h>
 #include <ShlObj.h>
 #ifndef CSIDL_MYMUSIC

--- a/Engine/Timer.h
+++ b/Engine/Timer.h
@@ -35,7 +35,7 @@
 //----------------------------------------------------------------------------
 
 #if defined(__NATRON_WIN32__) && !defined(__NATRON_MINGW__)
-#include <windows.h>
+#include <winsock2.h>
 #else
 #include <sys/time.h>
 #endif

--- a/Engine/TrackerContext.cpp
+++ b/Engine/TrackerContext.cpp
@@ -46,6 +46,7 @@ CLANG_DIAG_ON(uninitialized)
 #include "Engine/KnobTypes.h"
 #include "Engine/Project.h"
 #include "Engine/Curve.h"
+#include "Engine/Timer.h" // gettimeofday()
 #include "Engine/TLSHolder.h"
 #include "Engine/Transform.h"
 #include "Engine/TrackMarker.h"

--- a/Global/Macros.h
+++ b/Global/Macros.h
@@ -455,6 +455,9 @@ GCC_ONLY_DIAG_OFF(pragmas)  // warning: unknown option after '#pragma GCC diagno
 /////////////////////////////////////////////////////////////////////////////////////////////
 
 /* COMPILER() - the compiler being used to build the project */
+#ifdef COMPILER
+#undef COMPILER
+#endif
 #define COMPILER(NATRON_FEATURE) (NATRON_COMPILER_ ## NATRON_FEATURE)
 
 /* COMPILER_SUPPORTS() - whether the compiler being used to build the project supports the given feature. */

--- a/Global/ProcInfo.cpp
+++ b/Global/ProcInfo.cpp
@@ -38,6 +38,10 @@
 #include <string.h> // strdup
 #endif
 
+#ifdef __NATRON_WIN32__
+#include <shellapi.h>  // CommandLineToArgvW
+#endif
+
 #include "StrUtils.h"
 
 NATRON_NAMESPACE_ENTER
@@ -499,7 +503,7 @@ ProcInfo::getenv_wrapper(const char *varName)
     std::vector<char> buffer;
     getenv_s(&requiredSize, 0, 0, varName);
     if (requiredSize == 0)
-        return buffer;
+        return std::string();
     buffer.resize(requiredSize);
     getenv_s(&requiredSize, &buffer[0], requiredSize, varName);
     // requiredSize includes the terminating null, which we don't want.

--- a/Gui/CMakeLists.txt
+++ b/Gui/CMakeLists.txt
@@ -90,7 +90,7 @@ target_include_directories(NatronGui
 )
 target_compile_definitions(NatronGui
     PRIVATE
-        NATRON_CUSTOM_BUILD_USER_TOKEN=${BUILD_USER_NAME}
+        NATRON_CUSTOM_BUILD_USER_TOKEN="${BUILD_USER_NAME}"
         NATRON_BUILD_NUMBER=0
         QT_NO_KEYWORDS
 )

--- a/Gui/FileTypeMainWindow_win.cpp
+++ b/Gui/FileTypeMainWindow_win.cpp
@@ -45,7 +45,8 @@
 #include <stdexcept>
 
 // —— general includes —————————————————————————
-#include <windows.h>
+#include <Dde.h>
+
 #include <QMessageBox>
 #include <QApplication>
 #include <QtCore/QDir>

--- a/Gui/HostOverlay.cpp
+++ b/Gui/HostOverlay.cpp
@@ -1006,41 +1006,6 @@ PositionInteract::draw(double time,
         glTranslated(direction * shadow.x, -direction * shadow.y, 0);
         glMatrixMode(GL_MODELVIEW); // Modelview should be used on Nuke
 
-#warning TODO
-#if 0
-        int numKeys = knob->get;
-
-        if (numKeys > 0) {
-            const double darken = 0.5;
-            glColor3f(pR * l * darken, pG * l * darken, pB * l * darken);
-
-            glPointSize(pointSize() * screenPixelRatio);
-            glBegin(GL_POINTS);
-            for (int i=0; i < numKeys; ++i) {
-                double time = p->getKeyTime(i);
-                OfxPointD pt;
-                p->getValueAtTime(time, pt.x, pt.y);
-                glVertex2d(pt.x, pt.y);
-
-            }
-            glEnd();
-            glLineWidth(1.5 * screenPixelRatio);
-            glBegin(GL_LINE_STRIP);
-            double time = p->getKeyTime(0);
-            for (int i = 1; i < numKeys; ++i) {
-                double timeNext = p->getKeyTime(i);
-                for (int j = (i == 1 ? 0 : 1); j <= steps; ++j) {
-                    double timeStep = time + j * (timeNext - time) / steps;
-                    OfxPointD pt;
-                    p->getValueAtTime(timeStep, pt.x, pt.y);
-                    glVertex2d(pt.x, pt.y);
-                }
-                time = timeNext;
-            }
-            glEnd();
-        }
-#endif
-
         glColor3f(pR * l, pG * l, pB * l);
         glPointSize(pointSize() * screenPixelRatio);
         glBegin(GL_POINTS);

--- a/Gui/HostOverlay.cpp
+++ b/Gui/HostOverlay.cpp
@@ -77,6 +77,18 @@ NATRON_NAMESPACE_ENTER
 //
 // TODO: This is a bug, there is no reason to not use setValues().
 // OpenFX plugins are not affected, because instanceChanged does not pass the dimension information.
+namespace {
+
+void nonBlockingSetValues(Natron::KnobDoublePtr& knob, const double x, const double y, const ValueChangedReasonEnum reason) {
+    knob->setValue(x, ViewSpec::all(), 0, reason, nullptr);
+    knob->setValue(y, ViewSpec::all(), 1, reason, nullptr);
+}
+
+inline void nonBlockingSetValues(Natron::KnobDoublePtr& knob, const OfxPointD& point, const ValueChangedReasonEnum reason) {
+    nonBlockingSetValues(knob, point.x, point.y, reason);
+}
+
+}  // namespace
 
 
 DefaultInteractI::DefaultInteractI(HostOverlay* overlay)
@@ -1750,8 +1762,7 @@ PositionInteract::penMotion(double time,
         EffectInstancePtr holder = _overlay->getNode()->getNode()->getEffectInstance();
         holder->setMultipleParamsEditLevel(KnobHolder::eMultipleParamsEditOnCreateNewCommand);
         // Do not use setValues(x,y) (see note at the top of this file).
-        knob->setValue(p[0], ViewSpec::all(), 0, eValueChangedReasonNatronGuiEdited);
-        knob->setValue(p[1], ViewSpec::all(), 1, eValueChangedReasonNatronGuiEdited);
+        nonBlockingSetValues(knob, p[0], p[1], eValueChangedReasonNatronGuiEdited);
         holder->setMultipleParamsEditLevel(KnobHolder::eMultipleParamsEditOff);
     }
 
@@ -2196,20 +2207,17 @@ TransformInteract::penMotion(double time,
         if (centerChanged) {
             KnobDoublePtr knob = _center.lock();
             // Do not use setValues(x,y) (see note at the top of this file).
-            knob->setValue(center.x, ViewSpec::all(), 0, eValueChangedReasonNatronGuiEdited);
-            knob->setValue(center.y, ViewSpec::all(), 1, eValueChangedReasonNatronGuiEdited);
+            nonBlockingSetValues(knob, center, eValueChangedReasonNatronGuiEdited);
         }
         if (translateChanged) {
             KnobDoublePtr knob = _translate.lock();
             // Do not use setValues(x,y) (see note at the top of this file).
-            knob->setValue(translate.x, ViewSpec::all(), 0, eValueChangedReasonNatronGuiEdited);
-            knob->setValue(translate.y, ViewSpec::all(), 1, eValueChangedReasonNatronGuiEdited);
+            nonBlockingSetValues(knob, translate, eValueChangedReasonNatronGuiEdited);
         }
         if (scaleChanged) {
             KnobDoublePtr knob = _scale.lock();
             // Do not use setValues(x,y) (see note at the top of this file).
-            knob->setValue(scale.x, ViewSpec::all(), 0, eValueChangedReasonNatronGuiEdited);
-            knob->setValue(scale.y, ViewSpec::all(), 1, eValueChangedReasonNatronGuiEdited);
+            nonBlockingSetValues(knob, scale, eValueChangedReasonNatronGuiEdited);
         }
         if (rotateChanged) {
             KnobDoublePtr knob = _rotate.lock();
@@ -2330,14 +2338,12 @@ CornerPinInteract::penMotion(double time,
             KnobDoublePtr knob = _from[_dragging].lock();
             assert(knob);
             // Do not use setValues(x,y) (see note at the top of this file).
-            knob->setValue(from[_dragging].x, ViewSpec::all(), 0, eValueChangedReasonPluginEdited);
-            knob->setValue(from[_dragging].y, ViewSpec::all(), 1, eValueChangedReasonPluginEdited);
+            nonBlockingSetValues(knob, from[_dragging], eValueChangedReasonPluginEdited);
         } else {
             KnobDoublePtr knob = _to[_dragging].lock();
             assert(knob);
             // Do not use setValues(x,y) (see note at the top of this file).
-            knob->setValue(to[_dragging].x, ViewSpec::all(), 0, eValueChangedReasonPluginEdited);
-            knob->setValue(to[_dragging].y, ViewSpec::all(), 1, eValueChangedReasonPluginEdited);
+            nonBlockingSetValues(knob, to[_dragging], eValueChangedReasonPluginEdited);
         }
         holder->setMultipleParamsEditLevel(KnobHolder::eMultipleParamsEditOff);
     }
@@ -2403,8 +2409,7 @@ PositionInteract::penUp(double time,
             EffectInstancePtr holder = _overlay->getNode()->getNode()->getEffectInstance();
             holder->setMultipleParamsEditLevel(KnobHolder::eMultipleParamsEditOnCreateNewCommand);
             // Do not use setValues(x,y) (see note at the top of this file).
-            knob->setValue(p[0], ViewSpec::all(), 0, eValueChangedReasonNatronGuiEdited);
-            knob->setValue(p[1], ViewSpec::all(), 1, eValueChangedReasonNatronGuiEdited);
+            nonBlockingSetValues(knob, p[0], p[1], eValueChangedReasonNatronGuiEdited);
             holder->setMultipleParamsEditLevel(KnobHolder::eMultipleParamsEditOff);
         }
 
@@ -2441,20 +2446,17 @@ TransformInteract::penUp(double /*time*/,
         {
             KnobDoublePtr knob = _center.lock();
             // Do not use setValues(x,y) (see note at the top of this file).
-            knob->setValue(_centerDrag.x, ViewSpec::all(), 0, eValueChangedReasonPluginEdited);
-            knob->setValue(_centerDrag.y, ViewSpec::all(), 1, eValueChangedReasonPluginEdited);
+            nonBlockingSetValues(knob, _centerDrag, eValueChangedReasonPluginEdited);
         }
         {
             KnobDoublePtr knob = _translate.lock();
             // Do not use setValues(x,y) (see note at the top of this file).
-            knob->setValue(_translateDrag.x, ViewSpec::all(), 0, eValueChangedReasonPluginEdited);
-            knob->setValue(_translateDrag.y, ViewSpec::all(), 1, eValueChangedReasonPluginEdited);
+            nonBlockingSetValues(knob, _translateDrag, eValueChangedReasonPluginEdited);
         }
         {
             KnobDoublePtr knob = _scale.lock();
             // Do not use setValues(x,y) (see note at the top of this file).
-            knob->setValue(_scaleParamDrag.x, ViewSpec::all(), 0, eValueChangedReasonPluginEdited);
-            knob->setValue(_scaleParamDrag.y, ViewSpec::all(), 1, eValueChangedReasonPluginEdited);
+            nonBlockingSetValues(knob, _scaleParamDrag, eValueChangedReasonPluginEdited);
         }
         {
             KnobDoublePtr knob = _rotate.lock();
@@ -2509,14 +2511,12 @@ CornerPinInteract::penUp(double /*time*/,
             KnobDoublePtr knob = _from[_dragging].lock();
             assert(knob);
             // Do not use setValues(x,y) (see note at the top of this file).
-            knob->setValue(_fromDrag[_dragging].x, ViewSpec::all(), 0, eValueChangedReasonPluginEdited);
-            knob->setValue(_fromDrag[_dragging].y, ViewSpec::all(), 1, eValueChangedReasonPluginEdited);
+            nonBlockingSetValues(knob, _fromDrag[_dragging], eValueChangedReasonPluginEdited);
         } else {
             KnobDoublePtr knob = _to[_dragging].lock();
             assert(knob);
             // Do not use setValues(x,y) (see note at the top of this file).
-            knob->setValue(_toDrag[_dragging].x, ViewSpec::all(), 0, eValueChangedReasonPluginEdited);
-            knob->setValue(_toDrag[_dragging].y, ViewSpec::all(), 1, eValueChangedReasonPluginEdited);
+            nonBlockingSetValues(knob, _toDrag[_dragging], eValueChangedReasonPluginEdited);
         }
         holder->setMultipleParamsEditLevel(KnobHolder::eMultipleParamsEditOff);
     }

--- a/Tests/OSGLContext_Test.cpp
+++ b/Tests/OSGLContext_Test.cpp
@@ -33,6 +33,17 @@
 
 NATRON_NAMESPACE_USING
 
+#if defined(__NATRON_WIN32__) && !defined(__NATRON_MINGW__)
+namespace {
+
+// Define nullptr_t operator since MSVC dosn't appear to have one by default.
+std::ostream& operator<<(std::ostream& os, const std::nullptr_t p) {
+    return os << "<nullptr>";
+}
+
+}  // namespace
+#endif
+
 TEST(OSGLContext, Basic)
 {
     if (!appPTR->isOpenGLLoaded()) {


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

This change fixes various issues that prevent the code from compiling with the MSVC compiler.
- Fixes an implicit cast from enum to bool in the HostOverlay code that I believe was an unintended bug.
- Removed a few declared but undefined functions.
- Fixed compiler errors related to windows.h by defining WIN32_LEAN_AND_MEAN and only included the actual header required instead of windows.h in some cases.
- Fixed a few minor preprocessor macro issues.
- Defined a << operator for nullptr_t in a test because it appears that MSVC doesn't define one.

**Have you tested your changes (if applicable)? If so, how?**

Yes. The installer [still builds and all the tests still pass](https://github.com/acolwell/Natron/actions/runs/10065598915). This change doesn't really change any behavior. It just makes slight adjustments to make the MSVC compiler happy.

**Futher details of this pull request**

This fixes MSVC compiling issues, but I do not have a full MSVC build working yet.

The HostOverlay fixes resolve the compiler errors I was encountering and preserves existing behavior (i.e. turns off "autokeying" when setting the value). It is not clear to me that this is correct since all the other setValue() calls near the ones that where fixed appear to pass in a KeyFrame object. I'm not familiar enough with this code to determine if this is correct or not so I just opted for preserving existing behavior for now. If we do decide to provide a KeyFrame object in the future, this should be easy to do in the new code.