### PR TITLE
Fix Windows Installer build.

### DIFF
--- a/tools/jenkins/genDllVersions.sh
+++ b/tools/jenkins/genDllVersions.sh
@@ -231,7 +231,7 @@ catDll libsnappy
 catDll libheif
 catDll libkvazaar-
 catDll libcryptopp
-catDll rav1e
+catDll librav1e
 catDll libde265-
 catDll libx265
 catDll libdav1d


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

The msys2 rav1e package recently renamed its DLL with a lib prefix. https://github.com/msys2/MINGW-packages/commit/182707ecdd9ccd35685e9c06a72ef1eb54e689f1

This change adds the prefix to the relevant installer code.

**Have you tested your changes (if applicable)? If so, how?**

Yes. The windows installer successfully builds again (https://github.com/acolwell/Natron/actions/runs/13479836742)

