### PR TITLE
Fix GMIC DLL dependencies in Windows Installer build

### DIFF
--- a/tools/jenkins/genDllVersions.sh
+++ b/tools/jenkins/genDllVersions.sh
@@ -305,6 +305,8 @@ catDll libfftw3-
 catDll libfftw3_threads-
 catDll libcurl-
 catDll libnghttp2-
+catDll libngtcp2-
+catDll libngtcp2_crypto_ossl
 #catDll libbrotlidec
 #catDll libbrotlicommon
 


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

GMIC.ofx now appears to depend on libngtcp2 DLLs. This change updates genDllVersions.sh to include these DLLs in the installer so the plugin can load properly.


**Have you tested your changes (if applicable)? If so, how?**

Yes. Verified the Windows Installer [build successfully again](https://github.com/acolwell/Natron/actions/runs/15468720944)

