### PR TITLE
Gui/TimeLineGui: set bold text

### DIFF
--- a/Gui/TimeLineGui.cpp
+++ b/Gui/TimeLineGui.cpp
@@ -361,8 +361,7 @@ TimeLineGui::paintGL()
         double screenPixelRatio = _imp->viewerTab->getViewer()->getScreenPixelRatio();
         if (screenPixelRatio != _imp->_screenPixelRatio) {
             _imp->_screenPixelRatio = screenPixelRatio;
-            _imp->_textFont.reset(new QFont(appFont, appFontSize * screenPixelRatio));
-            _imp->_textFont->setBold(true);
+            _imp->_textFont.reset(new QFont(appFont, appFontSize * screenPixelRatio, QFont::Bold));
         }
     }
     assert(_imp->_textFont);

--- a/Gui/TimeLineGui.cpp
+++ b/Gui/TimeLineGui.cpp
@@ -362,6 +362,7 @@ TimeLineGui::paintGL()
         if (screenPixelRatio != _imp->_screenPixelRatio) {
             _imp->_screenPixelRatio = screenPixelRatio;
             _imp->_textFont.reset(new QFont(appFont, appFontSize * screenPixelRatio));
+            _imp->_textFont->setBold(true);
         }
     }
     assert(_imp->_textFont);


### PR DESCRIPTION
Make the text more visible in the timeline. Since Qt5 the text has been very jagged, setting the QFont to bold solves the issue.

Only tested on Linux using Qt 5.15.

### Qt4 (RB-2.5)
![natron-timeline-qt4](https://github.com/user-attachments/assets/eca07a2d-ce34-4a2a-815a-a3e5cac385a1)

### Qt5
![natron-timeline-qt5](https://github.com/user-attachments/assets/2c196df1-75c7-4504-94e6-00972ea47a66)

### Qt5 + bold
![natron-timeline-qt5-bold](https://github.com/user-attachments/assets/9a3e2fd8-0698-4d9c-af6c-94e127942361)
