### PR TITLE
Introduce QtCompat::QEnterEvent so enterEvent() overrides build on Qt5 & Qt6

### DIFF
--- a/Global/QtCompat.h
+++ b/Global/QtCompat.h
@@ -46,6 +46,15 @@ removeFileExtension(QString & filename)
     return extension;
 }
 
+// Define compatibility typedefs so code builds with Qt5 & Qt6
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+typedef QEnterEvent QEnterEvent;
+#elif QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+typedef QEvent QEnterEvent;
+#else
+#error "Unsupported version of QT"
+#endif
+
 } // namespace QtCompat
 
 NATRON_NAMESPACE_EXIT

--- a/Gui/ClickableLabel.cpp
+++ b/Gui/ClickableLabel.cpp
@@ -180,7 +180,7 @@ KnobClickableLabel::~KnobClickableLabel()
 }
 
 void
-KnobClickableLabel::enterEvent(QEvent* e)
+KnobClickableLabel::enterEvent(QtCompat::QEnterEvent* e)
 {
     _dnd->mouseEnter(e);
     ClickableLabel::enterEvent(e);

--- a/Gui/ClickableLabel.h
+++ b/Gui/ClickableLabel.h
@@ -34,7 +34,7 @@ CLANG_DIAG_OFF(uninitialized)
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
-#include "Global/Macros.h"
+#include "Global/QtCompat.h"
 #include "Gui/Label.h"
 #include "Gui/GuiFwd.h"
 
@@ -143,7 +143,7 @@ public:
 
 private:
 
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE FINAL;
     virtual void keyReleaseEvent(QKeyEvent* e) OVERRIDE FINAL;

--- a/Gui/CurveEditor.cpp
+++ b/Gui/CurveEditor.cpp
@@ -1559,7 +1559,7 @@ CurveEditor::keyReleaseEvent(QKeyEvent* e)
 }
 
 void
-CurveEditor::enterEvent(QEvent* e)
+CurveEditor::enterEvent(QtCompat::QEnterEvent* e)
 {
     enterEventBase();
     QWidget::enterEvent(e);

--- a/Gui/CurveEditor.h
+++ b/Gui/CurveEditor.h
@@ -28,7 +28,6 @@
 
 #include "Global/Macros.h"
 
-#include "Global/Macros.h"
 CLANG_DIAG_OFF(deprecated)
 CLANG_DIAG_OFF(uninitialized)
 #include <QWidget>
@@ -36,6 +35,7 @@ CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
 #include "Global/GlobalDefines.h"
+#include "Global/QtCompat.h"
 
 #include "Engine/EngineFwd.h"
 
@@ -380,7 +380,7 @@ public Q_SLOTS:
 private:
 
     virtual QUndoStack* getUndoStack() const OVERRIDE FINAL WARN_UNUSED_RETURN;
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE FINAL;
     virtual void keyReleaseEvent(QKeyEvent* e) OVERRIDE FINAL;

--- a/Gui/CurveWidget.cpp
+++ b/Gui/CurveWidget.cpp
@@ -1592,7 +1592,7 @@ CurveWidget::keyPressEvent(QKeyEvent* e)
 } // keyPressEvent
 
 void
-CurveWidget::enterEvent(QEvent* e)
+CurveWidget::enterEvent(QtCompat::QEnterEvent* e)
 {
     setFocus();
     QOpenGLWidget::enterEvent(e);

--- a/Gui/CurveWidget.h
+++ b/Gui/CurveWidget.h
@@ -44,6 +44,7 @@ CLANG_DIAG_ON(uninitialized)
 #include <QOpenGLWidget>
 
 #include "Global/GlobalDefines.h"
+#include "Global/QtCompat.h"
 
 #include "Engine/OverlaySupport.h"
 #include "Engine/Curve.h"
@@ -230,7 +231,7 @@ private:
     virtual void mouseDoubleClickEvent(QMouseEvent* e) OVERRIDE FINAL;
     virtual void mouseReleaseEvent(QMouseEvent* e) OVERRIDE FINAL;
     virtual void mouseMoveEvent(QMouseEvent* e) OVERRIDE FINAL;
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void wheelEvent(QWheelEvent* e) OVERRIDE FINAL;
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE FINAL;
     virtual void focusInEvent(QFocusEvent* e) OVERRIDE FINAL;

--- a/Gui/DopeSheetEditor.cpp
+++ b/Gui/DopeSheetEditor.cpp
@@ -264,7 +264,7 @@ DopeSheetEditor::keyReleaseEvent(QKeyEvent* e)
 }
 
 void
-DopeSheetEditor::enterEvent(QEvent *e)
+DopeSheetEditor::enterEvent(QtCompat::QEnterEvent *e)
 {
     enterEventBase();
     QWidget::enterEvent(e);

--- a/Gui/DopeSheetEditor.h
+++ b/Gui/DopeSheetEditor.h
@@ -37,6 +37,8 @@ CLANG_DIAG_OFF(uninitialized)
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
+#include "Global/QtCompat.h"
+
 #include "Gui/PanelWidget.h"
 #include "Gui/GuiFwd.h"
 
@@ -122,7 +124,7 @@ public:
 
 private:
 
-    virtual void enterEvent(QEvent *e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent *e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent *e) OVERRIDE FINAL;
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE FINAL;
     virtual void keyReleaseEvent(QKeyEvent* e) OVERRIDE FINAL;

--- a/Gui/GuiPrivate.cpp
+++ b/Gui/GuiPrivate.cpp
@@ -65,6 +65,7 @@ GCC_DIAG_UNUSED_PRIVATE_FIELD_ON
 #include <cairo/cairo.h>
 
 #include "Global/ProcInfo.h"
+#include "Global/QtCompat.h"
 
 #include "Engine/Image.h"
 #include "Engine/KnobFile.h"
@@ -523,7 +524,7 @@ private:
         }
     }
 
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL
     {
         AutoRaiseToolButton* btn = dynamic_cast<AutoRaiseToolButton*>( _gui->getToolButtonMenuOpened() );
 

--- a/Gui/Histogram.cpp
+++ b/Gui/Histogram.cpp
@@ -1483,7 +1483,7 @@ Histogram::keyReleaseEvent(QKeyEvent* e)
 }
 
 void
-Histogram::enterEvent(QEvent* e)
+Histogram::enterEvent(QtCompat::QEnterEvent* e)
 {
     enterEventBase();
     QOpenGLWidget::enterEvent(e);

--- a/Gui/Histogram.h
+++ b/Gui/Histogram.h
@@ -36,6 +36,8 @@ CLANG_DIAG_ON(uninitialized)
 
 #include <QOpenGLWidget>
 
+#include <Global/QtCompat.h>
+
 #include "Gui/PanelWidget.h"
 #include "Gui/GuiFwd.h"
 
@@ -109,7 +111,7 @@ private:
     virtual void wheelEvent(QWheelEvent* e) OVERRIDE FINAL;
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE FINAL;
     virtual void keyReleaseEvent(QKeyEvent* e) OVERRIDE FINAL;
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
     virtual void showEvent(QShowEvent* e) OVERRIDE FINAL;
     virtual QSize sizeHint() const OVERRIDE FINAL;

--- a/Gui/KnobGuiBool.cpp
+++ b/Gui/KnobGuiBool.cpp
@@ -113,7 +113,7 @@ Bool_CheckBox::getBackgroundColor(double *r,
 }
 
 void
-Bool_CheckBox::enterEvent(QEvent* e)
+Bool_CheckBox::enterEvent(QtCompat::QEnterEvent* e)
 {
     _dnd->mouseEnter(e);
     AnimatedCheckBox::enterEvent(e);

--- a/Gui/KnobGuiBool.h
+++ b/Gui/KnobGuiBool.h
@@ -40,6 +40,7 @@ CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
 #include "Global/GlobalDefines.h"
+#include "Global/QtCompat.h"
 
 #include "Engine/Singleton.h"
 #include "Engine/Knob.h"
@@ -77,7 +78,7 @@ public:
 
 private:
 
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE FINAL;
     virtual void keyReleaseEvent(QKeyEvent* e) OVERRIDE FINAL;

--- a/Gui/KnobGuiChoice.cpp
+++ b/Gui/KnobGuiChoice.cpp
@@ -116,7 +116,7 @@ KnobComboBox::wheelEvent(QWheelEvent *e)
 }
 
 void
-KnobComboBox::enterEvent(QEvent* e)
+KnobComboBox::enterEvent(QtCompat::QEnterEvent* e)
 {
     _dnd->mouseEnter(e);
     ComboBox::enterEvent(e);

--- a/Gui/KnobGuiChoice.h
+++ b/Gui/KnobGuiChoice.h
@@ -40,6 +40,7 @@ CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
 #include "Global/GlobalDefines.h"
+#include "Global/QtCompat.h"
 
 #include "Engine/Singleton.h"
 #include "Engine/Knob.h"
@@ -68,7 +69,7 @@ public:
 private:
 
     virtual void wheelEvent(QWheelEvent *e) OVERRIDE FINAL;
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE FINAL;
     virtual void keyReleaseEvent(QKeyEvent* e) OVERRIDE FINAL;

--- a/Gui/KnobGuiColor.cpp
+++ b/Gui/KnobGuiColor.cpp
@@ -106,7 +106,7 @@ ColorPickerLabel::mousePressEvent(QMouseEvent*)
 }
 
 void
-ColorPickerLabel::enterEvent(QEvent*)
+ColorPickerLabel::enterEvent(QtCompat::QEnterEvent*)
 {
     QToolTip::showText( QCursor::pos(), toolTip() );
 }

--- a/Gui/KnobGuiColor.h
+++ b/Gui/KnobGuiColor.h
@@ -41,6 +41,7 @@ CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
 #include "Global/GlobalDefines.h"
+#include "Global/QtCompat.h"
 
 #include "Engine/Singleton.h"
 #include "Engine/Knob.h"
@@ -97,7 +98,7 @@ Q_SIGNALS:
 
 private:
 
-    virtual void enterEvent(QEvent*) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent*) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent*) OVERRIDE FINAL;
     virtual void mousePressEvent(QMouseEvent*) OVERRIDE FINAL;
 

--- a/Gui/KnobGuiString.cpp
+++ b/Gui/KnobGuiString.cpp
@@ -147,7 +147,7 @@ AnimatingTextEdit::setDirty(bool b)
 }
 
 void
-AnimatingTextEdit::enterEvent(QEvent* e)
+AnimatingTextEdit::enterEvent(QtCompat::QEnterEvent* e)
 {
     _dnd->mouseEnter(e);
     QTextEdit::enterEvent(e);
@@ -270,7 +270,7 @@ KnobLineEdit::~KnobLineEdit()
 }
 
 void
-KnobLineEdit::enterEvent(QEvent* e)
+KnobLineEdit::enterEvent(QtCompat::QEnterEvent* e)
 {
     _dnd->mouseEnter(e);
     LineEdit::enterEvent(e);

--- a/Gui/KnobGuiString.h
+++ b/Gui/KnobGuiString.h
@@ -40,6 +40,7 @@ CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
 #include "Global/GlobalDefines.h"
+#include "Global/QtCompat.h"
 
 #include "Engine/Singleton.h"
 #include "Engine/Knob.h"
@@ -109,7 +110,7 @@ private:
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE;
     virtual void keyReleaseEvent(QKeyEvent* e) OVERRIDE;
     virtual void paintEvent(QPaintEvent* e) OVERRIDE;
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
     virtual void mousePressEvent(QMouseEvent* e) OVERRIDE FINAL;
     virtual void mouseMoveEvent(QMouseEvent* e) OVERRIDE FINAL;
@@ -140,7 +141,7 @@ private:
 
     virtual void focusInEvent(QFocusEvent* e) OVERRIDE FINAL;
     virtual void focusOutEvent(QFocusEvent* e) OVERRIDE FINAL;
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE FINAL;
     virtual void keyReleaseEvent(QKeyEvent* e) OVERRIDE FINAL;

--- a/Gui/NodeGraph.h
+++ b/Gui/NodeGraph.h
@@ -41,6 +41,7 @@ CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
 #include "Global/GlobalDefines.h"
+#include "Global/QtCompat.h"
 
 #include "Engine/NodeGraphI.h"
 #include "Engine/EngineFwd.h"
@@ -260,7 +261,7 @@ private:
 
     bool isNearbyNavigator(const QPoint& widgetPos, QPointF& scenePos) const;
 
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE FINAL;
     virtual void keyReleaseEvent(QKeyEvent* e) OVERRIDE FINAL;

--- a/Gui/NodeGraph30.cpp
+++ b/Gui/NodeGraph30.cpp
@@ -139,7 +139,7 @@ NodeGraph::connectCurrentViewerToSelection(int inputNB,
 } // connectCurrentViewerToSelection
 
 void
-NodeGraph::enterEvent(QEvent* e)
+NodeGraph::enterEvent(QtCompat::QEnterEvent* e)
 {
     enterEventBase();
     QGraphicsView::enterEvent(e);

--- a/Gui/ProgressPanel.cpp
+++ b/Gui/ProgressPanel.cpp
@@ -299,7 +299,7 @@ ProgressPanel::keyReleaseEvent(QKeyEvent* e)
 }
 
 void
-ProgressPanel::enterEvent(QEvent* e)
+ProgressPanel::enterEvent(QtCompat::QEnterEvent* e)
 {
     enterEventBase();
     QWidget::enterEvent(e);

--- a/Gui/ProgressPanel.h
+++ b/Gui/ProgressPanel.h
@@ -34,6 +34,8 @@ CLANG_DIAG_OFF(uninitialized)
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
+#include "Global/QtCompat.h"
+
 #include "Gui/PanelWidget.h"
 #include "Gui/GuiFwd.h"
 
@@ -139,7 +141,7 @@ private:
     // overridden from QWidget
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE FINAL;
     virtual void keyReleaseEvent(QKeyEvent* e) OVERRIDE FINAL;
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
     std::unique_ptr<ProgressPanelPrivate> _imp;
     TaskBar *_taskbar;

--- a/Gui/PropertiesBinWrapper.cpp
+++ b/Gui/PropertiesBinWrapper.cpp
@@ -54,7 +54,7 @@ PropertiesBinWrapper::mousePressEvent(QMouseEvent* e)
 }
 
 void
-PropertiesBinWrapper::enterEvent(QEvent* e)
+PropertiesBinWrapper::enterEvent(QtCompat::QEnterEvent* e)
 {
     QWidget::enterEvent(e);
 }

--- a/Gui/PropertiesBinWrapper.h
+++ b/Gui/PropertiesBinWrapper.h
@@ -27,6 +27,7 @@
 // ***** END PYTHON BLOCK *****
 
 #include "Global/Macros.h"
+#include "Global/QtCompat.h"
 
 #include "Gui/PanelWidget.h"
 #include "Gui/GuiFwd.h"
@@ -44,7 +45,7 @@ public:
 
 private:
     virtual void mousePressEvent(QMouseEvent* e) OVERRIDE FINAL;
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE FINAL;
     virtual void keyReleaseEvent(QKeyEvent* e) OVERRIDE FINAL;

--- a/Gui/PythonPanels.cpp
+++ b/Gui/PythonPanels.cpp
@@ -538,7 +538,7 @@ PyPanel::mousePressEvent(QMouseEvent* e)
 }
 
 void
-PyPanel::enterEvent(QEvent* e)
+PyPanel::enterEvent(QtCompat::QEnterEvent* e)
 {
     enterEventBase();
     QWidget::enterEvent(e);

--- a/Gui/PythonPanels.h
+++ b/Gui/PythonPanels.h
@@ -36,6 +36,8 @@ CLANG_DIAG_OFF(uninitialized)
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
+#include "Global/QtCompat.h"
+
 #include "Engine/PyNode.h"
 #include "Engine/ScriptObject.h"
 #include "Engine/Knob.h"
@@ -157,7 +159,7 @@ protected:
 
     void onUserDataChanged();
     virtual void mousePressEvent(QMouseEvent* e) OVERRIDE;
-    virtual void enterEvent(QEvent* e) OVERRIDE;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE;
     virtual void leaveEvent(QEvent* e) OVERRIDE;
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE;
 

--- a/Gui/RightClickableWidget.cpp
+++ b/Gui/RightClickableWidget.cpp
@@ -68,7 +68,7 @@ RightClickableWidget::keyPressEvent(QKeyEvent* e)
 }
 
 void
-RightClickableWidget::enterEvent(QEvent* e)
+RightClickableWidget::enterEvent(QtCompat::QEnterEvent* e)
 {
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );

--- a/Gui/RightClickableWidget.h
+++ b/Gui/RightClickableWidget.h
@@ -39,6 +39,7 @@ CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
 #include "Global/GlobalDefines.h"
+#include "Global/QtCompat.h"
 
 #include "Engine/DockablePanelI.h"
 
@@ -80,7 +81,7 @@ Q_SIGNALS:
 
 private:
 
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE FINAL;
     virtual void mousePressEvent(QMouseEvent* e) OVERRIDE FINAL;
 };

--- a/Gui/ScaleSliderQWidget.cpp
+++ b/Gui/ScaleSliderQWidget.cpp
@@ -277,7 +277,7 @@ ScaleSliderQWidget::zoomRange()
 }
 
 void
-ScaleSliderQWidget::enterEvent(QEvent* e)
+ScaleSliderQWidget::enterEvent(QtCompat::QEnterEvent* e)
 {
     if ( Gui::isFocusStealingPossible() ) {
         setFocus();

--- a/Gui/ScaleSliderQWidget.h
+++ b/Gui/ScaleSliderQWidget.h
@@ -36,6 +36,7 @@ CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
 #include "Global/GlobalDefines.h"
+#include "Global/QtCompat.h"
 
 #include "Gui/GuiFwd.h"
 
@@ -121,7 +122,7 @@ private:
     virtual QSize minimumSizeHint() const OVERRIDE FINAL;
     virtual void paintEvent(QPaintEvent* e) OVERRIDE FINAL;
     virtual void resizeEvent(QResizeEvent* e) OVERRIDE FINAL;
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
     virtual void focusInEvent(QFocusEvent* e) OVERRIDE FINAL;
     virtual void focusOutEvent(QFocusEvent* e) OVERRIDE FINAL;

--- a/Gui/ScriptEditor.cpp
+++ b/Gui/ScriptEditor.cpp
@@ -621,7 +621,7 @@ ScriptEditor::printAutoDeclaredVariable(const QString& str)
 }
 
 void
-ScriptEditor::enterEvent(QEvent *e)
+ScriptEditor::enterEvent(QtCompat::QEnterEvent *e)
 {
     enterEventBase();
     QWidget::enterEvent(e);

--- a/Gui/ScriptEditor.h
+++ b/Gui/ScriptEditor.h
@@ -34,6 +34,8 @@ CLANG_DIAG_OFF(uninitialized)
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
+#include "Global/QtCompat.h"
+
 #include "Gui/PanelWidget.h"
 #include "Gui/GuiFwd.h"
 
@@ -111,7 +113,7 @@ private:
 
     virtual void focusInEvent(QFocusEvent* e) OVERRIDE FINAL;
     virtual void mousePressEvent(QMouseEvent* e) OVERRIDE FINAL;
-    virtual void enterEvent(QEvent *e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent *e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent *e) OVERRIDE FINAL;
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE FINAL;
     virtual void keyReleaseEvent(QKeyEvent* e) OVERRIDE FINAL;

--- a/Gui/ScriptTextEdit.cpp
+++ b/Gui/ScriptTextEdit.cpp
@@ -497,7 +497,7 @@ InputScriptTextEdit::dropEvent(QDropEvent* e)
 }
 
 void
-InputScriptTextEdit::enterEvent(QEvent* /*e*/)
+InputScriptTextEdit::enterEvent(QtCompat::QEnterEvent* /*e*/)
 {
     if ( acceptDrops() && (cursor().shape() != Qt::OpenHandCursor) ) {
         setCursor(Qt::OpenHandCursor);

--- a/Gui/ScriptTextEdit.h
+++ b/Gui/ScriptTextEdit.h
@@ -37,6 +37,8 @@ CLANG_DIAG_OFF(uninitialized)
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
+#include "Global/QtCompat.h"
+
 #include "Gui/GuiFwd.h"
 
 NATRON_NAMESPACE_ENTER
@@ -98,7 +100,7 @@ private:
     virtual void dropEvent(QDropEvent* e) OVERRIDE FINAL;
     virtual void resizeEvent(QResizeEvent *event) OVERRIDE FINAL;
     virtual void dragMoveEvent(QDragMoveEvent* e) OVERRIDE FINAL;
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
 
 private:

--- a/Gui/SpinBox.cpp
+++ b/Gui/SpinBox.cpp
@@ -1000,7 +1000,7 @@ KnobSpinBox::~KnobSpinBox()
 }
 
 void
-KnobSpinBox::enterEvent(QEvent* e)
+KnobSpinBox::enterEvent(QtCompat::QEnterEvent* e)
 {
     _dnd->mouseEnter(e);
     SpinBox::enterEvent(e);

--- a/Gui/SpinBox.h
+++ b/Gui/SpinBox.h
@@ -27,6 +27,7 @@
 // ***** END PYTHON BLOCK *****
 
 #include "Global/Macros.h"
+#include "Global/QtCompat.h"
 
 #include "Gui/LineEdit.h"
 #include "Gui/GuiFwd.h"
@@ -171,7 +172,7 @@ public:
 private:
 
     virtual void wheelEvent(QWheelEvent* e) OVERRIDE FINAL;
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE FINAL;
     virtual void keyReleaseEvent(QKeyEvent* e) OVERRIDE FINAL;

--- a/Gui/TabWidget.cpp
+++ b/Gui/TabWidget.cpp
@@ -2070,7 +2070,7 @@ TabWidget::leaveEvent(QEvent* e)
 }
 
 void
-TabWidget::enterEvent(QEvent* e)
+TabWidget::enterEvent(QtCompat::QEnterEvent* e)
 {
     if (_imp->gui) {
         _imp->gui->setLastEnteredTabWidget(this);

--- a/Gui/TabWidget.h
+++ b/Gui/TabWidget.h
@@ -39,6 +39,8 @@ CLANG_DIAG_OFF(uninitialized)
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
+#include "Global/QtCompat.h"
+
 #include "Gui/GuiFwd.h"
 
 NATRON_NAMESPACE_ENTER
@@ -352,7 +354,7 @@ private:
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE FINAL;
     virtual void mouseMoveEvent(QMouseEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
 
 private:
 

--- a/Gui/TimeLineGui.cpp
+++ b/Gui/TimeLineGui.cpp
@@ -1007,7 +1007,7 @@ TimeLineGui::mouseMoveEvent(QMouseEvent* e)
 } // TimeLineGui::mouseMoveEvent
 
 void
-TimeLineGui::enterEvent(QEvent* e)
+TimeLineGui::enterEvent(QtCompat::QEnterEvent* e)
 {
     _imp->alphaCursor = true;
     update();

--- a/Gui/TimeLineGui.h
+++ b/Gui/TimeLineGui.h
@@ -42,6 +42,7 @@ CLANG_DIAG_ON(uninitialized)
 #include <QOpenGLWidget>
 
 #include "Global/GlobalDefines.h"
+#include "Global/QtCompat.h"
 
 #include "Gui/GuiFwd.h"
 
@@ -166,7 +167,7 @@ private:
     virtual void mouseMoveEvent(QMouseEvent* e) OVERRIDE FINAL;
     virtual void mouseReleaseEvent(QMouseEvent* e) OVERRIDE FINAL;
     virtual void wheelEvent(QWheelEvent* e) OVERRIDE FINAL;
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
     virtual QSize sizeHint() const OVERRIDE FINAL;
 

--- a/Gui/ViewerGL.cpp
+++ b/Gui/ViewerGL.cpp
@@ -3100,7 +3100,7 @@ ViewerGL::focusOutEvent(QFocusEvent* e)
 }
 
 void
-ViewerGL::enterEvent(QEvent* e)
+ViewerGL::enterEvent(QtCompat::QEnterEvent* e)
 {
     // always running in the main thread
     assert( qApp && qApp->thread() == QThread::currentThread() );

--- a/Gui/ViewerGL.h
+++ b/Gui/ViewerGL.h
@@ -38,6 +38,8 @@
 
 #include <QOpenGLWidget>
 
+#include "Global/QtCompat.h"
+
 #include "Engine/OpenGLViewerI.h"
 #include "Engine/ViewIdx.h"
 #include "Engine/EngineFwd.h"
@@ -494,7 +496,7 @@ private:
     virtual void wheelEvent(QWheelEvent* e) OVERRIDE FINAL;
     virtual void focusInEvent(QFocusEvent* e) OVERRIDE FINAL;
     virtual void focusOutEvent(QFocusEvent* e) OVERRIDE FINAL;
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
     virtual void tabletEvent(QTabletEvent* e) OVERRIDE FINAL;
 

--- a/Gui/ViewerTab.h
+++ b/Gui/ViewerTab.h
@@ -30,6 +30,7 @@
 
 #include "Global/GlobalDefines.h"
 #include "Global/KeySymbols.h" // Key
+#include "Global/QtCompat.h"
 
 #include "Engine/RenderStats.h"
 #include "Engine/ViewIdx.h"
@@ -467,7 +468,7 @@ private:
     virtual bool eventFilter(QObject *target, QEvent* e) OVERRIDE FINAL;
     virtual void keyPressEvent(QKeyEvent* e) OVERRIDE FINAL;
     virtual void keyReleaseEvent(QKeyEvent* e) OVERRIDE FINAL;
-    virtual void enterEvent(QEvent* e) OVERRIDE FINAL;
+    virtual void enterEvent(QtCompat::QEnterEvent* e) OVERRIDE FINAL;
     virtual void leaveEvent(QEvent* e) OVERRIDE FINAL;
     virtual QSize minimumSizeHint() const OVERRIDE FINAL;
     virtual QSize sizeHint() const OVERRIDE FINAL;

--- a/Gui/ViewerTab10.cpp
+++ b/Gui/ViewerTab10.cpp
@@ -589,7 +589,7 @@ ViewerTab::previousLayer()
 }
 
 void
-ViewerTab::enterEvent(QEvent* e)
+ViewerTab::enterEvent(QtCompat::QEnterEvent* e)
 {
     enterEventBase();
     QWidget::enterEvent(e);


### PR DESCRIPTION



Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

The signature of QWidget::enterEvent() changed between Qt5 & Qt6. This change simply creates a typedef that provides the correct type based on which version of Qt we are building with.

**Have you tested your changes (if applicable)? If so, how?**

Yes. The [Qt5 installer still builds](https://github.com/acolwell/Natron/actions/runs/14816074143).  It  is also consistent with and a little cleaner than the similar Qt6 changes in #1019 .
