### PR TITLE
Fix null cache crashes.

### DIFF
--- a/Engine/AppManager.cpp
+++ b/Engine/AppManager.cpp
@@ -457,9 +457,15 @@ AppManager::~AppManager()
     QThreadPool::globalInstance()->waitForDone();
 
     ///Kill caches now because decreaseNCacheFilesOpened can be called
-    _imp->_nodeCache->waitForDeleterThread();
-    _imp->_diskCache->waitForDeleterThread();
-    _imp->_viewerCache->waitForDeleterThread();
+    if (_imp->_nodeCache) {
+        _imp->_nodeCache->waitForDeleterThread();
+    }
+    if (_imp->_diskCache) {
+        _imp->_diskCache->waitForDeleterThread();
+    }
+    if (_imp->_viewerCache) {
+        _imp->_viewerCache->waitForDeleterThread();
+    }
     _imp->_nodeCache.reset();
     _imp->_viewerCache.reset();
     _imp->_diskCache.reset();

--- a/Engine/AppManagerPrivate.cpp
+++ b/Engine/AppManagerPrivate.cpp
@@ -448,6 +448,10 @@ template <typename T>
 void
 saveCache(Cache<T>* cache)
 {
+    if (!cache) {
+        return;
+    }
+
     std::string cacheRestoreFilePath = cache->getRestoreFilePath();
     FStreamsSupport::ofstream ofile;
     FStreamsSupport::open(&ofile, cacheRestoreFilePath);


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

It fixes a few crashes caused by null cache pointers if an error occurs early in Natron startup. This change simply avoids dereferencing these null pointers so that Natron can exit cleanly without crashing.


**Have you tested your changes (if applicable)? If so, how?**

Yes. The crashes were easy to reproduce when an error occurs trying to initialize the python bindings or building with NATRON_RUN_WITHOUT_PYTHON. I know these aren't the common build/run situations, but the fix is trivial and it helps avoid early startup errors from being masked by null pointer exceptions. With these changes I've verified that Natron exits cleanly when errors in python initialization occur.

