### PR TITLE
Fix 'unknown warning option' warnings when building with Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,9 +119,10 @@ if (MSVC)
 else()
     SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wmissing-prototypes" )
     add_compile_options(-Wall -Wextra -Wmissing-declarations -Wno-multichar -Winit-self -Wno-long-long
-                        -Wvla -Wdate-time -Wshift-overflow=2
-                        -Wduplicated-cond -Wno-stringop-overflow -Wno-format-overflow
-                        -Wno-deprecated-copy)
+                        -Wvla -Wdate-time -Wno-format-overflow -Wno-deprecated-copy)
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        add_compile_options(-Wshift-overflow=2 -Wduplicated-cond -Wno-stringop-overflow)
+    endif()
 endif()
 
 if(NATRON_SYSTEM_LIBS)
@@ -141,7 +142,10 @@ elseif(WIN32)
     add_compile_definitions(WINDOWS WIN32 _UNICODE UNICODE NOMINMAX QHTTP_SERVER_STATIC)
     add_compile_definitions(COMPILED_FROM_DSP XML_STATIC) # for expat
     if (NOT MSVC)
-        add_compile_options(-mwindows -municode -mthreads)
+        add_compile_options(-municode)
+        if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            add_compile_options(-mwindows -mthreads)
+        endif()
         add_link_options(-mwindows -municode)
         set(CMAKE_RC_COMPILER_INIT windres)
         set(CMAKE_RC_COMPILE_OBJECT


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Updates cmake build file to only specify gcc specific warnings when gcc is being used to build the code.

**Have you tested your changes (if applicable)? If so, how?**

Yes. I built the code locally with gcc and with clang. I verified that the clang builds no longer complain about unknown options and the options are still specified on gcc builds.
