### PR TITLE
Build against C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ project(Natron
     LANGUAGES CXX C
 )
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 include(GNUInstallDirs)
 

--- a/global.pri
+++ b/global.pri
@@ -17,7 +17,7 @@
 # along with Natron.  If not, see <http://www.gnu.org/licenses/gpl-2.0.html>
 # ***** END LICENSE BLOCK *****
 
-CONFIG += c++17
+CONFIG += c++20
 
 # libs may modify the config (eg openmp), so it must be included before
 include(libs.pri)
@@ -289,14 +289,14 @@ macx-clang-libc++ {
     # in Qt 4.8.7, objective-C misses the stdlib and macos version flags
     QMAKE_OBJECTIVE_CFLAGS += -mmacosx-version-min=$$QMAKE_MACOSX_DEPLOYMENT_TARGET
     QMAKE_OBJECTIVE_CXXFLAGS += -stdlib=libc++ -mmacosx-version-min=$$QMAKE_MACOSX_DEPLOYMENT_TARGET
-    QMAKE_OBJECTIVE_CXXFLAGS += -std=c++17
+    QMAKE_OBJECTIVE_CXXFLAGS += -std=c++20
 }
 
 macx-clang {
     # in Qt 4.8.7, objective-C misses the stdlib and macos version flags
     QMAKE_OBJECTIVE_CFLAGS += -mmacosx-version-min=$$QMAKE_MACOSX_DEPLOYMENT_TARGET
     QMAKE_OBJECTIVE_CXXFLAGS += -mmacosx-version-min=$$QMAKE_MACOSX_DEPLOYMENT_TARGET
-    QMAKE_OBJECTIVE_CXXFLAGS += -std=c++17
+    QMAKE_OBJECTIVE_CXXFLAGS += -std=c++20
 }
 
 CONFIG(debug) {
@@ -489,16 +489,16 @@ unix {
   symbols_hidden_by_default.name = GCC_SYMBOLS_PRIVATE_EXTERN
   symbols_hidden_by_default.value = YES
   QMAKE_MAC_XCODE_SETTINGS += symbols_hidden_by_default
-  QMAKE_CXXFLAGS += -std=c++17
-  enable_cxx17.name = CLANG_CXX_LANGUAGE_STANDARD
-  enable_cxx17.value = c++17
-  QMAKE_MAC_XCODE_SETTINGS += enable_cxx17
+  QMAKE_CXXFLAGS += -std=c++20
+  enable_cxx20.name = CLANG_CXX_LANGUAGE_STANDARD
+  enable_cxx20.value = c++20
+  QMAKE_MAC_XCODE_SETTINGS += enable_cxx20
 }
 
 *clang* {
   QMAKE_CXXFLAGS += -ftemplate-depth-1024
   QMAKE_CXXFLAGS_WARN_ON += -Wno-c++11-extensions
-  QMAKE_CXXFLAGS += -std=c++17
+  QMAKE_CXXFLAGS += -std=c++20
 }
 
 # see http://clang.llvm.org/docs/AddressSanitizer.html and http://blog.qt.digia.com/blog/2013/04/17/using-gccs-4-8-0-address-sanitizer-with-qt/


### PR DESCRIPTION
`CMAKE_CXX_STANDARD` and the six occurrences in `global.pri` move together,
so the two build systems cannot drift apart on this.

Nothing in the tree needed changing to compile, the vendored ceres, libmv,
openMVG and hoedown included.

The macOS and Xcode flags in `global.pri` went along for consistency and are
unverified, there being no Mac here to check them against.
