### PR TITLE
Gui: spell the remaining key combinations with operator|

### DIFF
--- a/Gui/CurveWidgetPrivate.cpp
+++ b/Gui/CurveWidgetPrivate.cpp
@@ -189,20 +189,20 @@ CurveWidgetPrivate::createMenu()
 
     QAction* copyKeyFramesAction = new ActionWithShortcut(kShortcutGroupCurveEditor, kShortcutIDActionCurveEditorCopy,
                                                           kShortcutDescActionCurveEditorCopy, editMenu);
-    copyKeyFramesAction->setShortcut( QKeySequence(Qt::CTRL + Qt::Key_C) );
+    copyKeyFramesAction->setShortcut( QKeySequence(Qt::CTRL | Qt::Key_C) );
 
     QObject::connect( copyKeyFramesAction, SIGNAL(triggered()), _widget, SLOT(copySelectedKeyFramesToClipBoard()) );
     editMenu->addAction(copyKeyFramesAction);
 
     QAction* pasteKeyFramesAction = new ActionWithShortcut(kShortcutGroupCurveEditor, kShortcutIDActionCurveEditorPaste,
                                                            kShortcutDescActionCurveEditorPaste, editMenu);
-    pasteKeyFramesAction->setShortcut( QKeySequence(Qt::CTRL + Qt::Key_V) );
+    pasteKeyFramesAction->setShortcut( QKeySequence(Qt::CTRL | Qt::Key_V) );
     QObject::connect( pasteKeyFramesAction, SIGNAL(triggered()), _widget, SLOT(pasteKeyFramesFromClipBoardToSelectedCurve()) );
     editMenu->addAction(pasteKeyFramesAction);
 
     QAction* selectAllAction = new ActionWithShortcut(kShortcutGroupCurveEditor, kShortcutIDActionCurveEditorSelectAll,
                                                       kShortcutDescActionCurveEditorSelectAll, editMenu);
-    selectAllAction->setShortcut( QKeySequence(Qt::CTRL + Qt::Key_A) );
+    selectAllAction->setShortcut( QKeySequence(Qt::CTRL | Qt::Key_A) );
     QObject::connect( selectAllAction, SIGNAL(triggered()), _widget, SLOT(selectAllKeyFrames()) );
     editMenu->addAction(selectAllAction);
 

--- a/Gui/Gui15.cpp
+++ b/Gui/Gui15.cpp
@@ -250,13 +250,13 @@ Gui::updateViewsActions(int viewsCount)
     if (viewsCount == 2) {
         QAction* left = new QAction(this);
         left->setCheckable(false);
-        left->setShortcut( QKeySequence(Qt::CTRL + Qt::Key_1) );
+        left->setShortcut( QKeySequence(Qt::CTRL | Qt::Key_1) );
         _imp->viewersViewMenu->addAction(left);
         left->setText( tr("Display Left View") );
         QObject::connect( left, SIGNAL(triggered()), this, SLOT(showView0()) );
         QAction* right = new QAction(this);
         right->setCheckable(false);
-        right->setShortcut( QKeySequence(Qt::CTRL + Qt::Key_2) );
+        right->setShortcut( QKeySequence(Qt::CTRL | Qt::Key_2) );
         _imp->viewersViewMenu->addAction(right);
         right->setText( tr("Display Right View") );
         QObject::connect( right, SIGNAL(triggered()), this, SLOT(showView1()) );

--- a/Gui/KnobGuiString.cpp
+++ b/Gui/KnobGuiString.cpp
@@ -1354,7 +1354,7 @@ KnobGuiString::updateToolTip()
                 tt += tr("This text area supports html encoding. "
                          "Please check <a href=http://qt-project.org/doc/qt-5/richtext-html-subset.html>Qt website</a> for more info.");
             }
-            QKeySequence seq(Qt::CTRL + Qt::Key_Return);
+            QKeySequence seq(Qt::CTRL | Qt::Key_Return);
             tt += tr("Use %1 to validate changes made to the text.").arg( seq.toString(QKeySequence::NativeText) );
             _textEdit->setToolTip(tt);
         } else if (_lineEdit) {

--- a/Gui/RotoPanel.cpp
+++ b/Gui/RotoPanel.cpp
@@ -2235,17 +2235,17 @@ RotoPanel::showItemMenu(QTreeWidgetItem* item,
     deleteAct->setShortcut( QKeySequence(Qt::Key_Backspace) );
     QObject::connect( deleteAct, SIGNAL(triggered()), this, SLOT(onDeleteItemActionTriggered()) );
     QAction* cutAct = menu.addAction( tr("Cut") );
-    cutAct->setShortcut( QKeySequence(Qt::Key_X + Qt::CTRL) );
+    cutAct->setShortcut( QKeySequence(Qt::CTRL | Qt::Key_X) );
     QObject::connect( cutAct, SIGNAL(triggered()), this, SLOT(onCutItemActionTriggered()) );
     QAction* copyAct = menu.addAction( tr("Copy") );
-    copyAct->setShortcut( QKeySequence(Qt::Key_C + Qt::CTRL) );
+    copyAct->setShortcut( QKeySequence(Qt::CTRL | Qt::Key_C) );
     QObject::connect( copyAct, SIGNAL(triggered()), this, SLOT(onCopyItemActionTriggered()) );
     QAction* pasteAct = menu.addAction( tr("Paste") );
-    pasteAct->setShortcut( QKeySequence(Qt::Key_V + Qt::CTRL) );
+    pasteAct->setShortcut( QKeySequence(Qt::CTRL | Qt::Key_V) );
     QObject::connect( pasteAct, SIGNAL(triggered()), this, SLOT(onPasteItemActionTriggered()) );
     pasteAct->setEnabled( !_imp->clipBoard.empty() );
     QAction* duplicateAct = menu.addAction( tr("Duplicate") );
-    duplicateAct->setShortcut( QKeySequence(Qt::Key_C + Qt::ALT) );
+    duplicateAct->setShortcut( QKeySequence(Qt::ALT | Qt::Key_C) );
     QObject::connect( duplicateAct, SIGNAL(triggered()), this, SLOT(onDuplicateItemActionTriggered()) );
 
     ///The base layer cannot be duplicated

--- a/Gui/ScriptEditor.cpp
+++ b/Gui/ScriptEditor.cpp
@@ -132,7 +132,7 @@ ScriptEditor::ScriptEditor(Gui* gui)
     appPTR->getIcon(NATRON_PIXMAP_SCRIPT_SAVE_SCRIPT, NATRON_MEDIUM_BUTTON_ICON_SIZE, &saveScriptPix);
 
     _imp->undoB = new Button(QIcon(undoPix), QString(), _imp->buttonsContainer);
-    QKeySequence undoSeq(Qt::CTRL + Qt::Key_BracketLeft);
+    QKeySequence undoSeq(Qt::CTRL | Qt::Key_BracketLeft);
     _imp->undoB->setFixedSize(NATRON_MEDIUM_BUTTON_SIZE, NATRON_MEDIUM_BUTTON_SIZE);
     _imp->undoB->setIconSize( QSize(NATRON_MEDIUM_BUTTON_ICON_SIZE, NATRON_MEDIUM_BUTTON_ICON_SIZE) );
     _imp->undoB->setFocusPolicy(Qt::NoFocus);
@@ -141,7 +141,7 @@ ScriptEditor::ScriptEditor(Gui* gui)
     QObject::connect( _imp->undoB, SIGNAL(clicked(bool)), this, SLOT(onUndoClicked()) );
 
     _imp->redoB = new Button(QIcon(redoPix), QString(), _imp->buttonsContainer);
-    QKeySequence redoSeq(Qt::CTRL + Qt::Key_BracketRight);
+    QKeySequence redoSeq(Qt::CTRL | Qt::Key_BracketRight);
     _imp->redoB->setFocusPolicy(Qt::NoFocus);
     _imp->redoB->setFixedSize(NATRON_MEDIUM_BUTTON_SIZE, NATRON_MEDIUM_BUTTON_SIZE);
     _imp->redoB->setIconSize( QSize(NATRON_MEDIUM_BUTTON_ICON_SIZE, NATRON_MEDIUM_BUTTON_ICON_SIZE) );
@@ -180,7 +180,7 @@ ScriptEditor::ScriptEditor(Gui* gui)
     QObject::connect( _imp->saveScriptB, SIGNAL(clicked(bool)), this, SLOT(onSaveScriptClicked()) );
 
     _imp->execScriptB = new Button(QIcon(execScriptPix), QString(), _imp->buttonsContainer);
-    QKeySequence execSeq(Qt::CTRL + Qt::Key_Return);
+    QKeySequence execSeq(Qt::CTRL | Qt::Key_Return);
     _imp->execScriptB->setFocusPolicy(Qt::NoFocus);
     _imp->execScriptB->setFixedSize(NATRON_MEDIUM_BUTTON_SIZE, NATRON_MEDIUM_BUTTON_SIZE);
     _imp->execScriptB->setIconSize( QSize(NATRON_MEDIUM_BUTTON_ICON_SIZE, NATRON_MEDIUM_BUTTON_ICON_SIZE) );
@@ -201,7 +201,7 @@ ScriptEditor::ScriptEditor(Gui* gui)
     QObject::connect( _imp->showHideOutputB, SIGNAL(clicked(bool)), this, SLOT(onShowHideOutputClicked(bool)) );
 
     _imp->clearOutputB = new Button(QIcon(clearOutpoutPix), QString(), _imp->buttonsContainer);
-    QKeySequence clearSeq(Qt::CTRL + Qt::Key_Backspace);
+    QKeySequence clearSeq(Qt::CTRL | Qt::Key_Backspace);
     _imp->clearOutputB->setFocusPolicy(Qt::NoFocus);
     _imp->clearOutputB->setFixedSize(NATRON_MEDIUM_BUTTON_SIZE, NATRON_MEDIUM_BUTTON_SIZE);
     _imp->clearOutputB->setIconSize( QSize(NATRON_MEDIUM_BUTTON_ICON_SIZE, NATRON_MEDIUM_BUTTON_ICON_SIZE) );


### PR DESCRIPTION
The tail of what #1084 started, and the last of step 1 in
`Documentation/source/maintainers/qt6-migration.rst`. Ten sites in Gui still
wrote `Qt::CTRL + Qt::Key_X`, plus four in RotoPanel that wrote the modifier
second and so were missed by the first pass.

These compiled: Qt6 removed only `Modifier + Modifier`, which #1084 covered,
and left `Modifier + Key` deprecated. The bitwise form resolves to a real
`operator|(Qt::Modifier, Qt::Key)` returning a QKeyCombination, so nothing is
converted between two unrelated enums.

On Qt5 the value is identical, the bits being disjoint, and the enum-to-enum
conversion warning stays: Qt5 has no such overload. So this is a Qt6
deprecation fix, not by itself a step toward a newer C++ standard.

RotoPanel's four were normalised to modifier-first while converting, so the
tree reads one way.

Independent of the other open PRs. Applies to RB-2.6 as it stands.

CI on the fork, Ubuntu and Windows both green:
https://github.com/lockewerks/Natron/actions/runs/33837779471
