### PR TITLE
Replace the Qt6-removed APIs that have Qt5 equivalents

### DIFF
--- a/Engine/CLArgs.cpp
+++ b/Engine/CLArgs.cpp
@@ -39,6 +39,7 @@
 #include <QDebug>
 #include <QFile>
 #include <QFileInfo>
+#include <QRegularExpression>
 
 #include "Global/GlobalDefines.h"
 #include "Global/GitVersion.h"
@@ -1139,10 +1140,10 @@ CLArgsPrivate::parse()
         // A clean solution would be to separate the scriptName and the fileName with a comma.
         if ( it != args.end() && !it->startsWith( QChar::fromLatin1('-') ) ) {
             // Check that it's neither a python script, a natron project, nor a frame range.
-            QRegExp re( QString::fromUtf8("[0-9\\-,]*") ); // Matches frame ranges.
+            QRegularExpression re( QRegularExpression::anchoredPattern( QString::fromUtf8("[0-9\\-,]*") ) ); // Matches frame ranges.
             if (!it->endsWith(QString::fromUtf8(".py"), Qt::CaseInsensitive) &&
                 !it->endsWith(QString::fromUtf8(".ntp"), Qt::CaseInsensitive) &&
-                !re.exactMatch(*it)) {
+                !re.match(*it).hasMatch()) {
                 w.filename = *it;
 #ifdef __NATRON_UNIX__
                 w.filename = AppManager::qt_tildeExpansion(w.filename);

--- a/Engine/FileSystemModel.cpp
+++ b/Engine/FileSystemModel.cpp
@@ -47,6 +47,7 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QDebug>
 #include <QUrl>
 #include <QMimeData>
+#include <QRegularExpression>
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
@@ -193,7 +194,7 @@ struct FileSystemModelPrivate
     QStringList headers;
     QDir::Filters filters;
     QString encodedRegexps;
-    std::list<QRegExp> regexps;
+    std::list<QRegularExpression> regexps;
     mutable QMutex filtersMutex;
     mutable QMutex sequenceModeEnabledMutex;
     bool sequenceModeEnabled;
@@ -1041,7 +1042,8 @@ FileSystemModel::setRegexpFilters(const QString& filters)
                 ++i;
             }
             if ( regExp != QString( QLatin1Char('*') ) ) {
-                QRegExp rx(regExp, Qt::CaseInsensitive, QRegExp::Wildcard);
+                QRegularExpression rx(QRegularExpression::wildcardToRegularExpression(regExp),
+                                      QRegularExpression::CaseInsensitiveOption);
                 if ( rx.isValid() ) {
                     _imp->regexps.push_back(rx);
                 }
@@ -1082,8 +1084,8 @@ FileSystemModel::isAcceptedByRegexps(const QString & path) const
         return true;
     }
 
-    for (std::list<QRegExp>::const_iterator it = _imp->regexps.begin(); it != _imp->regexps.end(); ++it) {
-        if ( it->exactMatch(path) ) {
+    for (std::list<QRegularExpression>::const_iterator it = _imp->regexps.begin(); it != _imp->regexps.end(); ++it) {
+        if ( it->match(path).hasMatch() ) {
             return true;
         }
     }

--- a/Engine/Markdown.cpp
+++ b/Engine/Markdown.cpp
@@ -30,7 +30,7 @@
 CLANG_DIAG_OFF(deprecated)
 CLANG_DIAG_OFF(uninitialized)
 #include <QTextStream>
-#include <QRegExp>
+#include <QRegularExpression>
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
@@ -79,7 +79,7 @@ QString
 Markdown::parseCustomLinksForHTML(const QString& markdown)
 {
     QString result = markdown;
-    QRegExp rx( QString::fromUtf8("(\\|html::[^|]*\\|)\\|rst::[^|]*\\|") );
+    QRegularExpression rx( QString::fromUtf8("(\\|html::[^|]*\\|)\\|rst::[^|]*\\|") );
     result.replace( rx, QString::fromUtf8("\\1") );
 
     return result;
@@ -105,9 +105,9 @@ Markdown::fixSettingsHTML(const QString &html)
     QStringList list = html.split( QString::fromUtf8("\n") );
     Q_FOREACH(const QString &line, list) {
         if ( line.startsWith(QString::fromUtf8("<h2>")) ) {
-            QRegExp rx( QString::fromUtf8("<h2>(.*)</h2>") );
-            rx.indexIn(line);
-            QString header = rx.cap(1);
+            QRegularExpression rx( QString::fromUtf8("<h2>(.*)</h2>") );
+            QRegularExpressionMatch match = rx.match(line);
+            QString header = match.captured(1);
             QString headerLink = header.toLower();
             headerLink.replace( QString::fromUtf8(" "), QString::fromUtf8("-") );
             result.append(QString::fromUtf8("<h2 id=\"%1\">%2</h2>").arg(headerLink).arg(header));

--- a/Engine/Node.cpp
+++ b/Engine/Node.cpp
@@ -42,7 +42,6 @@
 #include <QWaitCondition>
 #include <QTextStream>
 #include <QFile>
-#include <QRegExp>
 
 #include <ofxNatron.h>
 

--- a/Engine/NodeDocumentation.cpp
+++ b/Engine/NodeDocumentation.cpp
@@ -27,6 +27,7 @@
 
 #include <QTextStream>
 #include <QFile>
+#include <QRegularExpression>
 
 #include "Engine/EffectInstance.h"
 #include "Engine/KnobTypes.h"
@@ -409,7 +410,7 @@ Node::makeDocumentation(bool genHTML) const
             pluginDescription = NATRON_NAMESPACE::convertFromPlainText(pluginDescription, NATRON_NAMESPACE::WhiteSpaceNormal);
 
             // replace URLs with links
-            QRegExp re( QString::fromUtf8("((http|ftp|https)://([\\w_-]+(?:(?:\\.[\\w_-]+)+))([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])?)") );
+            QRegularExpression re( QString::fromUtf8("((http|ftp|https)://([\\w_-]+(?:(?:\\.[\\w_-]+)+))([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])?)") );
             pluginDescription.replace( re, QString::fromUtf8("<a href=\"\\1\">\\1</a>") );
         } else {
             pluginDescription = convertFromPlainTextToMarkdown(pluginDescription, genHTML, false);

--- a/Engine/OutputEffectInstance.cpp
+++ b/Engine/OutputEffectInstance.cpp
@@ -35,7 +35,7 @@
 #include <QReadWriteLock>
 #include <QCoreApplication>
 #include <QThread>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QtConcurrentMap> // QtCore on Qt4, QtConcurrent on Qt5
 #include <QtConcurrentRun> // QtCore on Qt4, QtConcurrent on Qt5
 
@@ -268,7 +268,7 @@ OutputEffectInstance::renderFullSequence(bool isBlocking,
         std::size_t foundHash = pattern.find_first_of("#");
         if (foundHash == std::string::npos) {
             // Look for printf style numbering
-            QRegExp exp(QString::fromUtf8("%[0-9]*d"));
+            QRegularExpression exp( QString::fromUtf8("%[0-9]*d") );
             QString qp(QString::fromUtf8(pattern.c_str()));
             if (!qp.contains(exp)) {
                 QString message = tr("You are trying to render the frame range [%1 - %2] but you did not specify any hash ('#') character(s) or printf-like format ('%d') for the padding. This will result in the same image being overwritten multiple times.").arg(first).arg(last);

--- a/Engine/Project.cpp
+++ b/Engine/Project.cpp
@@ -54,6 +54,7 @@
 #include <QDebug>
 #include <QTextStream>
 #include <QHostInfo>
+#include <QRegularExpression>
 #include <QtConcurrentRun> // QtCore on Qt4, QtConcurrent on Qt5
 
 #include <ofxhXml.h> // OFX::XML::escape
@@ -504,7 +505,7 @@ findBackups(const QString & filePath)
         ret.append(filePath);
     }
     // find files matching filePath.~[0-9]+~
-    QRegExp rx(QString::fromUtf8("\\.~(\\d+)~$"));
+    QRegularExpression rx( QString::fromUtf8("\\.~(\\d+)~$") );
     QFileInfo fileInfo(filePath);
     QString fileName = fileInfo.fileName();
     QDirIterator it(fileInfo.dir());
@@ -518,7 +519,11 @@ findBackups(const QString & filePath)
 
         // If the filename contains target string - put it in the hitlist
         QString fn = file.fileName();
-        if (fn.startsWith(fileName) && rx.lastIndexIn(fn) == fileName.size()) {
+        // The pattern ends with $, so there is at most one match and
+        // lastIndexIn() is just that match.
+        QRegularExpressionMatch backupMatch = rx.match(fn);
+        if ( fn.startsWith(fileName) && backupMatch.hasMatch() &&
+             ( backupMatch.capturedStart() == fileName.size() ) ) {
             ret.append(file.filePath());
         }
     }
@@ -532,11 +537,11 @@ findBackups(const QString & filePath)
 static QString
 nextBackup(const QString & filePath)
 {
-    QRegExp rx(QString::fromUtf8("\\.~(\\d+)~$"));
-    int pos = rx.lastIndexIn(filePath);
-    if (pos >= 0) {
-        int i = rx.cap(1).toInt();
-        return filePath.left(pos) + QString::fromUtf8(".~%1~").arg(i+1);
+    QRegularExpression rx( QString::fromUtf8("\\.~(\\d+)~$") );
+    QRegularExpressionMatch match = rx.match(filePath);
+    if ( match.hasMatch() ) {
+        int i = match.captured(1).toInt();
+        return filePath.left( match.capturedStart() ) + QString::fromUtf8(".~%1~").arg(i+1);
     } else {
         return filePath + QString::fromUtf8(".~1~");
     }

--- a/Engine/VariantSerialization.h
+++ b/Engine/VariantSerialization.h
@@ -55,45 +55,48 @@ Variant::save(Archive & ar,
               const unsigned int version) const
 {
     Q_UNUSED(version);
-    QVariant::Type t = type();
+    // QVariant::Type and QVariant::type() are deprecated in Qt6 in favour of
+    // the metatype id. userType() returns that id in both Qt 5.15 and Qt 6, and
+    // the QMetaType constants below are the same values QVariant::Type used.
+    const int t = userType();
     std::string typeStr;
     switch (t) {
-    case QVariant::Bool: {
+    case QMetaType::Bool: {
         bool v = toBool();
         typeStr = "bool";
         ar & ::boost::serialization::make_nvp("Type", typeStr);
         ar & ::boost::serialization::make_nvp("Value", v);
         break;
     }
-    case QVariant::Int: {
+    case QMetaType::Int: {
         int v = toInt();
         typeStr = "int";
         ar & ::boost::serialization::make_nvp("Type", typeStr);
         ar & ::boost::serialization::make_nvp("Value", v);
         break;
     }
-    case QVariant::UInt: {
+    case QMetaType::UInt: {
         int v = toUInt();
         typeStr = "uint";
         ar & ::boost::serialization::make_nvp("Type", typeStr);
         ar & ::boost::serialization::make_nvp("Value", v);
         break;
     }
-    case QVariant::Double: {
+    case QMetaType::Double: {
         double v = toDouble();
         typeStr = "double";
         ar & ::boost::serialization::make_nvp("Type", typeStr);
         ar & ::boost::serialization::make_nvp("Value", v);
         break;
     }
-    case QVariant::String: {
+    case QMetaType::QString: {
         typeStr = "string";
         ar & ::boost::serialization::make_nvp("Type", typeStr);
         std::string str = toString().toStdString();
         ar & ::boost::serialization::make_nvp("Value", str);
         break;
     }
-    case QVariant::StringList: {
+    case QMetaType::QStringList: {
         typeStr = "stringlist";
         ar & ::boost::serialization::make_nvp("Type", typeStr);
         std::list<std::string> list;

--- a/Gui/FileTypeMainWindow_win.cpp
+++ b/Gui/FileTypeMainWindow_win.cpp
@@ -51,7 +51,7 @@
 #include <QApplication>
 #include <QDir>
 #include <QFileInfo>
-#include <QRegExp>
+#include <QRegularExpression>
 
 NATRON_NAMESPACE_ENTER
 
@@ -283,9 +283,10 @@ DocumentWindow::ddeExecute(MSG* message,
         return true;
     }
 
-    QRegExp regCommand( QString::fromUtf8("^\\[(\\w+)\\((.*)\\)\\]$") );
-    if ( regCommand.exactMatch(command) ) {
-        executeDdeCommand( regCommand.cap(1), regCommand.cap(2) );
+    QRegularExpression regCommand( QString::fromUtf8("^\\[(\\w+)\\((.*)\\)\\]$") );
+    const QRegularExpressionMatch commandMatch = regCommand.match(command);
+    if ( commandMatch.hasMatch() ) {
+        executeDdeCommand( commandMatch.captured(1), commandMatch.captured(2) );
     }
 
     *result = 0;
@@ -345,15 +346,16 @@ void
 DocumentWindow::executeDdeCommand(const QString& command,
                                   const QString& params)
 {
-    QRegExp regCommand( QString::fromUtf8("^\"(.*)\"$") );
-    bool singleCommand = regCommand.exactMatch(params);
+    QRegularExpression regCommand( QString::fromUtf8("^\"(.*)\"$") );
+    const QRegularExpressionMatch paramsMatch = regCommand.match(params);
+    bool singleCommand = paramsMatch.hasMatch();
 
     if ( ( 0 == command.compare(QString::fromUtf8("open"), Qt::CaseInsensitive) ) && singleCommand ) {
-        ddeOpenFile( regCommand.cap(1) );
+        ddeOpenFile( paramsMatch.captured(1) );
     } else if ( ( 0 == command.compare(QString::fromUtf8("new"), Qt::CaseInsensitive) ) && singleCommand ) {
-        ddeNewFile( regCommand.cap(1) );
+        ddeNewFile( paramsMatch.captured(1) );
     } else if ( ( 0 == command.compare(QString::fromUtf8("print"), Qt::CaseInsensitive) ) && singleCommand ) {
-        ddePrintFile( regCommand.cap(1) );
+        ddePrintFile( paramsMatch.captured(1) );
     } else {
         executeUnknownDdeCommand(command, params);
     }

--- a/Gui/GuiApplicationManager10.cpp
+++ b/Gui/GuiApplicationManager10.cpp
@@ -41,7 +41,8 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QSettings>
 #include <QFileInfo>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QGuiApplication>
+#include <QScreen>
 #include <QFileOpenEvent>
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
@@ -299,9 +300,11 @@ GuiApplicationManager::initializeQApp(int &argc,
 #endif
         app = new Application(this, argc, argv);
     }
-    QDesktopWidget* desktop = app->desktop();
-    int dpiX = desktop->logicalDpiX();
-    int dpiY = desktop->logicalDpiY();
+    // QDesktopWidget is gone in Qt6; QScreen carries the same values and exists
+    // in Qt 5.15. Keep the int truncation the QDesktopWidget accessors did.
+    QScreen* screen = QGuiApplication::primaryScreen();
+    int dpiX = screen->logicalDotsPerInchX();
+    int dpiY = screen->logicalDotsPerInchY();
 
     setCurrentLogicalDPI(dpiX, dpiY);
 

--- a/Gui/Histogram.cpp
+++ b/Gui/Histogram.cpp
@@ -32,7 +32,6 @@
 #include <QVBoxLayout>
 #include <QCheckBox>
 #include <QSplitter>
-#include <QDesktopWidget>
 GCC_DIAG_UNUSED_PRIVATE_FIELD_OFF
 // /opt/local/include/QtGui/qmime.h:119:10: warning: private field 'type' is not used [-Wunused-private-field]
 #include <QMouseEvent>

--- a/Gui/MessageBox.cpp
+++ b/Gui/MessageBox.cpp
@@ -38,7 +38,6 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QCheckBox>
 #include <QTextEdit>
 #include <QApplication>
-#include <QDesktopWidget>
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
@@ -183,7 +182,7 @@ MessageBox::init(const QString & title,
     // -- leave space for information label --
     grid->addWidget(_imp->buttonBox, 2, 0, 1, 2);
 #else
-    grid->setMargin(0);
+    grid->setContentsMargins(0, 0, 0, 0);
     grid->setVerticalSpacing(8);
     grid->setHorizontalSpacing(0);
     setContentsMargins(24, 15, 24, 20);

--- a/Gui/NodeCreationDialog.cpp
+++ b/Gui/NodeCreationDialog.cpp
@@ -37,7 +37,6 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QApplication>
 #include <QListView>
 #include <QSettings>
-#include <QDesktopWidget>
 #include <QRegExp>
 #include <QApplication>
 #include <QStringListModel>

--- a/Gui/NodeCreationDialog.cpp
+++ b/Gui/NodeCreationDialog.cpp
@@ -37,7 +37,7 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QApplication>
 #include <QListView>
 #include <QSettings>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QApplication>
 #include <QStringListModel>
 CLANG_DIAG_ON(deprecated)
@@ -150,13 +150,17 @@ CompleterLineEdit::filterText(const QString & txt)
             pattern.push_back(txt[i]);
         }
         pattern.push_back( QLatin1Char('*') );
-        QRegExp expr(pattern, Qt::CaseInsensitive, QRegExp::WildcardUnix);
+        // The pattern is wildcarded at both ends, so the anchored conversion
+        // matches exactly what exactMatch() and contains() did.
+        QRegularExpression expr(QRegularExpression::wildcardToRegularExpression(pattern),
+                                QRegularExpression::CaseInsensitiveOption);
 
 #ifdef NODE_TAB_DIALOG_USE_MATCHED_LENGTH
         std::map<int, QStringList> matchOrdered;
         for (PluginsNamesMap::iterator it = _imp->names.begin(); it != _imp->names.end(); ++it) {
-            if ( expr.exactMatch(it->second.first) ) {
-                QStringList& matchedForLength =  matchOrdered[expr.matchedLength()];
+            QRegularExpressionMatch match = expr.match(it->second.first);
+            if ( match.hasMatch() ) {
+                QStringList& matchedForLength =  matchOrdered[match.capturedLength()];
                 matchedForLength.push_front(it->second.second);
             }
         }

--- a/Gui/NodeGraph45.cpp
+++ b/Gui/NodeGraph45.cpp
@@ -38,6 +38,7 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QKeyEvent>
 #include <QApplication>
 #include <QCheckBox>
+#include <QRegularExpression>
 GCC_DIAG_UNUSED_PRIVATE_FIELD_ON
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
@@ -368,14 +369,17 @@ FindNodeDialog::updateFindResults(const QString& filter)
     }
     Qt::CaseSensitivity sensitivity = _imp->caseSensitivity->isChecked() ? Qt::CaseSensitive : Qt::CaseInsensitive;
     const NodesGuiList& activeNodes = _imp->graph->getAllActiveNodes();
-    QRegExp exp(_imp->matchWhole->isChecked() ? filter :
-                ( QChar::fromLatin1('*') + filter + QChar::fromLatin1('*') ),
-                sensitivity,
-                QRegExp::Wildcard);
+    // wildcardToRegularExpression() anchors, which is what exactMatch() did.
+    QRegularExpression exp(QRegularExpression::wildcardToRegularExpression(
+                               _imp->matchWhole->isChecked() ? filter :
+                               ( QChar::fromLatin1('*') + filter + QChar::fromLatin1('*') ) ),
+                           sensitivity == Qt::CaseInsensitive ?
+                           QRegularExpression::CaseInsensitiveOption :
+                           QRegularExpression::NoPatternOption);
 
     if ( exp.isValid() ) {
         for (NodesGuiList::const_iterator it = activeNodes.begin(); it != activeNodes.end(); ++it) {
-            if ( (*it)->isVisible() && exp.exactMatch( QString::fromUtf8( (*it)->getNode()->getLabel().c_str() ) ) ) {
+            if ( (*it)->isVisible() && exp.match( QString::fromUtf8( (*it)->getNode()->getLabel().c_str() ) ).hasMatch() ) {
                 _imp->nodeResults.push_back(*it);
             }
         }

--- a/Gui/PreferencesPanel.cpp
+++ b/Gui/PreferencesPanel.cpp
@@ -819,7 +819,10 @@ PreferencesPanel::filterPlugins(const QString & txt)
             pattern.push_back(txt[i]);
         }
         pattern.push_back( QLatin1Char('*') );
-        QRegExp expr(pattern, Qt::CaseInsensitive, QRegExp::WildcardUnix);
+        // The pattern is wildcarded at both ends, so the anchored conversion
+        // matches exactly what the unanchored contains() did.
+        QRegularExpression expr(QRegularExpression::wildcardToRegularExpression(pattern),
+                                QRegularExpression::CaseInsensitiveOption);
         std::list<QTreeWidgetItem*> itemsToDisplay;
         for (PluginTreeNodeList::iterator it = _imp->pluginsList.begin(); it != _imp->pluginsList.end(); ++it) {
             if ( it->plugin && it->plugin->getLabelWithoutSuffix().contains(expr) ) {

--- a/Gui/RenderStatsDialog.cpp
+++ b/Gui/RenderStatsDialog.cpp
@@ -34,7 +34,7 @@
 #include <QHeaderView>
 #include <QCheckBox>
 #include <QItemSelectionModel>
-#include <QRegExp>
+#include <QRegularExpression>
 
 #include "Engine/Node.h"
 #include "Engine/Timer.h"
@@ -1010,12 +1010,14 @@ RenderStatsDialogPrivate::updateVisibleRowsInternal(const QString& nameFilter,
 
 
     if ( useUnixWildcardsCheckbox->isChecked() ) {
-        QRegExp nameExpr(nameFilter, Qt::CaseInsensitive, QRegExp::Wildcard);
+        QRegularExpression nameExpr(QRegularExpression::wildcardToRegularExpression(nameFilter),
+                                    QRegularExpression::CaseInsensitiveOption);
         if ( !nameExpr.isValid() ) {
             return;
         }
 
-        QRegExp idExpr(pluginIDFilter, Qt::CaseInsensitive, QRegExp::Wildcard);
+        QRegularExpression idExpr(QRegularExpression::wildcardToRegularExpression(pluginIDFilter),
+                                  QRegularExpression::CaseInsensitiveOption);
         if ( !idExpr.isValid() ) {
             return;
         }
@@ -1028,8 +1030,8 @@ RenderStatsDialogPrivate::updateVisibleRowsInternal(const QString& nameFilter,
                 continue;
             }
 
-            if ( ( nameFilter.isEmpty() || nameExpr.exactMatch( QString::fromUtf8( node->getLabel().c_str() ) ) ) &&
-                 ( pluginIDFilter.isEmpty() || idExpr.exactMatch( QString::fromUtf8( node->getPluginID().c_str() ) ) ) ) {
+            if ( ( nameFilter.isEmpty() || nameExpr.match( QString::fromUtf8( node->getLabel().c_str() ) ).hasMatch() ) &&
+                 ( pluginIDFilter.isEmpty() || idExpr.match( QString::fromUtf8( node->getPluginID().c_str() ) ).hasMatch() ) ) {
                 if ( view->isRowHidden(i, rootIdx) ) {
                     view->setRowHidden(i, rootIdx, false);
                 }

--- a/Gui/ScriptTextEdit.cpp
+++ b/Gui/ScriptTextEdit.cpp
@@ -33,7 +33,7 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QScrollBar>
 #include <QTextBlock>
 #include <QPainter>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QMimeData>
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
@@ -58,13 +58,13 @@ struct PyHighLightRule
                     const QTextCharFormat &matchingFormat)
     {
         originalRuleStr = patternStr;
-        pattern = QRegExp(patternStr);
+        pattern = QRegularExpression(patternStr);
         nth = n;
         format = matchingFormat;
     }
 
     QString originalRuleStr;
-    QRegExp pattern;
+    QRegularExpression pattern;
     int nth;
     QTextCharFormat format;
 };
@@ -77,8 +77,8 @@ struct PySyntaxHighlighterPrivate
     QStringList braces;
     QHash<QString, QTextCharFormat> basicStyles;
     QList<PyHighLightRule> rules;
-    QRegExp triSingleQuote;
-    QRegExp triDoubleQuote;
+    QRegularExpression triSingleQuote;
+    QRegularExpression triDoubleQuote;
 
     PySyntaxHighlighterPrivate(PySyntaxHighlighter* publicInterface)
         : publicInterface(publicInterface)
@@ -125,13 +125,17 @@ void
 PySyntaxHighlighter::highlightBlock(const QString &text)
 {
     for (QList<PyHighLightRule>::Iterator it = _imp->rules.begin(); it != _imp->rules.end(); ++it) {
-        int idx = it->pattern.indexIn(text, 0);
-        while (idx >= 0) {
+        QRegularExpressionMatch match = it->pattern.match(text, 0);
+        while ( match.hasMatch() ) {
             // Get index of Nth match
-            idx = it->pattern.pos(it->nth);
-            int length = it->pattern.cap(it->nth).length();
+            const int idx = match.capturedStart(it->nth);
+            if (idx < 0) {
+                // The Nth group did not participate in this match.
+                break;
+            }
+            const int length = match.capturedLength(it->nth);
             setFormat(idx, length, it->format);
-            idx = it->pattern.indexIn(text, idx + length);
+            match = it->pattern.match(text, idx + length);
         }
     }
 
@@ -186,7 +190,7 @@ PySyntaxHighlighterPrivate::initializeRules()
 
 bool
 PySyntaxHighlighter::matchMultiline(const QString &text,
-                                    const QRegExp &delimiter,
+                                    const QRegularExpression &delimiter,
                                     const int inState,
                                     const QTextCharFormat &style)
 {
@@ -201,18 +205,20 @@ PySyntaxHighlighter::matchMultiline(const QString &text,
         start = 0;
         add = 0;
     } else {
-        start = delimiter.indexIn(text);
+        const QRegularExpressionMatch startMatch = delimiter.match(text);
+        start = startMatch.capturedStart();
         // Move past this match
-        add = delimiter.matchedLength();
+        add = startMatch.hasMatch() ? startMatch.capturedLength() : 0;
     }
 
     // As long as there's a delimiter match on this line...
     while (start >= 0) {
         // Look for the ending delimiter
-        end = delimiter.indexIn(text, start + add);
+        const QRegularExpressionMatch endMatch = delimiter.match(text, start + add);
+        end = endMatch.capturedStart();
         // Ending delimiter on this line?
         if (end >= add) {
-            length = end - start + add + delimiter.matchedLength();
+            length = end - start + add + endMatch.capturedLength();
             setCurrentBlockState(0);
         } else {
             // No= multi-line string
@@ -221,7 +227,7 @@ PySyntaxHighlighter::matchMultiline(const QString &text,
         }
         // Apply formatting and look for next
         setFormat(start, length, style);
-        start = delimiter.indexIn(text, start + length);
+        start = delimiter.match(text, start + length).capturedStart();
     }
     // Return True if still inside a multi-line string, False otherwise
     if (currentBlockState() == inState) {

--- a/Gui/ScriptTextEdit.h
+++ b/Gui/ScriptTextEdit.h
@@ -34,6 +34,7 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QTextEdit>
 #include <QPlainTextEdit>
 #include <QSyntaxHighlighter>
+#include <QRegularExpression>
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
@@ -59,7 +60,7 @@ public:
 private:
 
     virtual void highlightBlock(const QString &text) OVERRIDE FINAL;
-    bool matchMultiline(const QString &text, const QRegExp &delimiter, const int inState, const QTextCharFormat &style);
+    bool matchMultiline(const QString &text, const QRegularExpression &delimiter, const int inState, const QTextCharFormat &style);
 
     std::unique_ptr<PySyntaxHighlighterPrivate> _imp;
 };

--- a/Gui/SequenceFileDialog.h
+++ b/Gui/SequenceFileDialog.h
@@ -47,7 +47,6 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QStringList>
 #include <QDir>
 #include <QUrl>
-#include <QRegExp>
 #include <QLatin1Char>
 #include <QSize>
 #include <QComboBox>

--- a/Gui/ViewerGL.cpp
+++ b/Gui/ViewerGL.cpp
@@ -82,6 +82,7 @@ GCC_DIAG_UNUSED_PRIVATE_FIELD_ON
 #include "Gui/ViewerTab.h"
 
 #include <QOpenGLContext>
+#include <QRegularExpression>
 
 
 #define USER_ROI_BORDER_TICK_SIZE 15.f
@@ -1069,7 +1070,7 @@ NATRON_NAMESPACE_ANONYMOUS_ENTER
 static QStringList
 explode(const QString& str)
 {
-    QRegExp rx( QString::fromUtf8("(\\ |\\-|\\.|\\/|\\t|\\n)") ); //RegEx for ' ' '/' '.' '-' '\t' '\n'
+    QRegularExpression rx( QString::fromUtf8("(\\ |\\-|\\.|\\/|\\t|\\n)") ); //RegEx for ' ' '/' '.' '-' '\t' '\n'
     QStringList ret;
     int startIndex = 0;
 


### PR DESCRIPTION
Step 1 of `Documentation/source/maintainers/qt6-migration.rst`: the
modernizations that need no version guard, because every replacement here
exists in Qt 5.15. Nothing is conditional and the Qt5 build is unchanged.

QRegExp is the bulk of it, and the conversions are not mechanical, so each
site got its own reading. The reasoning per site is in the individual
commits; the part worth knowing up front is that
`wildcardToRegularExpression()` and `anchoredPattern()` both return anchored
patterns. That matches `exactMatch()`, but the call sites using `contains()`
and `indexOf()` are unanchored, so those were checked one at a time instead
of converted blind. `ScriptTextEdit` needed real restructuring rather than a
substitution: `QRegExp` carried match state on the object, so `pos()`,
`cap()` and `matchedLength()` read back the last `indexIn()`, and
`matchMultiline` depended on two different matches being live at once.

The rest are small. `QDesktopWidget` had one live use reading logical DPI,
which `QScreen` reports identically, and four dead references.
`QLayout::setMargin` becomes `setContentsMargins`. `QVariant::type()`
becomes `userType()`.

One caveat: the `QVariant` change is in a header nothing currently compiles,
so it is verified against the enum equivalences rather than by the build.
