### PR TITLE
Remove QTextCodec usage.

### DIFF
--- a/Engine/AppManager.cpp
+++ b/Engine/AppManager.cpp
@@ -88,7 +88,6 @@
 #include <QDateTime>
 #include <QDebug>
 #include <QDir>
-#include <QTextCodec>
 #include <QCoreApplication>
 #include <QSettings>
 #include <QThreadPool>

--- a/Gui/AboutWindow.cpp
+++ b/Gui/AboutWindow.cpp
@@ -37,7 +37,6 @@ CLANG_DIAG_OFF(deprecated)
 #include <QVBoxLayout>
 #include <QTabWidget>
 #include <QFile>
-#include <QTextCodec>
 #include <QItemSelectionModel>
 #include <QHeaderView>
 #include <QDir>
@@ -130,7 +129,7 @@ AboutWindow::AboutWindow(QWidget* parent)
         QString licenseStr;
         QFile license( QString::fromUtf8(":LICENSE_SHORT.txt") );
         license.open(QIODevice::ReadOnly | QIODevice::Text);
-        licenseStr = NATRON_NAMESPACE::convertFromPlainText(QTextCodec::codecForName("UTF-8")->toUnicode( license.readAll() ), NATRON_NAMESPACE::WhiteSpaceNormal);
+        licenseStr = NATRON_NAMESPACE::convertFromPlainText(QString::fromUtf8( license.readAll() ), NATRON_NAMESPACE::WhiteSpaceNormal);
         aboutText.append(licenseStr);
     }
     {
@@ -445,7 +444,7 @@ AboutWindow::AboutWindow(QWidget* parent)
     {
         QFile changelogFile( QString::fromUtf8(":CHANGELOG.md") );
         changelogFile.open(QIODevice::ReadOnly | QIODevice::Text);
-        _changelogText->setText( QTextCodec::codecForName("UTF-8")->toUnicode( changelogFile.readAll() ) );
+        _changelogText->setText( QString::fromUtf8( changelogFile.readAll() ) );
     }
     _tabWidget->addTab( _changelogText, tr("Changelog") );
 
@@ -460,7 +459,7 @@ AboutWindow::AboutWindow(QWidget* parent)
     {
         QFile team_file( QString::fromUtf8(":CONTRIBUTORS.txt") );
         team_file.open(QIODevice::ReadOnly | QIODevice::Text);
-        _teamText->setText( QTextCodec::codecForName("UTF-8")->toUnicode( team_file.readAll() ) );
+        _teamText->setText( QString::fromUtf8( team_file.readAll() ) );
     }
     _tabWidget->addTab( _teamText, tr("Contributors") );
 
@@ -469,7 +468,7 @@ AboutWindow::AboutWindow(QWidget* parent)
     {
         QFile license( QString::fromUtf8(":LICENSE.txt") );
         license.open(QIODevice::ReadOnly | QIODevice::Text);
-        _licenseText->setText( QTextCodec::codecForName("UTF-8")->toUnicode( license.readAll() ) );
+        _licenseText->setText( QString::fromUtf8( license.readAll() ) );
     }
     _tabWidget->addTab( _licenseText, tr("License") );
 
@@ -563,7 +562,7 @@ AboutWindow::onSelectionChanged(const QItemSelection & newSelection,
         fileName += ( item->text() == QString::fromUtf8("README") ) ? QString::fromUtf8(".md") : QString::fromUtf8(".txt");
         QFile file(fileName);
         if ( file.open(QIODevice::ReadOnly | QIODevice::Text) ) {
-            QString content = QTextCodec::codecForName("UTF-8")->toUnicode( file.readAll() );
+            QString content = QString::fromUtf8( file.readAll() );
             _thirdPartyBrowser->setText(content);
         }
     }


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Removes usage of QTextCodec  in favor of QString::fromUtf8().

**Have you tested your changes (if applicable)? If so, how?**

Yes. [Installer still builds](https://github.com/acolwell/Natron/actions/runs/14815388153) and text in the About dialog box related to this change still appears correctly.

