### PR TITLE
Replace WINDOWS with WIN32 in CMakeLists.txt

### DIFF
--- a/App/CMakeLists.txt
+++ b/App/CMakeLists.txt
@@ -18,7 +18,7 @@
 # ***** END LICENSE BLOCK *****
 
 set(Natron_SOURCES NatronApp_main.cpp)
-if(WINDOWS)
+if(WIN32)
     list(APPEND Natron_SOURCES ../Natron.rc)
 endif()
 add_executable(Natron ${Natron_SOURCES})

--- a/Renderer/CMakeLists.txt
+++ b/Renderer/CMakeLists.txt
@@ -18,7 +18,7 @@
 # ***** END LICENSE BLOCK *****
 
 set(NatronRenderer_SOURCES NatronRenderer_main.cpp)
-if(WINDOWS)
+if(WIN32)
     list(APPEND NatronRenderer_SOURCES ../Natron.rc)
 endif()
 add_executable(NatronRenderer ${NatronRenderer_SOURCES})

--- a/libs/gflags/CMakeLists.txt
+++ b/libs/gflags/CMakeLists.txt
@@ -30,7 +30,7 @@ set(gflags_SOURCES
     src/gflags_completions.cc
     src/gflags_reporting.cc
 )
-if(WINDOWS)
+if(WIN32)
     set(gflags_HEADERS ${gflags_HEADERS} src/windows_port.h)
     set(gflags_SOURCES ${gflags_SOURCES} src/windows_port.cc)
 endif()


### PR DESCRIPTION
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Additionally, make sure you've done all of these things:

- [x] I've followed the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CODE_OF_CONDUCT.md) to the best of my understanding
- [x] I've read and understood the [contributing guidelines](https://github.com/NatronGitHub/Natron/blob/RB-2.4/CONTRIBUTING.md)
- [x] I've formatted my code according to Natron's [code style]([#](https://github.com/NatronGitHub/Natron#logistics))
- [x] I've searched the [pull requests tracker](https://github.com/NatronGitHub/Natron/pulls?q=is%3Apr) to ensure that this PR is not a duplicate

## PR Description

**What type of PR is this? (Check one of the boxes below)**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality nor fixes a bug but improves Natron in some way)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
    - [ ] I have updated the documentation accordingly

**What does this pull request do?**

Fixes Windows specific code in CMake files by using the proper platform variable for Windows.

This is a slightly modified version of @cedricp changes proposed in #1040.

**Have you tested your changes (if applicable)? If so, how?**

Built locally and verified Windows specific files were properly included on Windows build.

