### PR TITLE
Fix git command-line to use --init instead of -i

### DIFF
--- a/tools/jenkins/checkout-repository.sh
+++ b/tools/jenkins/checkout-repository.sh
@@ -66,9 +66,9 @@ function checkoutRepository() {
 
     # the snapshot are always built with latest version
     # slow version:
-    #$TIMEOUT 1800 $GIT submodule update -i --recursive --remote
+    #$TIMEOUT 1800 $GIT submodule update --init --recursive --remote
     # fast version (depth=1):
-    $TIMEOUT 1800 $GIT submodule update --depth 1 -i --recursive --remote
+    $TIMEOUT 1800 $GIT submodule update --depth 1 --init --recursive --remote
 
     # copy tarball of sources pruned of git files
     if [ "${TAR_SOURCES:-}" = "1" ]; then


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Fixes Windows build.  A new version of git appears to be rejecting the -i command-line option on "git submodule update" commands now.  I suspect this is because of the [changes in 2.9.0](https://github.com/git/git/blob/master/Documentation/RelNotes/2.9.0.adoc) that port 'git submodule update' logic to C. 


**Have you tested your changes (if applicable)? If so, how?**

Yes. I've verified [an installer build runs successfully again](https://github.com/acolwell/Natron/actions/runs/13982366814)
