### PR TITLE
Fix Windows installer build by removing libboost DLLs

### DIFF
--- a/tools/jenkins/genDllVersions.sh
+++ b/tools/jenkins/genDllVersions.sh
@@ -125,9 +125,7 @@ catDll fbclient
 catDll libass-
 catDll libbluray-
 catDll libboost_filesystem-mt
-catDll libboost_regex-mt
 catDll libboost_serialization-mt
-catDll libboost_system-mt
 catDll libboost_thread-mt
 catDll libbz2-
 catDll libcaca-


### PR DESCRIPTION
Msys2 has updated to a version of boost that no longer includes the libboost-regex-mt and libboost-system-mt DLLs. This change removes references to these DLLs so that the installer build stops trying to find them and failing.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Fixes the Windows installer build by removing 2 boost DLLs that are no longer included in Msys2.

**Have you tested your changes (if applicable)? If so, how?**

Yes. I verified the Windows installer successfully builds again (https://github.com/acolwell/Natron/actions/runs/11138194808)

