### PR TITLE
Change tools/utils/sourceList.py to always output posix paths.

### DIFF
--- a/tools/utils/sourceList.py
+++ b/tools/utils/sourceList.py
@@ -1,7 +1,7 @@
 from xml.etree import ElementTree
 import os
 import sys
-
+from pathlib import PurePath
 
 def list_typesystem_cpp_sources(typesystem, out):
     tree = ElementTree.parse(typesystem)
@@ -15,7 +15,10 @@ def list_typesystem_cpp_sources(typesystem, out):
     sources = [f"{package.lower()}_module_wrapper.cpp"]
     sources.extend([f"{typename.lower()}_wrapper.cpp" for typename in types])
 
-    return [os.path.normpath(os.path.join(out, package, f)) for f in sources]
+    # Return normalized paths that can be consumed by cmake/qmake.
+    # These paths must be in posix form (i.e. have forward slashes) since that
+    # is what cmake/qmake uses internally.
+    return [PurePath(os.path.normpath(os.path.join(out, package, f))).as_posix() for f in sources]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Fixes the script so that it always outputs paths with forward slashes even on Windows when using a Windows native Python build instead of the msys2/cygwin one. Forward slash paths are needed because this is the form qmake/cmake uses internally and is what is expected when they call this build script.


**Have you tested your changes (if applicable)? If so, how?**

Yes. Verified cmake build still works via [Tests action](https://github.com/acolwell/Natron/actions/runs/15548422681).  Verified qmake build still works via [Build installer action](https://github.com/acolwell/Natron/actions/runs/15548411458). Manually verified a cmake build inside VS Code works with both msys2 python and Windows native python.

**Futher details of this pull request**

While technically this isn't needed given our current build scripts, it is helpful to actually have the script output the intended path separators independent of which python is being used. The use of os.path.normpath() introduces the python build dependent behavior as part of its normalization logic on Windows. The PurePath code simply allows us to reliably convert the separators back to the posix style after normalization.
