### PR TITLE
Improve project loading/saving time by using binary format

### DIFF
--- a/Engine/AppInstance.h
+++ b/Engine/AppInstance.h
@@ -218,7 +218,15 @@ public:
     {
     }
 
+    virtual void loadProjectGui(bool /*isAutosave*/, boost::archive::binary_iarchive & /*archive*/) const
+    {
+    }
+
     virtual void saveProjectGui(boost::archive::xml_oarchive & /*archive*/)
+    {
+    }
+
+    virtual void saveProjectGui(boost::archive::binary_oarchive & /*archive*/)
     {
     }
 

--- a/Engine/EngineFwd.h
+++ b/Engine/EngineFwd.h
@@ -39,6 +39,8 @@ namespace boost {
 namespace archive {
 class xml_iarchive;
 class xml_oarchive;
+class binary_iarchive;
+class binary_oarchive;
 }
 namespace serialization {
 class access;

--- a/Engine/Project.cpp
+++ b/Engine/Project.cpp
@@ -287,11 +287,6 @@ Project::loadProjectInternal(const QString & path,
     }
 
     bool ret = false;
-    FStreamsSupport::ifstream ifile;
-    FStreamsSupport::open( &ifile, filePath.toStdString() );
-    if (!ifile) {
-        throw std::runtime_error( tr("Failed to open %1").arg(filePath).toStdString() );
-    }
 
     if ( (NATRON_VERSION_MAJOR == 1) && (NATRON_VERSION_MINOR == 0) && (NATRON_VERSION_REVISION == 0) ) {
         ///Try to determine if the project was made during Natron v1.0.0 - RC2 or RC3 to detect a bug we introduced at that time
@@ -315,21 +310,28 @@ Project::loadProjectInternal(const QString & path,
     }
 
     LoadProjectSplashScreen_RAII __raii_splashscreen__(getApp(), name);
+    bool xml_loaded = false;
 
     try {
-        bool bgProject;
-        boost::archive::xml_iarchive iArchive(ifile);
-        {
-            FlagSetter __raii_loadingProjectInternal__(true, &_imp->isLoadingProjectInternal, &_imp->isLoadingProjectMutex);
+        // XML loading tests first, then binary loading
+        FStreamsSupport::ifstream ifile;
+        FStreamsSupport::open( &ifile, filePath.toStdString());
+        if (ifile) {
+            bool bgProject;
+            boost::archive::xml_iarchive iArchive(ifile);
+            {
+                FlagSetter __raii_loadingProjectInternal__(true, &_imp->isLoadingProjectInternal, &_imp->isLoadingProjectMutex);
 
-            iArchive >> boost::serialization::make_nvp("Background_project", bgProject);
-            ProjectSerialization projectSerializationObj( getApp() );
-            iArchive >> boost::serialization::make_nvp("Project", projectSerializationObj);
-            ret = load(projectSerializationObj, name, path, mustSave);
-        } // __raii_loadingProjectInternal__
+                iArchive >> boost::serialization::make_nvp("Background_project", bgProject);
+                ProjectSerialization projectSerializationObj( getApp() );
+                iArchive >> boost::serialization::make_nvp("Project", projectSerializationObj);
+                ret = load(projectSerializationObj, name, path, mustSave);
+            } // __raii_loadingProjectInternal__
 
-        if (!bgProject) {
-            getApp()->loadProjectGui(isAutoSave, iArchive);
+            if (!bgProject) {
+                getApp()->loadProjectGui(isAutoSave, iArchive);
+            }
+            xml_loaded = true;
         }
     } catch (const std::exception &e) {
         const ProjectBeingLoadedInfo& pInfo = getApp()->getProjectBeingLoadedInfo();
@@ -339,7 +341,6 @@ Project::loadProjectInternal(const QString & path,
             QString message = tr("This project was saved with a more recent version (%1.%2.%3) of %4. Projects are not forward compatible and may only be opened in a version of %4 equal or more recent than the version that saved it.").arg(pInfo.vMajor).arg(pInfo.vMinor).arg(pInfo.vRev).arg(QString::fromUtf8(NATRON_APPLICATION_NAME));
             throw std::runtime_error(message.toStdString());
         }
-        throw std::runtime_error( tr("Unrecognized or damaged project file:").toStdString() + ' ' + e.what());
     } catch (...) {
         const ProjectBeingLoadedInfo& pInfo = getApp()->getProjectBeingLoadedInfo();
         if (pInfo.vMajor > NATRON_VERSION_MAJOR ||
@@ -348,7 +349,48 @@ Project::loadProjectInternal(const QString & path,
             QString message = tr("This project was saved with a more recent version (%1.%2.%3) of %4. Projects are not forward compatible and may only be opened in a version of %4 equal or more recent than the version that saved it.").arg(pInfo.vMajor).arg(pInfo.vMinor).arg(pInfo.vRev).arg(QString::fromUtf8(NATRON_APPLICATION_NAME));
             throw std::runtime_error(message.toStdString());
         }
-        throw std::runtime_error( tr("Unrecognized or damaged project file").toStdString() );
+    }
+
+    if (!xml_loaded){
+        try {
+            FStreamsSupport::ifstream ifile;
+            FStreamsSupport::open( &ifile, filePath.toStdString(), std::ios::in | std::ios::binary );
+            if (!ifile) {
+                throw std::runtime_error( tr("Failed to open %1").arg(filePath).toStdString() );
+            }
+            bool bgProject;
+            boost::archive::binary_iarchive iArchive(ifile);
+            {
+                FlagSetter __raii_loadingProjectInternal__(true, &_imp->isLoadingProjectInternal, &_imp->isLoadingProjectMutex);
+
+                iArchive >> boost::serialization::make_nvp("Background_project", bgProject);
+                ProjectSerialization projectSerializationObj( getApp() );
+                iArchive >> boost::serialization::make_nvp("Project", projectSerializationObj);
+                ret = load(projectSerializationObj, name, path, mustSave);
+            } // __raii_loadingProjectInternal__
+
+            if (!bgProject) {
+                getApp()->loadProjectGui(isAutoSave, iArchive);
+            }
+        } catch (const std::exception &e) {
+            const ProjectBeingLoadedInfo& pInfo = getApp()->getProjectBeingLoadedInfo();
+            if (pInfo.vMajor > NATRON_VERSION_MAJOR ||
+                (pInfo.vMajor == NATRON_VERSION_MAJOR && pInfo.vMinor > NATRON_VERSION_MINOR) ||
+                (pInfo.vMajor == NATRON_VERSION_MAJOR && pInfo.vMinor == NATRON_VERSION_MINOR && pInfo.vRev > NATRON_VERSION_REVISION)) {
+                QString message = tr("This project was saved with a more recent version (%1.%2.%3) of %4. Projects are not forward compatible and may only be opened in a version of %4 equal or more recent than the version that saved it.").arg(pInfo.vMajor).arg(pInfo.vMinor).arg(pInfo.vRev).arg(QString::fromUtf8(NATRON_APPLICATION_NAME));
+                throw std::runtime_error(message.toStdString());
+            }
+            throw std::runtime_error( tr("Unrecognized or damaged project file:").toStdString() + ' ' + e.what());
+        } catch (...) {
+            const ProjectBeingLoadedInfo& pInfo = getApp()->getProjectBeingLoadedInfo();
+            if (pInfo.vMajor > NATRON_VERSION_MAJOR ||
+                (pInfo.vMajor == NATRON_VERSION_MAJOR && pInfo.vMinor > NATRON_VERSION_MINOR) ||
+                (pInfo.vMajor == NATRON_VERSION_MAJOR && pInfo.vMinor == NATRON_VERSION_MINOR && pInfo.vRev > NATRON_VERSION_REVISION)) {
+                QString message = tr("This project was saved with a more recent version (%1.%2.%3) of %4. Projects are not forward compatible and may only be opened in a version of %4 equal or more recent than the version that saved it.").arg(pInfo.vMajor).arg(pInfo.vMinor).arg(pInfo.vRev).arg(QString::fromUtf8(NATRON_APPLICATION_NAME));
+                throw std::runtime_error(message.toStdString());
+            }
+            throw std::runtime_error( tr("Unrecognized or damaged project file").toStdString() );
+        }
     }
 
     Format f;
@@ -599,12 +641,6 @@ Project::saveProjectInternal(const QString & path,
     tmpFilename.append( QString::number( time.toMSecsSinceEpoch() ) );
 
     {
-        FStreamsSupport::ofstream ofile;
-        FStreamsSupport::open( &ofile, tmpFilename.toStdString() );
-        if (!ofile) {
-            throw std::runtime_error( tr("Failed to open file ").toStdString() + tmpFilename.toStdString() );
-        }
-
         ///Fix file paths before saving.
         QString oldProjectPath = QString::fromUtf8( _imp->getProjectPath().c_str() );
 
@@ -615,27 +651,62 @@ Project::saveProjectInternal(const QString & path,
             _imp->natronVersion->setValue( generateUserFriendlyNatronVersionName() );
         }
 
-        try {
-            boost::archive::xml_oarchive oArchive(ofile);
-            bool bgProject = getApp()->isBackground();
-            oArchive << boost::serialization::make_nvp("Background_project", bgProject);
-            ProjectSerialization projectSerializationObj( getApp() );
-            save(&projectSerializationObj);
-            oArchive << boost::serialization::make_nvp("Project", projectSerializationObj);
-            if (!bgProject) {
-                AppInstancePtr app = getApp();
-                if (app) {
-                    app->saveProjectGui(oArchive);
+        if (!appPTR->getCurrentSettings()->saveAsBinary()){
+            try {
+                FStreamsSupport::ofstream ofile;
+                FStreamsSupport::open( &ofile, tmpFilename.toStdString(), std::ios::out);
+                if (!ofile) {
+                    throw std::runtime_error( tr("Failed to open file ").toStdString() + tmpFilename.toStdString() );
                 }
+                boost::archive::xml_oarchive oArchive(ofile);
+                bool bgProject = getApp()->isBackground();
+                oArchive << boost::serialization::make_nvp("Background_project", bgProject);
+                ProjectSerialization projectSerializationObj( getApp() );
+                save(&projectSerializationObj);
+                oArchive << boost::serialization::make_nvp("Project", projectSerializationObj);
+                if (!bgProject) {
+                    AppInstancePtr app = getApp();
+                    if (app) {
+                        app->saveProjectGui(oArchive);
+                    }
+                }
+            } catch (...) {
+                if (!autoSave && updateProjectProperties) {
+                    ///Reset the old project path in case of failure.
+                    _imp->autoSetProjectDirectory(oldProjectPath);
+                }
+                throw;
             }
-        } catch (...) {
-            if (!autoSave && updateProjectProperties) {
-                ///Reset the old project path in case of failure.
-                _imp->autoSetProjectDirectory(oldProjectPath);
-            }
-            throw;
         }
-    } // ofile
+        else
+        {
+            try {
+                FStreamsSupport::ofstream ofile;
+                FStreamsSupport::open( &ofile, tmpFilename.toStdString(), std::ios::out | std::ios::binary);
+                if (!ofile) {
+                    throw std::runtime_error( tr("Failed to open file ").toStdString() + tmpFilename.toStdString() );
+                }
+                boost::archive::binary_oarchive oArchive(ofile);
+                bool bgProject = getApp()->isBackground();
+                oArchive << boost::serialization::make_nvp("Background_project", bgProject);
+                ProjectSerialization projectSerializationObj( getApp() );
+                save(&projectSerializationObj);
+                oArchive << boost::serialization::make_nvp("Project", projectSerializationObj);
+                if (!bgProject) {
+                    AppInstancePtr app = getApp();
+                    if (app) {
+                        app->saveProjectGui(oArchive);
+                    }
+                }
+            } catch (...) {
+                if (!autoSave && updateProjectProperties) {
+                    ///Reset the old project path in case of failure.
+                    _imp->autoSetProjectDirectory(oldProjectPath);
+                }
+                throw;
+            }
+        }
+    }
 
     if (!autoSave) {
         // rotate backups

--- a/Engine/Settings.cpp
+++ b/Engine/Settings.cpp
@@ -207,6 +207,12 @@ Settings::initializeKnobsGeneral()
                                       "last saved), *.~2~ (third last saved).") );
     _generalTab->addKnob(_saveVersions);
 
+    _saveAsBinary = AppManager::createKnob<KnobBool>( this, tr("Save projects as binary") );
+    _saveAsBinary->setName("saveAsBinary");
+    _saveAsBinary->setHintToolTip( tr("When checked, %1 will save projects in a binary format which is faster to load and save. "
+                                      "When unchecked, projects will be saved in a human-readable text format. "
+                                      "Note that the text format is not guaranteed to be stable across versions of %1.").arg( QString::fromUtf8(NATRON_APPLICATION_NAME) ) );
+
     _hostName = AppManager::createKnob<KnobChoice>( this, tr("Appear to plug-ins as") );
     _hostName->setName("pluginHostName");
     _hostName->setHintToolTip( tr("%1 will appear with the name of the selected application to the OpenFX plug-ins. "
@@ -1469,6 +1475,7 @@ Settings::setDefaultValues()
     _autoSaveUnSavedProjects->setDefaultValue(true);
     _autoSaveDelay->setDefaultValue(5, 0);
     _saveVersions->setDefaultValue(1);
+    _saveAsBinary->setDefaultValue(false);
     _hostName->setDefaultValue(0);
     _customHostName->setDefaultValue(NATRON_ORGANIZATION_DOMAIN_TOPLEVEL "." NATRON_ORGANIZATION_DOMAIN_SUB "." NATRON_APPLICATION_NAME);
 
@@ -2910,6 +2917,12 @@ int
 Settings::saveVersions() const
 {
     return _saveVersions->getValue();
+}
+
+bool
+Settings::saveAsBinary() const
+{
+    return _saveAsBinary->getValue();
 }
 
 

--- a/Engine/Settings.h
+++ b/Engine/Settings.h
@@ -181,6 +181,8 @@ public:
 
     int saveVersions() const;
 
+    bool saveAsBinary() const;
+
     bool isSnapToNodeEnabled() const;
 
     bool isCheckForUpdatesEnabled() const;
@@ -434,6 +436,7 @@ private:
     KnobBoolPtr _autoSaveUnSavedProjects;
     KnobIntPtr _autoSaveDelay;
     KnobIntPtr _saveVersions;
+    KnobBoolPtr _saveAsBinary;
     KnobChoicePtr _hostName;
     KnobStringPtr _customHostName;
 

--- a/Gui/Gui.h
+++ b/Gui/Gui.h
@@ -305,8 +305,10 @@ public:
     static QPixmap screenShot(QWidget* w);
 
     void loadProjectGui(bool isAutosave, boost::archive::xml_iarchive & obj) const;
+    void loadProjectGui(bool isAutosave, boost::archive::binary_iarchive & obj) const;
 
     void saveProjectGui(boost::archive::xml_oarchive & archive);
+    void saveProjectGui(boost::archive::binary_oarchive & archive);
 
     void setColorPickersColor(double r, double g, double b, double a);
 

--- a/Gui/Gui20.cpp
+++ b/Gui/Gui20.cpp
@@ -1466,7 +1466,21 @@ Gui::loadProjectGui(bool isAutosave, boost::archive::xml_iarchive & obj) const
 }
 
 void
+Gui::loadProjectGui(bool isAutosave, boost::archive::binary_iarchive & obj) const
+{
+    assert(_imp->_projectGui);
+    _imp->_projectGui->load(isAutosave, obj);
+}
+
+void
 Gui::saveProjectGui(boost::archive::xml_oarchive & archive)
+{
+    assert(_imp->_projectGui);
+    _imp->_projectGui->save(archive);
+}
+
+void
+Gui::saveProjectGui(boost::archive::binary_oarchive & archive)
 {
     assert(_imp->_projectGui);
     _imp->_projectGui->save(archive);

--- a/Gui/GuiAppInstance.cpp
+++ b/Gui/GuiAppInstance.cpp
@@ -789,7 +789,21 @@ GuiAppInstance::loadProjectGui(bool isAutosave, boost::archive::xml_iarchive & a
 }
 
 void
+GuiAppInstance::loadProjectGui(bool isAutosave, boost::archive::binary_iarchive & archive) const
+{
+    _imp->_gui->loadProjectGui(isAutosave, archive);
+}
+
+void
 GuiAppInstance::saveProjectGui(boost::archive::xml_oarchive & archive)
+{
+    if (_imp->_gui) {
+        _imp->_gui->saveProjectGui(archive);
+    }
+}
+
+void
+GuiAppInstance::saveProjectGui(boost::archive::binary_oarchive & archive)
 {
     if (_imp->_gui) {
         _imp->_gui->saveProjectGui(archive);

--- a/Gui/GuiAppInstance.h
+++ b/Gui/GuiAppInstance.h
@@ -132,7 +132,9 @@ public:
                                               Natron::StandardButtonEnum defaultButton,
                                               bool* stopAsking) OVERRIDE FINAL WARN_UNUSED_RETURN;
     virtual void loadProjectGui(bool isAutosave,  boost::archive::xml_iarchive & archive) const OVERRIDE FINAL;
+    virtual void loadProjectGui(bool isAutosave,  boost::archive::binary_iarchive & archive) const OVERRIDE FINAL;
     virtual void saveProjectGui(boost::archive::xml_oarchive & archive) OVERRIDE FINAL;
+    virtual void saveProjectGui(boost::archive::binary_oarchive & archive) OVERRIDE FINAL;
     virtual void notifyRenderStarted(const QString & sequenceName,
                                      int firstFrame, int lastFrame,
                                      int frameStep, bool canPause,

--- a/Gui/ProjectGui.cpp
+++ b/Gui/ProjectGui.cpp
@@ -261,10 +261,18 @@ AddFormatDialog::getFormat() const
     return Format(0, 0, w, h, name.toStdString(), pa);
 }
 
-// Version is handled in ProjectGuiSerialization
-template<>
+template
 void
-ProjectGui::save<boost::archive::xml_oarchive>(boost::archive::xml_oarchive & archive) const
+ProjectGui::save<boost::archive::xml_oarchive>(boost::archive::xml_oarchive & archive) const;
+
+template
+void
+ProjectGui::save<boost::archive::binary_oarchive>(boost::archive::binary_oarchive & archive) const;
+
+// Version is handled in ProjectGuiSerialization
+template<class Archive>
+void
+ProjectGui::save(Archive & archive) const
 {
     ProjectGuiSerialization projectGuiSerializationObj;
 
@@ -430,9 +438,15 @@ loadNodeGuiSerialization(Gui* gui,
     }
 } // loadNodeGuiSerialization
 
-template<>
+template void
+ProjectGui::load<boost::archive::xml_iarchive>(bool isAutosave,  boost::archive::xml_iarchive & archive);
+
+template void
+ProjectGui::load<boost::archive::binary_iarchive>(bool isAutosave,  boost::archive::binary_iarchive & archive);
+
+template<class Archive>
 void
-ProjectGui::load<boost::archive::xml_iarchive>(bool isAutosave,  boost::archive::xml_iarchive & archive)
+ProjectGui::load(bool isAutosave,  Archive & archive)
 {
     ProjectGuiSerialization obj;
 

--- a/Gui/ProjectGuiSerialization.h
+++ b/Gui/ProjectGuiSerialization.h
@@ -38,6 +38,8 @@ GCC_DIAG_OFF(unused-parameter)
 // /opt/local/include/boost/serialization/smart_cast.hpp:254:25: warning: unused parameter 'u' [-Wunused-parameter]
 #include <boost/archive/xml_iarchive.hpp>
 #include <boost/archive/xml_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
 #include <boost/serialization/list.hpp>
 #include <boost/serialization/map.hpp>
 // /usr/local/include/boost/serialization/shared_ptr.hpp:112:5: warning: unused typedef 'boost_static_assert_typedef_112' [-Wunused-local-typedef]


### PR DESCRIPTION
- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [ ] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [ ] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

Add the possibility to load/save project in binary format to speed it up. Some of my projects could take several seconds to serialize and deserialize. Now the project is saved and restored almost immediately.
The XML format is still the default choice, but the preference panel gives the ability to switch.

**What type of PR is this? (Check one of the boxes below)**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Saving a project was way too long, and the autosave feature slows down your workflow

**Have you tested your changes (if applicable)? If so, how?**

Several tests with and without.

