### PR TITLE
Fix deprecated Qt constants

### DIFF
--- a/Engine/FileSystemModel.cpp
+++ b/Engine/FileSystemModel.cpp
@@ -842,7 +842,7 @@ FileSystemModel::data(const QModelIndex &index,
         data = item->fileExtension();
         break;
     case DateModified:
-        data = item->getLastModified().toString(Qt::LocalDate);
+        data = QLocale().toString(item->getLastModified(), QLocale::ShortFormat);
         break;
     default:
         break;

--- a/Engine/StandardPaths.cpp
+++ b/Engine/StandardPaths.cpp
@@ -110,7 +110,7 @@ load(const wchar_t *libraryName,
         // This code is windows-only anyway, but this is here for consistency with other parts of the source
         const QChar pathSep = QChar::fromLatin1(':');
 #     endif
-        searchOrder << PATH.split(pathSep, QString::SkipEmptyParts);
+        searchOrder << PATH.split(pathSep, Qt::SkipEmptyParts);
     }
     QString fileName = QString::fromWCharArray(libraryName);
     fileName.append( QLatin1String(".dll") );
@@ -317,7 +317,7 @@ StandardPaths::writableLocation(StandardLocationEnum type)
         path = QStandardPaths::HomeLocation;
         break;
     case StandardPaths::eStandardLocationData:
-        path = QStandardPaths::DataLocation;
+        path = QStandardPaths::AppLocalDataLocation;
         break;
     case StandardPaths::eStandardLocationCache:
         path = QStandardPaths::CacheLocation;

--- a/Gui/KnobGuiFile.cpp
+++ b/Gui/KnobGuiFile.cpp
@@ -226,7 +226,7 @@ KnobGuiFile::updateGUI(int /*dimension*/)
 
             QString tt = toolTip();
             tt.append( QString::fromUtf8("\n\nLast modified: ") );
-            tt.append( dateTime.toString(Qt::SystemLocaleShortDate) );
+            tt.append( QLocale().toString(dateTime, QLocale::ShortFormat));
             _lineEdit->setToolTip(tt);
         }
     }

--- a/Gui/NodeViewerContext.cpp
+++ b/Gui/NodeViewerContext.cpp
@@ -242,7 +242,7 @@ addSpacer(QBoxLayout* layout)
     line->setFrameShape(QFrame::VLine);
     line->setFrameShadow(QFrame::Raised);
     QPalette palette;
-    palette.setColor(QPalette::Foreground, Qt::black);
+    palette.setColor(QPalette::WindowText, Qt::black);
     line->setPalette(palette);
     layout->addWidget(line);
     layout->addSpacing( TO_DPIX(5) );

--- a/Gui/QtColorTriangle.cpp
+++ b/Gui/QtColorTriangle.cpp
@@ -215,7 +215,7 @@ void QtColorTriangle::genBackground()
     // Create an image of the same size as the contents rect.
     bg = QImage(contentsRect().size(), QImage::Format_RGB32);
     QPainter p(&bg);
-    p.setRenderHint(QPainter::HighQualityAntialiasing);
+    p.setRenderHint(QPainter::Antialiasing);
     p.fillRect(bg.rect(), palette().mid());
 
     QConicalGradient gradient(bg.rect().center(), 90);

--- a/Gui/TableModelView.h
+++ b/Gui/TableModelView.h
@@ -159,12 +159,12 @@ public:
 
     inline QColor backgroundColor() const
     {
-        return qvariant_cast<QColor>( data(Qt::BackgroundColorRole) );
+        return qvariant_cast<QColor>( data(Qt::BackgroundRole) );
     }
 
     inline void setBackgroundColor(const QColor &color)
     {
-        setData(Qt::BackgroundColorRole, color);
+        setData(Qt::BackgroundRole, color);
     }
 
     inline QBrush background() const
@@ -179,12 +179,12 @@ public:
 
     inline QColor textColor() const
     {
-        return qvariant_cast<QColor>( data(Qt::TextColorRole) );
+        return qvariant_cast<QColor>( data(Qt::ForegroundRole) );
     }
 
     inline void setTextColor(const QColor &color)
     {
-        setData(Qt::TextColorRole, color);
+        setData(Qt::ForegroundRole, color);
     }
 
     inline QBrush foreground() const

--- a/Gui/TextRenderer.cpp
+++ b/Gui/TextRenderer.cpp
@@ -179,7 +179,7 @@ TextRendererPrivate::createCharacter(QChar c)
     image.fill(Qt::transparent);
     QPainter painter;
     painter.begin(&image);
-    painter.setRenderHints(QPainter::HighQualityAntialiasing
+    painter.setRenderHints(QPainter::Antialiasing
                            | QPainter::TextAntialiasing);
     painter.setFont(_font);
     painter.setPen(Qt::white);

--- a/Gui/ViewerTab.cpp
+++ b/Gui/ViewerTab.cpp
@@ -91,7 +91,7 @@ addSpacer(QBoxLayout* layout)
     line->setFrameShadow(QFrame::Raised);
     //line->setObjectName("LayoutSeparator");
     QPalette palette;
-    palette.setColor(QPalette::Foreground, Qt::black);
+    palette.setColor(QPalette::WindowText, Qt::black);
     line->setPalette(palette);
     layout->addWidget(line);
     layout->addSpacing(5);


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Replacing deprecated Qt constants with the supported alternatives. This is a step on the path towards getting Qt6 building and does not introduce any functional changes.


**Have you tested your changes (if applicable)? If so, how?**

Yes. [installer still builds](https://github.com/acolwell/Natron/actions/runs/14802255086) and [Tests action still builds](https://github.com/acolwell/Natron/actions/runs/14802707104) and both still pass all their tests. I've verified that all the Qt related deprecation warning messages are gone.

