### PR TITLE
Add tomllib to directories copied for Python zip.

### DIFF
--- a/tools/jenkins/zip-python-mingw.sh
+++ b/tools/jenkins/zip-python-mingw.sh
@@ -37,6 +37,7 @@ multiprocessing
 pydoc_data
 re
 sqlite3
+tomllib
 unittest
 urllib
 wsgiref


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

This just adds the tomllib directory to the list used to create the python zipfile. It appears that get-pip now appears to need tomllib and the installer build started failing because it was missing. Adding the directory fixed the "ModuleNotFoundError: No module named 'tomllib'" failure in get-pip.

**Have you tested your changes (if applicable)? If so, how?**

Yes. I've verified the installer [builds successfully again](https://github.com/acolwell/Natron/actions/runs/10149292193) with this fix.
