### PR TITLE
Fix crashes related to TabWidget::removeTab() that were reported by #1029

### DIFF
--- a/Documentation/source/devel/PythonReference/NatronGui/PyTabWidget.rst
+++ b/Documentation/source/devel/PythonReference/NatronGui/PyTabWidget.rst
@@ -201,8 +201,8 @@ This is used internally by :func:`moveTab(tab,pane)<NatronGui.GuiApp.moveTab>`.
 
     :param index: :class:`int`
 
-Same as :func:`removeTab(tab)<NatronGui.PyTabWidget.removeTab>` but the *index* of a tab
-is given instead.
+Similar to :func:`removeTab(tab)<NatronGui.PyTabWidget.removeTab>` but the *index* of a tab
+is given instead. The tab may be destroyed if this object has the only reference to the tab.
 
 
 .. method:: NatronGui.PyTabWidget.setCurrentIndex(index)

--- a/Gui/PythonPanels.cpp
+++ b/Gui/PythonPanels.cpp
@@ -428,6 +428,7 @@ PyPanel::PyPanel(const QString& scriptName,
 
 PyPanel::~PyPanel()
 {
+    getGui()->unregisterTab(this);
     getGui()->unregisterPyPanel(this);
 }
 

--- a/Gui/TabWidget.cpp
+++ b/Gui/TabWidget.cpp
@@ -1061,7 +1061,7 @@ TabWidget::insertTab(int index,
     insertTab(index, QIcon(), widget, object);
 }
 
-PanelWidget*
+void
 TabWidget::removeTab(int index,
                      bool userAction)
 {
@@ -1070,12 +1070,13 @@ TabWidget::removeTab(int index,
 
     tabAt(index, &tab, &obj);
     if (!tab || !obj) {
-        return 0;
+        return;
     }
 
     ViewerTab* isViewer = dynamic_cast<ViewerTab*>(tab);
     Histogram* isHisto = dynamic_cast<Histogram*>(tab);
     NodeGraph* isGraph = dynamic_cast<NodeGraph*>(tab);
+    Natron::Python::PyPanel* isPyPanel = dynamic_cast<Natron::Python::PyPanel*>(tab);
     int newIndex = -1;
     if (isGraph) {
         /*
@@ -1142,8 +1143,17 @@ TabWidget::removeTab(int index,
         //tab->setParent(_imp->gui);
     }
 
-
+    // Note: The tab may get destroyed inside this call if the python variable on the app
+    // object that removeTabToPython() deletes is the only reference to the tab and the
+    // tab is a PyPanel created by Python code.
     _imp->removeTabToPython( tab, obj->getScriptName() );
+
+    if (isPyPanel) {
+        // At this point tab might have been destroyed if it was a PyPanel
+        // and no other python code has a reference to it.
+        // tab, w, and obj are all likely invalid now so just return.
+        return;
+    }
 
     if (userAction) {
         if (isViewer && _imp->gui) {
@@ -1154,7 +1164,7 @@ TabWidget::removeTab(int index,
             _imp->gui->removeHistogram(isHisto);
 
             //Return because at this point isHisto is invalid
-            return tab;
+            return;
         } else {
             ///Do not delete unique widgets such as the properties bin, node graph or curve editor
             w->setVisible(false);
@@ -1167,8 +1177,6 @@ TabWidget::removeTab(int index,
     }
     w->setParent(_imp->gui);
 
-
-    return tab;
 } // TabWidget::removeTab
 
 void
@@ -1188,9 +1196,7 @@ TabWidget::removeTab(PanelWidget* widget,
     }
 
     if (index != -1) {
-        PanelWidget* tab = removeTab(index, userAction);
-        assert(tab == widget);
-        Q_UNUSED(tab);
+        removeTab(index, userAction);
     }
 }
 

--- a/Gui/TabWidget.h
+++ b/Gui/TabWidget.h
@@ -189,9 +189,10 @@ public:
 
     void insertTab(int index, PanelWidget* widget, ScriptObject* object);
 
-    /*Removes from the TabWidget, but does not delete the widget.
-       Returns NULL if the index is not in a good range.*/
-    PanelWidget* removeTab(int index, bool userAction);
+    /*Removes from the TabWidget, but does not delete the widget if it is owned by C++ code. If
+      the widget was owned by Python code (e.g. a PyPanel), then the widget may get destroyed
+      if no other references exist in Python.*/
+    void removeTab(int index, bool userAction);
 
     /*Get the header name of the tab at index "index".*/
     QString getTabLabel(int index) const;
@@ -201,7 +202,9 @@ public:
 
     void setTabLabel(PanelWidget* tab, const QString & name);
 
-    /*Removes from the TabWidget, but does not delete the widget.*/
+    /*Removes from the TabWidget, but does not delete the widget if it is owned by C++ code. If
+      the widget was owned by Python code (e.g. a PyPanel), then the widget may get destroyed
+      if no other references exist in Python.*/
     void removeTab(PanelWidget* widget, bool userAction);
 
     int count() const;


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Fix crashes related to TabWidget::removeTab() that were reported by #1029 
- Add code to ~PyPanel() to unregister itself.
- Added code in TabWidget::removeTab() to specifically handle PyPanel objects. The code was crashing in cases where the removeTab() call was deleting the last reference to the PyPanel object and Python was destroying the object. The new code avoids use-after-free crashes in this situation.
- Updated documentation to properly indicate that PyPanel objects may be destroyed if removeTab() deletes the last reference.
- Changed TabWidget::removeTab() return value since the function can't guarantee a valid object for the type it was returning. Only one call site needed to be updated and it was effectively ignoring the value anyways.


**Have you tested your changes (if applicable)? If so, how?**

Yes. I've verified locally that the crashes mentioned in #1029 no longer occur. I also [successfully built the Windows installer](https://github.com/acolwell/Natron/actions/runs/12779839146)  and verified that all the tests still pass and this build does not crash with the bug repro.

**Futher details of this pull request**

This fix is primarily just dealing with use-after-free issues. PyPanel objects would register themselves in their constructor, but never unregistered on destruction. This was causing code like the loop in PanelWidget::takeClickFocus() to make calls on PyPanel object pointers that were already destroyed. 

Some crashes were also caused by TabWidget::removeTab() trying to call w->setVisible(false) on objects that have already been destroyed. This can happen when the removeTabToPython() call, that removes the reference to the panel on the app.pane2 object, causes the PyPanel object to actually be destroyed. This happens when the Python code does not keep another reference to the panel when it makes a call to remove the tab. The fix for this was to simply return right after the removeTabToPython()  call in the PyPanel case. This avoids the crash and skips a bunch of code that doesn't appear to apply to the PyPanel case.

I updated the docs for removeTab() to make it a little clearer that the tab object can be destroyed within the call if it is the last reference.