### PR TITLE
Build against Qt6, keeping Qt5 working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         run: exit 1
 
   win-test:
-    name: Test ${{ matrix.os }} Python ${{ matrix.python-version }}
+    name: Test ${{ matrix.os }} Qt${{ matrix.qt }} Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -127,6 +127,9 @@ jobs:
       matrix:
         os: [ windows-latest]
         python-version: ['3.10']
+        # Build against both toolkits so the Qt6 port cannot regress unnoticed
+        # while Qt5 is still the shipping one.
+        qt: [5, 6]
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4.1.1
@@ -143,7 +146,7 @@ jobs:
       - name: Install Natron pacman repository
         run: |
           ${GITHUB_WORKSPACE}/.github/workflows/install_natron_pacman_repo.sh ${GITHUB_WORKSPACE} ${GITHUB_WORKSPACE}/natron_pacman_repo
-          pacman -S --needed --noconfirm --overwrite "*" mingw-w64-x86_64-natron-build-deps-qt5
+          pacman -S --needed --noconfirm --overwrite "*" mingw-w64-x86_64-natron-build-deps-qt${{ matrix.qt }}
 
       - name: Download OpenColorIO-Configs
         run: |
@@ -154,7 +157,9 @@ jobs:
       - name: Build Windows
         run: |
           mkdir build && cd build
-          cmake ../
+          # Name the interpreter for the Qt6 build or CMake picks up the
+          # runner's Windows Python instead of the one shiboken6 was built for.
+          cmake ${{ matrix.qt == 6 && '-DNATRON_QT6=ON -DPython_EXECUTABLE=/mingw64/bin/python.exe' || '' }} ../
           ninja
 
       - name: Run Windows Tests
@@ -171,10 +176,12 @@ jobs:
 
           PYTHONHOME=/mingw64 OFX_PLUGIN_PATH=$PWD/Plugins OCIO=$PWD/../OpenColorIO-Configs/blender/config.ocio ctest -V
 
-      - name: Upload ${{ matrix.os }} Test Log artifacts
+      - name: Upload ${{ matrix.os }} Qt${{ matrix.qt }} Test Log artifacts
         uses: actions/upload-artifact@v4.3.1
         with:
-          name: ${{ matrix.os }} Test Logs
+          # The Qt version has to be in the name: upload-artifact v4 rejects
+          # two matrix legs uploading under one name.
+          name: ${{ matrix.os }} Qt${{ matrix.qt }} Test Logs
           path: ${{ github.workspace }}/build/Testing/Temporary/LastTest.log
 
       - name: Check for test failures

--- a/App/App.pro
+++ b/App/App.pro
@@ -41,6 +41,8 @@ CONFIG += boost boost-serialization-lib opengl qt cairo python shiboken pyside
 CONFIG += static-gui static-engine static-host-support static-breakpadclient static-libmv static-openmvg static-ceres static-qhttpserver static-libtess
 
 QT += gui core opengl network widgets concurrent
+# QOpenGLWidget moved to its own module in Qt6; CMake already appends it.
+equals(QT_MAJOR_VERSION, 6): QT += openglwidgets
 
 !noexpat: CONFIG += expat
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,17 @@ if(IS_DEBUG_BUILD AND WIN32)
     set_property(TARGET ${SHIBOKEN_LIB} PROPERTY INTERFACE_COMPILE_DEFINITIONS SHIBOKEN_DEFS)
 endif()
 
+# Qt's PySide6 wheels are built for the stable ABI, and their imported target
+# passes Py_LIMITED_API on to everything that links it. The limited API does not
+# expose PyTuple_GET_ITEM, PyList_SET_ITEM or PyRun_String, all of which the
+# typesystem glue in Engine and Gui calls directly, so drop the definition and
+# build the bindings against the full API as a source build of shiboken gives.
+get_property(_shiboken_defs TARGET ${SHIBOKEN_LIB} PROPERTY INTERFACE_COMPILE_DEFINITIONS)
+if(_shiboken_defs)
+    list(FILTER _shiboken_defs EXCLUDE REGEX "^Py_LIMITED_API")
+    set_property(TARGET ${SHIBOKEN_LIB} PROPERTY INTERFACE_COMPILE_DEFINITIONS ${_shiboken_defs})
+endif()
+
 #Since in Natron and OpenFX all strings are supposed UTF-8 and that the constructor
 #for QString(const char*) assumes ASCII strings, we may run into troubles
 add_compile_definitions(QT_NO_CAST_FROM_ASCII)

--- a/Engine/CLArgs.cpp
+++ b/Engine/CLArgs.cpp
@@ -39,6 +39,7 @@
 #include <QDebug>
 #include <QFile>
 #include <QFileInfo>
+#include <QRegularExpression>
 
 #include "Global/GlobalDefines.h"
 #include "Global/GitVersion.h"
@@ -1139,10 +1140,10 @@ CLArgsPrivate::parse()
         // A clean solution would be to separate the scriptName and the fileName with a comma.
         if ( it != args.end() && !it->startsWith( QChar::fromLatin1('-') ) ) {
             // Check that it's neither a python script, a natron project, nor a frame range.
-            QRegExp re( QString::fromUtf8("[0-9\\-,]*") ); // Matches frame ranges.
+            QRegularExpression re( QRegularExpression::anchoredPattern( QString::fromUtf8("[0-9\\-,]*") ) ); // Matches frame ranges.
             if (!it->endsWith(QString::fromUtf8(".py"), Qt::CaseInsensitive) &&
                 !it->endsWith(QString::fromUtf8(".ntp"), Qt::CaseInsensitive) &&
-                !re.exactMatch(*it)) {
+                !re.match(*it).hasMatch()) {
                 w.filename = *it;
 #ifdef __NATRON_UNIX__
                 w.filename = AppManager::qt_tildeExpansion(w.filename);

--- a/Engine/EffectInstance.cpp
+++ b/Engine/EffectInstance.cpp
@@ -4097,9 +4097,9 @@ EffectInstance::attachOpenGLContext_public(const OSGLContextPtr& glContext,
 {
     NON_RECURSIVE_ACTION();
     bool concurrentGLRender = supportsConcurrentOpenGLRenders();
-    std::unique_ptr<QMutexLocker> locker;
+    std::unique_ptr<QtCompat::MutexLock> locker;
     if (concurrentGLRender) {
-        locker.reset( new QMutexLocker(&_imp->attachedContextsMutex) );
+        locker.reset( new QtCompat::MutexLock(&_imp->attachedContextsMutex) );
     } else {
         _imp->attachedContextsMutex.lock();
     }
@@ -4158,9 +4158,9 @@ EffectInstance::dettachOpenGLContext_public(const OSGLContextPtr& glContext, con
 {
     NON_RECURSIVE_ACTION();
     bool concurrentGLRender = supportsConcurrentOpenGLRenders();
-    std::unique_ptr<QMutexLocker> locker;
+    std::unique_ptr<QtCompat::MutexLock> locker;
     if (concurrentGLRender) {
-        locker.reset( new QMutexLocker(&_imp->attachedContextsMutex) );
+        locker.reset( new QtCompat::MutexLock(&_imp->attachedContextsMutex) );
     }
 
 

--- a/Engine/EffectInstanceRenderRoI.cpp
+++ b/Engine/EffectInstanceRenderRoI.cpp
@@ -1517,7 +1517,7 @@ EffectInstance::renderRoI(const RenderRoIArgs & args,
         ///locks belongs to an instance)
 
 
-        std::unique_ptr<QMutexLocker> locker;
+        std::unique_ptr<QtCompat::MutexLock> locker;
 
 
         EffectInstancePtr renderInstance;
@@ -1535,11 +1535,11 @@ EffectInstance::renderRoI(const RenderRoIArgs & args,
         assert(renderInstance);
 
         if (safety == eRenderSafetyInstanceSafe) {
-            locker.reset( new QMutexLocker( &getNode()->getRenderInstancesSharedMutex() ) );
+            locker.reset( new QtCompat::MutexLock( &getNode()->getRenderInstancesSharedMutex() ) );
         } else if (safety == eRenderSafetyUnsafe) {
             const Plugin* p = getNode()->getPlugin();
             assert(p);
-            locker.reset( new QMutexLocker( p->getPluginLock() ) );
+            locker.reset( new QtCompat::MutexLock( p->getPluginLock() ) );
         } else {
             // no need to lock
             Q_UNUSED(locker);

--- a/Engine/EngineFwd.h
+++ b/Engine/EngineFwd.h
@@ -28,6 +28,10 @@
 
 #include "Global/Macros.h"
 
+// QStringList is a class in Qt5 but an alias for QList<QString> in Qt6, so it
+// cannot be forward declared by hand. This header spells it correctly on both.
+#include <QtCore/qcontainerfwd.h>
+
 #include <memory>
 #include <list>
 #include <vector>
@@ -61,7 +65,6 @@ class QNetworkRequest;
 class QProcess;
 class QSettings;
 class QString;
-class QStringList;
 class QThread;
 class QTimer;
 class QUrl;

--- a/Engine/FileSystemModel.cpp
+++ b/Engine/FileSystemModel.cpp
@@ -47,6 +47,7 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QDebug>
 #include <QUrl>
 #include <QMimeData>
+#include <QRegularExpression>
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
@@ -193,7 +194,7 @@ struct FileSystemModelPrivate
     QStringList headers;
     QDir::Filters filters;
     QString encodedRegexps;
-    std::list<QRegExp> regexps;
+    std::list<QRegularExpression> regexps;
     mutable QMutex filtersMutex;
     mutable QMutex sequenceModeEnabledMutex;
     bool sequenceModeEnabled;
@@ -1041,7 +1042,8 @@ FileSystemModel::setRegexpFilters(const QString& filters)
                 ++i;
             }
             if ( regExp != QString( QLatin1Char('*') ) ) {
-                QRegExp rx(regExp, Qt::CaseInsensitive, QRegExp::Wildcard);
+                QRegularExpression rx(QRegularExpression::wildcardToRegularExpression(regExp),
+                                      QRegularExpression::CaseInsensitiveOption);
                 if ( rx.isValid() ) {
                     _imp->regexps.push_back(rx);
                 }
@@ -1082,8 +1084,8 @@ FileSystemModel::isAcceptedByRegexps(const QString & path) const
         return true;
     }
 
-    for (std::list<QRegExp>::const_iterator it = _imp->regexps.begin(); it != _imp->regexps.end(); ++it) {
-        if ( it->exactMatch(path) ) {
+    for (std::list<QRegularExpression>::const_iterator it = _imp->regexps.begin(); it != _imp->regexps.end(); ++it) {
+        if ( it->match(path).hasMatch() ) {
             return true;
         }
     }

--- a/Engine/Markdown.cpp
+++ b/Engine/Markdown.cpp
@@ -30,7 +30,7 @@
 CLANG_DIAG_OFF(deprecated)
 CLANG_DIAG_OFF(uninitialized)
 #include <QTextStream>
-#include <QRegExp>
+#include <QRegularExpression>
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
@@ -79,7 +79,7 @@ QString
 Markdown::parseCustomLinksForHTML(const QString& markdown)
 {
     QString result = markdown;
-    QRegExp rx( QString::fromUtf8("(\\|html::[^|]*\\|)\\|rst::[^|]*\\|") );
+    QRegularExpression rx( QString::fromUtf8("(\\|html::[^|]*\\|)\\|rst::[^|]*\\|") );
     result.replace( rx, QString::fromUtf8("\\1") );
 
     return result;
@@ -105,9 +105,9 @@ Markdown::fixSettingsHTML(const QString &html)
     QStringList list = html.split( QString::fromUtf8("\n") );
     Q_FOREACH(const QString &line, list) {
         if ( line.startsWith(QString::fromUtf8("<h2>")) ) {
-            QRegExp rx( QString::fromUtf8("<h2>(.*)</h2>") );
-            rx.indexIn(line);
-            QString header = rx.cap(1);
+            QRegularExpression rx( QString::fromUtf8("<h2>(.*)</h2>") );
+            QRegularExpressionMatch match = rx.match(line);
+            QString header = match.captured(1);
             QString headerLink = header.toLower();
             headerLink.replace( QString::fromUtf8(" "), QString::fromUtf8("-") );
             result.append(QString::fromUtf8("<h2 id=\"%1\">%2</h2>").arg(headerLink).arg(header));

--- a/Engine/Node.cpp
+++ b/Engine/Node.cpp
@@ -42,7 +42,6 @@
 #include <QWaitCondition>
 #include <QTextStream>
 #include <QFile>
-#include <QRegExp>
 
 #include <ofxNatron.h>
 

--- a/Engine/NodeDocumentation.cpp
+++ b/Engine/NodeDocumentation.cpp
@@ -27,6 +27,7 @@
 
 #include <QTextStream>
 #include <QFile>
+#include <QRegularExpression>
 
 #include "Engine/EffectInstance.h"
 #include "Engine/KnobTypes.h"
@@ -409,7 +410,7 @@ Node::makeDocumentation(bool genHTML) const
             pluginDescription = NATRON_NAMESPACE::convertFromPlainText(pluginDescription, NATRON_NAMESPACE::WhiteSpaceNormal);
 
             // replace URLs with links
-            QRegExp re( QString::fromUtf8("((http|ftp|https)://([\\w_-]+(?:(?:\\.[\\w_-]+)+))([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])?)") );
+            QRegularExpression re( QString::fromUtf8("((http|ftp|https)://([\\w_-]+(?:(?:\\.[\\w_-]+)+))([\\w.,@?^=%&:/~+#-]*[\\w@?^=%&/~+#-])?)") );
             pluginDescription.replace( re, QString::fromUtf8("<a href=\"\\1\">\\1</a>") );
         } else {
             pluginDescription = convertFromPlainTextToMarkdown(pluginDescription, genHTML, false);

--- a/Engine/NodeGroup.cpp
+++ b/Engine/NodeGroup.cpp
@@ -1654,7 +1654,9 @@ escapeString(const QString& str)
         } else {
 #if PY_MAJOR_VERSION >= 3
             // Python 3 strings are unicode
-            ret.append(QString::fromUtf8("\\u%1").arg(str[i].unicode(), 4, 16, QLatin1Char('0')));
+            // QChar::unicode() returns char16_t on Qt6, which arg() has no
+            // overload for, and ushort on Qt5, where the cast does nothing.
+            ret.append(QString::fromUtf8("\\u%1").arg(ushort(str[i].unicode()), 4, 16, QLatin1Char('0')));
 #else
             // Python 2: convert to Utf8
             QByteArray utf8 = QString(str[i]).toUtf8();

--- a/Engine/OSGLContext_x11.cpp
+++ b/Engine/OSGLContext_x11.cpp
@@ -33,6 +33,14 @@
 
 #include <dlfcn.h>
 
+// Qt has to come before the X11 headers. Xlib defines Status as a macro and
+// Qt6's qtextstream.h refuses to compile when it is already defined, which
+// Qt5 tolerated.
+
+#include "Engine/AppManager.h"
+#include "Engine/OSGLContext.h"
+#include "Global/GLIncludes.h"
+
 extern "C"
 {
 #include <X11/Xlib.h>
@@ -41,9 +49,6 @@ extern "C"
 #include <X11/Xresource.h>
 }
 
-#include "Engine/AppManager.h"
-#include "Engine/OSGLContext.h"
-#include "Global/GLIncludes.h"
 
 #define GLX_VENDOR 1
 #define GLX_RGBA_BIT 0x00000001

--- a/Engine/OutputEffectInstance.cpp
+++ b/Engine/OutputEffectInstance.cpp
@@ -35,7 +35,7 @@
 #include <QReadWriteLock>
 #include <QCoreApplication>
 #include <QThread>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QtConcurrentMap> // QtCore on Qt4, QtConcurrent on Qt5
 #include <QtConcurrentRun> // QtCore on Qt4, QtConcurrent on Qt5
 
@@ -268,7 +268,7 @@ OutputEffectInstance::renderFullSequence(bool isBlocking,
         std::size_t foundHash = pattern.find_first_of("#");
         if (foundHash == std::string::npos) {
             // Look for printf style numbering
-            QRegExp exp(QString::fromUtf8("%[0-9]*d"));
+            QRegularExpression exp( QString::fromUtf8("%[0-9]*d") );
             QString qp(QString::fromUtf8(pattern.c_str()));
             if (!qp.contains(exp)) {
                 QString message = tr("You are trying to render the frame range [%1 - %2] but you did not specify any hash ('#') character(s) or printf-like format ('%d') for the padding. This will result in the same image being overwritten multiple times.").arg(first).arg(last);

--- a/Engine/Project.cpp
+++ b/Engine/Project.cpp
@@ -54,6 +54,7 @@
 #include <QDebug>
 #include <QTextStream>
 #include <QHostInfo>
+#include <QRegularExpression>
 #include <QtConcurrentRun> // QtCore on Qt4, QtConcurrent on Qt5
 
 #include <ofxhXml.h> // OFX::XML::escape
@@ -504,7 +505,7 @@ findBackups(const QString & filePath)
         ret.append(filePath);
     }
     // find files matching filePath.~[0-9]+~
-    QRegExp rx(QString::fromUtf8("\\.~(\\d+)~$"));
+    QRegularExpression rx( QString::fromUtf8("\\.~(\\d+)~$") );
     QFileInfo fileInfo(filePath);
     QString fileName = fileInfo.fileName();
     QDirIterator it(fileInfo.dir());
@@ -518,7 +519,11 @@ findBackups(const QString & filePath)
 
         // If the filename contains target string - put it in the hitlist
         QString fn = file.fileName();
-        if (fn.startsWith(fileName) && rx.lastIndexIn(fn) == fileName.size()) {
+        // The pattern ends with $, so there is at most one match and
+        // lastIndexIn() is just that match.
+        QRegularExpressionMatch backupMatch = rx.match(fn);
+        if ( fn.startsWith(fileName) && backupMatch.hasMatch() &&
+             ( backupMatch.capturedStart() == fileName.size() ) ) {
             ret.append(file.filePath());
         }
     }
@@ -532,11 +537,11 @@ findBackups(const QString & filePath)
 static QString
 nextBackup(const QString & filePath)
 {
-    QRegExp rx(QString::fromUtf8("\\.~(\\d+)~$"));
-    int pos = rx.lastIndexIn(filePath);
-    if (pos >= 0) {
-        int i = rx.cap(1).toInt();
-        return filePath.left(pos) + QString::fromUtf8(".~%1~").arg(i+1);
+    QRegularExpression rx( QString::fromUtf8("\\.~(\\d+)~$") );
+    QRegularExpressionMatch match = rx.match(filePath);
+    if ( match.hasMatch() ) {
+        int i = match.captured(1).toInt();
+        return filePath.left( match.capturedStart() ) + QString::fromUtf8(".~%1~").arg(i+1);
     } else {
         return filePath + QString::fromUtf8(".~1~");
     }

--- a/Engine/Project.cpp
+++ b/Engine/Project.cpp
@@ -761,7 +761,9 @@ Project::onAutoSaveTimerTriggered()
     if (canAutoSave) {
         std::shared_ptr<QFutureWatcher<void> > watcher = std::make_shared<QFutureWatcher<void> >();
         QObject::connect( watcher.get(), SIGNAL(finished()), this, SLOT(onAutoSaveFutureFinished()) );
-        watcher->setFuture( QtConcurrent::run(this, &Project::autoSave) );
+        // Qt6 dropped the run(object, memberFunction) overload; a lambda is the
+        // one spelling both versions accept.
+        watcher->setFuture( QtConcurrent::run( [this]() { autoSave(); } ) );
         _imp->autoSaveFutures.push_back(watcher);
     } else {
         ///If the auto-save failed because a render is in progress, try every 2 seconds to auto-save.

--- a/Engine/PyGlobalFunctions.h
+++ b/Engine/PyGlobalFunctions.h
@@ -39,6 +39,13 @@
 
 #include "Engine/EngineFwd.h"
 
+// Both build systems pass this on the command line, where it wins over the
+// fallback below. shiboken parses this header without those defines, so give
+// it a value rather than failing binding generation.
+#ifndef NATRON_BUILD_NUMBER
+#define NATRON_BUILD_NUMBER 0
+#endif
+
 NATRON_NAMESPACE_ENTER;
 NATRON_PYTHON_NAMESPACE_ENTER;
 

--- a/Engine/TrackerNodeInteract.cpp
+++ b/Engine/TrackerNodeInteract.cpp
@@ -1099,7 +1099,11 @@ TrackerNodeInteract::refreshSelectedMarkerTexture()
 
     imageGetterWatcher = std::make_shared<TrackWatcher>();
     QObject::connect( imageGetterWatcher.get(), SIGNAL(finished()), this, SLOT(onTrackImageRenderingFinished()) );
-    imageGetterWatcher->setFuture( QtConcurrent::run(marker.get(), &TrackMarker::getMarkerImage, time, roi) );
+    // Qt6 dropped the run(object, memberFunction, args...) overload; a lambda
+    // is the one spelling both versions accept. Capture the bare pointer the
+    // old call passed rather than the shared pointer, to keep the lifetime
+    // rules of this call unchanged.
+    imageGetterWatcher->setFuture( QtConcurrent::run( [m = marker.get(), time, roi]() { return m->getMarkerImage(time, roi); } ) );
 }
 
 void
@@ -1130,7 +1134,7 @@ TrackerNodeInteract::makeMarkerKeyTexture(int time,
         TrackWatcherPtr watcher( new TrackWatcher() );
         QObject::connect( watcher.get(), SIGNAL(finished()), this, SLOT(onKeyFrameImageRenderingFinished()) );
         trackRequestsMap[k] = watcher;
-        watcher->setFuture( QtConcurrent::run(track.get(), &TrackMarker::getMarkerImage, time, k.roi) );
+        watcher->setFuture( QtConcurrent::run( [m = track.get(), time, roi = k.roi]() { return m->getMarkerImage(time, roi); } ) );
     }
 }
 

--- a/Engine/Variant.h
+++ b/Engine/Variant.h
@@ -31,6 +31,7 @@
 CLANG_DIAG_OFF(deprecated)
 #include <QVariant>
 #include <QMetaType>
+#include <QDebug>
 #include <QDataStream>
 #include <QByteArray>
 #include <QString>
@@ -213,6 +214,21 @@ Variant::setValue(const char* const & str)
 {
     QVariant::setValue( QString::fromUtf8(str) );
 }
+
+#ifndef QT_NO_DEBUG_STREAM
+// Qt6 turned QVariant's debug operator into a hidden friend template
+// constrained to std::is_same_v<T, QVariant>, so T deduces to the derived
+// class here, the constraint fails and no conversion to the base is ever
+// considered. Qt5 declared a plain operator<<(QDebug, const QVariant &),
+// which a derived class bound to. Only a debug build notices: everywhere
+// else QT_NO_DEBUG_OUTPUT makes qDebug() a QNoDebug that swallows any type.
+inline QDebug
+operator<<(QDebug dbg,
+           const Variant & v)
+{
+    return dbg << static_cast<const QVariant &>(v);
+}
+#endif // QT_NO_DEBUG_STREAM
 
 NATRON_NAMESPACE_EXIT
 

--- a/Engine/VariantSerialization.h
+++ b/Engine/VariantSerialization.h
@@ -55,45 +55,48 @@ Variant::save(Archive & ar,
               const unsigned int version) const
 {
     Q_UNUSED(version);
-    QVariant::Type t = type();
+    // QVariant::Type and QVariant::type() are deprecated in Qt6 in favour of
+    // the metatype id. userType() returns that id in both Qt 5.15 and Qt 6, and
+    // the QMetaType constants below are the same values QVariant::Type used.
+    const int t = userType();
     std::string typeStr;
     switch (t) {
-    case QVariant::Bool: {
+    case QMetaType::Bool: {
         bool v = toBool();
         typeStr = "bool";
         ar & ::boost::serialization::make_nvp("Type", typeStr);
         ar & ::boost::serialization::make_nvp("Value", v);
         break;
     }
-    case QVariant::Int: {
+    case QMetaType::Int: {
         int v = toInt();
         typeStr = "int";
         ar & ::boost::serialization::make_nvp("Type", typeStr);
         ar & ::boost::serialization::make_nvp("Value", v);
         break;
     }
-    case QVariant::UInt: {
+    case QMetaType::UInt: {
         int v = toUInt();
         typeStr = "uint";
         ar & ::boost::serialization::make_nvp("Type", typeStr);
         ar & ::boost::serialization::make_nvp("Value", v);
         break;
     }
-    case QVariant::Double: {
+    case QMetaType::Double: {
         double v = toDouble();
         typeStr = "double";
         ar & ::boost::serialization::make_nvp("Type", typeStr);
         ar & ::boost::serialization::make_nvp("Value", v);
         break;
     }
-    case QVariant::String: {
+    case QMetaType::QString: {
         typeStr = "string";
         ar & ::boost::serialization::make_nvp("Type", typeStr);
         std::string str = toString().toStdString();
         ar & ::boost::serialization::make_nvp("Value", str);
         break;
     }
-    case QVariant::StringList: {
+    case QMetaType::QStringList: {
         typeStr = "stringlist";
         ar & ::boost::serialization::make_nvp("Type", typeStr);
         std::list<std::string> list;

--- a/Engine/typesystem_engine.xml
+++ b/Engine/typesystem_engine.xml
@@ -52,7 +52,12 @@
             </target-to-native>
         </conversion-rule>
     </primitive-type>
-    
+
+    <!--PySide2 declared the CPython types it used in typesystem_core_common.xml
+        and shiboken2 knew PyList on top of those. PySide6 declares none of them,
+        so the ones this typesystem names have to be declared here. -->
+    <custom-type name="PyList" check-function="PyList_Check"/>
+
     <!--std::pair from/to Python pair-->
     <container-type name="std::pair" type="pair">
         <include file-name="utility" location="global"/>

--- a/Global/QtCompat.h
+++ b/Global/QtCompat.h
@@ -22,9 +22,16 @@
 #include "Global/Macros.h"
 
 #include <QtGlobal> // for Q_OS_*
+#include <QMutex>
+#include <QRecursiveMutex>
 #include <QString>
 #include <QUrl>
 #include <QFileInfo>
+
+// Qt6 declares QWidget::enterEvent(QEnterEvent*) where Qt5 used QEvent*. Only
+// Gui ever needs the definition and Engine does not link QtGui, so forward
+// declare it the way EngineFwd.h handles the rest of Qt.
+class QEnterEvent;
 
 NATRON_NAMESPACE_ENTER
 
@@ -48,12 +55,53 @@ removeFileExtension(QString & filename)
 
 // Define compatibility typedefs so code builds with Qt5 & Qt6
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-typedef QEnterEvent QEnterEvent;
+typedef ::QEnterEvent QEnterEvent;
 #elif QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 typedef QEvent QEnterEvent;
 #else
 #error "Unsupported version of QT"
 #endif
+
+/*Holds a lock on either kind of mutex for the duration of a scope.
+
+  Qt5 derived QRecursiveMutex from QMutex, so a single QMutexLocker could hold
+  whichever one a code path happened to pick. Qt6 made the two types unrelated
+  and turned QMutexLocker into a template on the mutex type, which leaves no
+  one type able to hold both. Deferred locking is the point here: these lockers
+  are declared unlocked and only engaged on some branches.*/
+class MutexLock
+{
+public:
+    explicit MutexLock(QMutex* mutex)
+        : _mutex(mutex)
+        , _recursiveMutex(0)
+    {
+        _mutex->lock();
+    }
+
+    explicit MutexLock(QRecursiveMutex* mutex)
+        : _mutex(0)
+        , _recursiveMutex(mutex)
+    {
+        _recursiveMutex->lock();
+    }
+
+    ~MutexLock()
+    {
+        if (_mutex) {
+            _mutex->unlock();
+        }
+        if (_recursiveMutex) {
+            _recursiveMutex->unlock();
+        }
+    }
+
+private:
+    Q_DISABLE_COPY(MutexLock)
+
+    QMutex* _mutex;
+    QRecursiveMutex* _recursiveMutex;
+};
 
 } // namespace QtCompat
 

--- a/Gui/ActionShortcuts.h
+++ b/Gui/ActionShortcuts.h
@@ -657,7 +657,13 @@ extractKeySequence(const QKeySequence & seq,
     ///The nativeSeqStr now contains only the symbol
     QKeySequence newSeq(nativeSeqStr, QKeySequence::NativeText);
     if (newSeq.count() > 0) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        // The modifiers were stripped from the string above, so the key is the
+        // whole of this combination.
+        symbol = newSeq[0].key();
+#else
         symbol = (Qt::Key)newSeq[0];
+#endif
     } else {
         symbol = (Qt::Key)0;
     }

--- a/Gui/DocumentationManager.cpp
+++ b/Gui/DocumentationManager.cpp
@@ -197,7 +197,7 @@ DocumentationManager::handler(QHttpRequest *req,
         }
     }
     if ( !staticPage.isEmpty() ) {
-        QFileInfo staticFileInfo = docDir + staticPage;
+        QFileInfo staticFileInfo(docDir + staticPage);
         if ( ( isStatic && !staticFileInfo.exists() ) ||
              ( !isStatic && staticFileInfo.exists() ) ) {
             // must redirect
@@ -510,9 +510,9 @@ DocumentationManager::handler(QHttpRequest *req,
         QFileInfo staticFileInfo;
 
         if ( page.startsWith( QString::fromUtf8("LOCAL_FILE/") ) ) {
-            staticFileInfo = page.replace( QString::fromUtf8("LOCAL_FILE/"), QString::fromUtf8("") ).replace( QString::fromUtf8("%2520"), QString::fromUtf8(" ") ).replace( QString::fromUtf8("%20"), QString::fromUtf8(" ") );
+            staticFileInfo.setFile( page.replace( QString::fromUtf8("LOCAL_FILE/"), QString::fromUtf8("") ).replace( QString::fromUtf8("%2520"), QString::fromUtf8(" ") ).replace( QString::fromUtf8("%20"), QString::fromUtf8(" ") ) );
         } else {
-            staticFileInfo = docDir + page;
+            staticFileInfo.setFile(docDir + page);
         }
 #ifdef DEBUG
         qDebug() << "www client requested page" << page << "->file" << staticFileInfo.absoluteFilePath();

--- a/Gui/DopeSheetHierarchyView.cpp
+++ b/Gui/DopeSheetHierarchyView.cpp
@@ -798,7 +798,12 @@ HierarchyView::drawRow(QPainter *painter,
         painter->fillRect(itemRect.adjusted(-1, 0, 0, 0), fillColor);
 
         // Draw the item text
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QStyleOptionViewItem newOpt;
+        initViewItemOption(&newOpt);
+#else
         QStyleOptionViewItem newOpt = viewOptions();
+#endif
 
         newOpt.rect = itemRect;
 
@@ -849,7 +854,12 @@ HierarchyView::drawBranches(QPainter *painter,
         painter->fillRect(rectForDull, nodeColorDull);
 
         // Draw the branch indicator
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QStyleOptionViewItem option;
+        initViewItemOption(&option);
+#else
         QStyleOptionViewItem option = viewOptions();
+#endif
 
         option.rect = _imp->getParentArrowRect(item, rect);
         option.displayAlignment = Qt::AlignCenter;

--- a/Gui/FileTypeMainWindow_win.cpp
+++ b/Gui/FileTypeMainWindow_win.cpp
@@ -51,7 +51,7 @@
 #include <QApplication>
 #include <QDir>
 #include <QFileInfo>
-#include <QRegExp>
+#include <QRegularExpression>
 
 NATRON_NAMESPACE_ENTER
 
@@ -283,9 +283,10 @@ DocumentWindow::ddeExecute(MSG* message,
         return true;
     }
 
-    QRegExp regCommand( QString::fromUtf8("^\\[(\\w+)\\((.*)\\)\\]$") );
-    if ( regCommand.exactMatch(command) ) {
-        executeDdeCommand( regCommand.cap(1), regCommand.cap(2) );
+    QRegularExpression regCommand( QString::fromUtf8("^\\[(\\w+)\\((.*)\\)\\]$") );
+    const QRegularExpressionMatch commandMatch = regCommand.match(command);
+    if ( commandMatch.hasMatch() ) {
+        executeDdeCommand( commandMatch.captured(1), commandMatch.captured(2) );
     }
 
     *result = 0;
@@ -345,15 +346,16 @@ void
 DocumentWindow::executeDdeCommand(const QString& command,
                                   const QString& params)
 {
-    QRegExp regCommand( QString::fromUtf8("^\"(.*)\"$") );
-    bool singleCommand = regCommand.exactMatch(params);
+    QRegularExpression regCommand( QString::fromUtf8("^\"(.*)\"$") );
+    const QRegularExpressionMatch paramsMatch = regCommand.match(params);
+    bool singleCommand = paramsMatch.hasMatch();
 
     if ( ( 0 == command.compare(QString::fromUtf8("open"), Qt::CaseInsensitive) ) && singleCommand ) {
-        ddeOpenFile( regCommand.cap(1) );
+        ddeOpenFile( paramsMatch.captured(1) );
     } else if ( ( 0 == command.compare(QString::fromUtf8("new"), Qt::CaseInsensitive) ) && singleCommand ) {
-        ddeNewFile( regCommand.cap(1) );
+        ddeNewFile( paramsMatch.captured(1) );
     } else if ( ( 0 == command.compare(QString::fromUtf8("print"), Qt::CaseInsensitive) ) && singleCommand ) {
-        ddePrintFile( regCommand.cap(1) );
+        ddePrintFile( paramsMatch.captured(1) );
     } else {
         executeUnknownDdeCommand(command, params);
     }

--- a/Gui/FileTypeMainWindow_win.cpp
+++ b/Gui/FileTypeMainWindow_win.cpp
@@ -89,7 +89,7 @@ DocumentWindow::~DocumentWindow()
 // —— protected slots —————————————————————————
 // —— events ————————————————————————————
 bool
-DocumentWindow::nativeEvent(const QByteArray& eventType, void* message, long* result)
+DocumentWindow::nativeEvent(const QByteArray& eventType, void* message, NativeEventResult* result)
 {
     MSG* msg = static_cast<MSG*>(message);
     switch (msg->message) {
@@ -233,7 +233,7 @@ DocumentWindow::enableShellOpen()
 // —— private helpers —————————————————————————
 bool
 DocumentWindow::ddeInitiate(MSG* message,
-                            long* result)
+                            NativeEventResult* result)
 {
     if ( ( 0 != LOWORD(message->lParam) ) &&
          ( 0 != HIWORD(message->lParam) ) &&
@@ -258,7 +258,7 @@ DocumentWindow::ddeInitiate(MSG* message,
 
 bool
 DocumentWindow::ddeExecute(MSG* message,
-                           long* result)
+                           NativeEventResult* result)
 {
     // unpack the DDE message
     UINT_PTR unused = 0;
@@ -296,7 +296,7 @@ DocumentWindow::ddeExecute(MSG* message,
 
 bool
 DocumentWindow::ddeTerminate(MSG* message,
-                             long* result)
+                             NativeEventResult* result)
 {
     Q_UNUSED(result);
     // The client or server application should respond by posting a WM_DDE_TERMINATE message.

--- a/Gui/FileTypeMainWindow_win.h
+++ b/Gui/FileTypeMainWindow_win.h
@@ -47,6 +47,15 @@
 
 NATRON_NAMESPACE_ENTER
 
+// QWidget::nativeEvent hands back a long* on Qt5 and a qintptr* on Qt6. Those
+// are distinct types on 64 bit Windows, so an override naming the wrong one
+// quietly becomes a new virtual instead of failing to compile.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+typedef qintptr NativeEventResult;
+#else
+typedef long NativeEventResult;
+#endif
+
 // —— local includes —————————————————————————-
 // —— pre defines ——————————————————————————-
 
@@ -138,7 +147,7 @@ protected:
     /**
      * reimpl as DDE events come as windows events and are not translated by Qt.
      */
-    virtual bool nativeEvent(const QByteArray& eventType, void* message, long* result);
+    virtual bool nativeEvent(const QByteArray& eventType, void* message, NativeEventResult* result);
 
     // —— helpers for the file registration ——————————————————
     /**
@@ -243,17 +252,17 @@ private:
     /**
      * implementation of the WM_DDE_INITIATE windows message
      */
-    bool ddeInitiate(MSG* message, long* result);
+    bool ddeInitiate(MSG* message, NativeEventResult* result);
 
     /**
      * implementation of the WM_DDE_EXECUTE windows message
      */
-    bool ddeExecute(MSG* message, long* result);
+    bool ddeExecute(MSG* message, NativeEventResult* result);
 
     /**
      * implementation of the WM_DDE_TERMINATE windows message
      */
-    bool ddeTerminate(MSG* message, long* result);
+    bool ddeTerminate(MSG* message, NativeEventResult* result);
 
     /**
      * Sets specified value in the registry under HKCU\Software\Classes, which is mapped to HKCR then.

--- a/Gui/Gui.pro
+++ b/Gui/Gui.pro
@@ -23,6 +23,8 @@ CONFIG += staticlib
 CONFIG += moc rcc
 CONFIG += boost opengl qt cairo python shiboken pyside 
 QT += gui core network concurrent widgets
+# QOpenGLWidget moved to its own module in Qt6; CMake already appends it.
+equals(QT_MAJOR_VERSION, 6): QT += openglwidgets
 
 GUI_WRAPPER_DIR = Qt$${QT_MAJOR_VERSION}/NatronGui
 ENGINE_WRAPPER_DIR = Qt$${QT_MAJOR_VERSION}/NatronEngine

--- a/Gui/Gui15.cpp
+++ b/Gui/Gui15.cpp
@@ -147,43 +147,43 @@ Gui::keySequenceForView(ViewIdx v)
     switch ( static_cast<int>(v) ) {
     case 0:
 
-        return QKeySequence(Qt::CTRL + Qt::ALT +  Qt::Key_1);
+        return QKeySequence(Qt::CTRL | Qt::ALT |  Qt::Key_1);
         break;
     case 1:
 
-        return QKeySequence(Qt::CTRL + Qt::ALT + Qt::Key_2);
+        return QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_2);
         break;
     case 2:
 
-        return QKeySequence(Qt::CTRL + Qt::ALT + Qt::Key_3);
+        return QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_3);
         break;
     case 3:
 
-        return QKeySequence(Qt::CTRL + Qt::ALT + Qt::Key_4);
+        return QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_4);
         break;
     case 4:
 
-        return QKeySequence(Qt::CTRL + Qt::ALT + Qt::Key_5);
+        return QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_5);
         break;
     case 5:
 
-        return QKeySequence(Qt::CTRL + Qt::ALT + Qt::Key_6);
+        return QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_6);
         break;
     case 6:
 
-        return QKeySequence(Qt::CTRL + Qt::ALT + Qt::Key_7);
+        return QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_7);
         break;
     case 7:
 
-        return QKeySequence(Qt::CTRL + Qt::ALT + Qt::Key_8);
+        return QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_8);
         break;
     case 8:
 
-        return QKeySequence(Qt::CTRL + Qt::ALT + Qt::Key_9);
+        return QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_9);
         break;
     case 9:
 
-        return QKeySequence(Qt::CTRL + Qt::ALT + Qt::Key_0);
+        return QKeySequence(Qt::CTRL | Qt::ALT | Qt::Key_0);
         break;
     default:
 

--- a/Gui/Gui40.cpp
+++ b/Gui/Gui40.cpp
@@ -182,7 +182,7 @@ Gui::updateRecentFileActions()
     assert(files.size() <= (int)NATRON_MAX_RECENT_FILES);
     assert(files.size() == fileNames.size());
     assert(dirNames.size() == fileNames.size());
-    int numRecentFiles = std::min(fileNames.size(), (int)NATRON_MAX_RECENT_FILES);
+    int numRecentFiles = std::min((int)fileNames.size(), (int)NATRON_MAX_RECENT_FILES);
 
     // the dirname can be the same too. for each fileName with count > 1, collect the indices of the identical filenames. if dirname and directory up-level is the same for at least two files, raise the directory level up until the two dirnames are different
     for (std::map<QString,QStringList>::const_iterator it = allDirNames.begin(); it != allDirNames.end(); ++it) {
@@ -196,7 +196,7 @@ Gui::updateRecentFileActions()
             }
             int minComps = dirParts[0].size();
             for (int i = 1; i < dirs.size(); ++i) {
-                minComps = std::min(minComps, dirParts[i].size());
+                minComps = std::min( minComps, (int)dirParts[i].size() );
             }
             // count the number of elements to remove
             int commonComps = 0;

--- a/Gui/GuiApplicationManager.cpp
+++ b/Gui/GuiApplicationManager.cpp
@@ -946,7 +946,9 @@ GuiApplicationManager::initGui(const CLArgs& args)
     QObject::connect( &_imp->updateSplashscreenTimer, SIGNAL(timeout()), this, SLOT(onFontconfigTimerTriggered()) );
     _imp->updateSplashscreenTimer.start(1000);
 
-    _imp->fontconfigUpdateWatcher->setFuture( QtConcurrent::run(_imp.get(), &GuiApplicationManagerPrivate::updateFontConfigCache) );
+    // Qt6 dropped the run(object, memberFunction) overload; a lambda is the one
+    // spelling both versions accept.
+    _imp->fontconfigUpdateWatcher->setFuture( QtConcurrent::run( [p = _imp.get()]() { p->updateFontConfigCache(); } ) );
 
     Gui::loadStyleSheet();
 

--- a/Gui/GuiApplicationManager10.cpp
+++ b/Gui/GuiApplicationManager10.cpp
@@ -41,7 +41,8 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QSettings>
 #include <QFileInfo>
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QGuiApplication>
+#include <QScreen>
 #include <QFileOpenEvent>
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
@@ -299,9 +300,11 @@ GuiApplicationManager::initializeQApp(int &argc,
 #endif
         app = new Application(this, argc, argv);
     }
-    QDesktopWidget* desktop = app->desktop();
-    int dpiX = desktop->logicalDpiX();
-    int dpiY = desktop->logicalDpiY();
+    // QDesktopWidget is gone in Qt6; QScreen carries the same values and exists
+    // in Qt 5.15. Keep the int truncation the QDesktopWidget accessors did.
+    QScreen* screen = QGuiApplication::primaryScreen();
+    int dpiX = screen->logicalDotsPerInchX();
+    int dpiY = screen->logicalDotsPerInchY();
 
     setCurrentLogicalDPI(dpiX, dpiY);
 

--- a/Gui/GuiApplicationManagerPrivate.h
+++ b/Gui/GuiApplicationManagerPrivate.h
@@ -34,6 +34,7 @@
 
 CLANG_DIAG_OFF(deprecated)
 CLANG_DIAG_OFF(uninitialized)
+#include <QCursor>
 #include <QFutureWatcher>
 #include <QString>
 #include <QTimer>

--- a/Gui/Histogram.cpp
+++ b/Gui/Histogram.cpp
@@ -32,7 +32,6 @@
 #include <QVBoxLayout>
 #include <QCheckBox>
 #include <QSplitter>
-#include <QDesktopWidget>
 GCC_DIAG_UNUSED_PRIVATE_FIELD_OFF
 // /opt/local/include/QtGui/qmime.h:119:10: warning: private field 'type' is not used [-Wunused-private-field]
 #include <QMouseEvent>

--- a/Gui/MessageBox.cpp
+++ b/Gui/MessageBox.cpp
@@ -38,7 +38,6 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QCheckBox>
 #include <QTextEdit>
 #include <QApplication>
-#include <QDesktopWidget>
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
@@ -183,7 +182,7 @@ MessageBox::init(const QString & title,
     // -- leave space for information label --
     grid->addWidget(_imp->buttonBox, 2, 0, 1, 2);
 #else
-    grid->setMargin(0);
+    grid->setContentsMargins(0, 0, 0, 0);
     grid->setVerticalSpacing(8);
     grid->setHorizontalSpacing(0);
     setContentsMargins(24, 15, 24, 20);

--- a/Gui/NodeCreationDialog.cpp
+++ b/Gui/NodeCreationDialog.cpp
@@ -37,7 +37,6 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QApplication>
 #include <QListView>
 #include <QSettings>
-#include <QDesktopWidget>
 #include <QRegExp>
 #include <QApplication>
 #include <QStringListModel>

--- a/Gui/NodeCreationDialog.cpp
+++ b/Gui/NodeCreationDialog.cpp
@@ -37,7 +37,7 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QApplication>
 #include <QListView>
 #include <QSettings>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QApplication>
 #include <QStringListModel>
 CLANG_DIAG_ON(deprecated)
@@ -150,13 +150,17 @@ CompleterLineEdit::filterText(const QString & txt)
             pattern.push_back(txt[i]);
         }
         pattern.push_back( QLatin1Char('*') );
-        QRegExp expr(pattern, Qt::CaseInsensitive, QRegExp::WildcardUnix);
+        // The pattern is wildcarded at both ends, so the anchored conversion
+        // matches exactly what exactMatch() and contains() did.
+        QRegularExpression expr(QRegularExpression::wildcardToRegularExpression(pattern),
+                                QRegularExpression::CaseInsensitiveOption);
 
 #ifdef NODE_TAB_DIALOG_USE_MATCHED_LENGTH
         std::map<int, QStringList> matchOrdered;
         for (PluginsNamesMap::iterator it = _imp->names.begin(); it != _imp->names.end(); ++it) {
-            if ( expr.exactMatch(it->second.first) ) {
-                QStringList& matchedForLength =  matchOrdered[expr.matchedLength()];
+            QRegularExpressionMatch match = expr.match(it->second.first);
+            if ( match.hasMatch() ) {
+                QStringList& matchedForLength =  matchOrdered[match.capturedLength()];
                 matchedForLength.push_front(it->second.second);
             }
         }

--- a/Gui/NodeGraph45.cpp
+++ b/Gui/NodeGraph45.cpp
@@ -38,6 +38,7 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QKeyEvent>
 #include <QApplication>
 #include <QCheckBox>
+#include <QRegularExpression>
 GCC_DIAG_UNUSED_PRIVATE_FIELD_ON
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
@@ -368,14 +369,17 @@ FindNodeDialog::updateFindResults(const QString& filter)
     }
     Qt::CaseSensitivity sensitivity = _imp->caseSensitivity->isChecked() ? Qt::CaseSensitive : Qt::CaseInsensitive;
     const NodesGuiList& activeNodes = _imp->graph->getAllActiveNodes();
-    QRegExp exp(_imp->matchWhole->isChecked() ? filter :
-                ( QChar::fromLatin1('*') + filter + QChar::fromLatin1('*') ),
-                sensitivity,
-                QRegExp::Wildcard);
+    // wildcardToRegularExpression() anchors, which is what exactMatch() did.
+    QRegularExpression exp(QRegularExpression::wildcardToRegularExpression(
+                               _imp->matchWhole->isChecked() ? filter :
+                               ( QChar::fromLatin1('*') + filter + QChar::fromLatin1('*') ) ),
+                           sensitivity == Qt::CaseInsensitive ?
+                           QRegularExpression::CaseInsensitiveOption :
+                           QRegularExpression::NoPatternOption);
 
     if ( exp.isValid() ) {
         for (NodesGuiList::const_iterator it = activeNodes.begin(); it != activeNodes.end(); ++it) {
-            if ( (*it)->isVisible() && exp.exactMatch( QString::fromUtf8( (*it)->getNode()->getLabel().c_str() ) ) ) {
+            if ( (*it)->isVisible() && exp.match( QString::fromUtf8( (*it)->getNode()->getLabel().c_str() ) ).hasMatch() ) {
                 _imp->nodeResults.push_back(*it);
             }
         }

--- a/Gui/PreferencesPanel.cpp
+++ b/Gui/PreferencesPanel.cpp
@@ -819,7 +819,10 @@ PreferencesPanel::filterPlugins(const QString & txt)
             pattern.push_back(txt[i]);
         }
         pattern.push_back( QLatin1Char('*') );
-        QRegExp expr(pattern, Qt::CaseInsensitive, QRegExp::WildcardUnix);
+        // The pattern is wildcarded at both ends, so the anchored conversion
+        // matches exactly what the unanchored contains() did.
+        QRegularExpression expr(QRegularExpression::wildcardToRegularExpression(pattern),
+                                QRegularExpression::CaseInsensitiveOption);
         std::list<QTreeWidgetItem*> itemsToDisplay;
         for (PluginTreeNodeList::iterator it = _imp->pluginsList.begin(); it != _imp->pluginsList.end(); ++it) {
             if ( it->plugin && it->plugin->getLabelWithoutSuffix().contains(expr) ) {

--- a/Gui/RenderStatsDialog.cpp
+++ b/Gui/RenderStatsDialog.cpp
@@ -34,7 +34,7 @@
 #include <QHeaderView>
 #include <QCheckBox>
 #include <QItemSelectionModel>
-#include <QRegExp>
+#include <QRegularExpression>
 
 #include "Engine/Node.h"
 #include "Engine/Timer.h"
@@ -1010,12 +1010,14 @@ RenderStatsDialogPrivate::updateVisibleRowsInternal(const QString& nameFilter,
 
 
     if ( useUnixWildcardsCheckbox->isChecked() ) {
-        QRegExp nameExpr(nameFilter, Qt::CaseInsensitive, QRegExp::Wildcard);
+        QRegularExpression nameExpr(QRegularExpression::wildcardToRegularExpression(nameFilter),
+                                    QRegularExpression::CaseInsensitiveOption);
         if ( !nameExpr.isValid() ) {
             return;
         }
 
-        QRegExp idExpr(pluginIDFilter, Qt::CaseInsensitive, QRegExp::Wildcard);
+        QRegularExpression idExpr(QRegularExpression::wildcardToRegularExpression(pluginIDFilter),
+                                  QRegularExpression::CaseInsensitiveOption);
         if ( !idExpr.isValid() ) {
             return;
         }
@@ -1028,8 +1030,8 @@ RenderStatsDialogPrivate::updateVisibleRowsInternal(const QString& nameFilter,
                 continue;
             }
 
-            if ( ( nameFilter.isEmpty() || nameExpr.exactMatch( QString::fromUtf8( node->getLabel().c_str() ) ) ) &&
-                 ( pluginIDFilter.isEmpty() || idExpr.exactMatch( QString::fromUtf8( node->getPluginID().c_str() ) ) ) ) {
+            if ( ( nameFilter.isEmpty() || nameExpr.match( QString::fromUtf8( node->getLabel().c_str() ) ).hasMatch() ) &&
+                 ( pluginIDFilter.isEmpty() || idExpr.match( QString::fromUtf8( node->getPluginID().c_str() ) ).hasMatch() ) ) {
                 if ( view->isRowHidden(i, rootIdx) ) {
                     view->setRowHidden(i, rootIdx, false);
                 }

--- a/Gui/ScaleSliderQWidget.cpp
+++ b/Gui/ScaleSliderQWidget.cpp
@@ -448,7 +448,7 @@ ScaleSliderQWidget::paintEvent(QPaintEvent* /*e*/)
 
     ///fill the background with the appropriate style color
     QStyleOption opt;
-    opt.init(this);
+    opt.initFrom(this);
     QPainter p(this);
     p.setOpacity(1);
     style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);

--- a/Gui/ScriptTextEdit.cpp
+++ b/Gui/ScriptTextEdit.cpp
@@ -33,7 +33,7 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QScrollBar>
 #include <QTextBlock>
 #include <QPainter>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QMimeData>
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
@@ -58,13 +58,13 @@ struct PyHighLightRule
                     const QTextCharFormat &matchingFormat)
     {
         originalRuleStr = patternStr;
-        pattern = QRegExp(patternStr);
+        pattern = QRegularExpression(patternStr);
         nth = n;
         format = matchingFormat;
     }
 
     QString originalRuleStr;
-    QRegExp pattern;
+    QRegularExpression pattern;
     int nth;
     QTextCharFormat format;
 };
@@ -77,8 +77,8 @@ struct PySyntaxHighlighterPrivate
     QStringList braces;
     QHash<QString, QTextCharFormat> basicStyles;
     QList<PyHighLightRule> rules;
-    QRegExp triSingleQuote;
-    QRegExp triDoubleQuote;
+    QRegularExpression triSingleQuote;
+    QRegularExpression triDoubleQuote;
 
     PySyntaxHighlighterPrivate(PySyntaxHighlighter* publicInterface)
         : publicInterface(publicInterface)
@@ -125,13 +125,17 @@ void
 PySyntaxHighlighter::highlightBlock(const QString &text)
 {
     for (QList<PyHighLightRule>::Iterator it = _imp->rules.begin(); it != _imp->rules.end(); ++it) {
-        int idx = it->pattern.indexIn(text, 0);
-        while (idx >= 0) {
+        QRegularExpressionMatch match = it->pattern.match(text, 0);
+        while ( match.hasMatch() ) {
             // Get index of Nth match
-            idx = it->pattern.pos(it->nth);
-            int length = it->pattern.cap(it->nth).length();
+            const int idx = match.capturedStart(it->nth);
+            if (idx < 0) {
+                // The Nth group did not participate in this match.
+                break;
+            }
+            const int length = match.capturedLength(it->nth);
             setFormat(idx, length, it->format);
-            idx = it->pattern.indexIn(text, idx + length);
+            match = it->pattern.match(text, idx + length);
         }
     }
 
@@ -186,7 +190,7 @@ PySyntaxHighlighterPrivate::initializeRules()
 
 bool
 PySyntaxHighlighter::matchMultiline(const QString &text,
-                                    const QRegExp &delimiter,
+                                    const QRegularExpression &delimiter,
                                     const int inState,
                                     const QTextCharFormat &style)
 {
@@ -201,18 +205,20 @@ PySyntaxHighlighter::matchMultiline(const QString &text,
         start = 0;
         add = 0;
     } else {
-        start = delimiter.indexIn(text);
+        const QRegularExpressionMatch startMatch = delimiter.match(text);
+        start = startMatch.capturedStart();
         // Move past this match
-        add = delimiter.matchedLength();
+        add = startMatch.hasMatch() ? startMatch.capturedLength() : 0;
     }
 
     // As long as there's a delimiter match on this line...
     while (start >= 0) {
         // Look for the ending delimiter
-        end = delimiter.indexIn(text, start + add);
+        const QRegularExpressionMatch endMatch = delimiter.match(text, start + add);
+        end = endMatch.capturedStart();
         // Ending delimiter on this line?
         if (end >= add) {
-            length = end - start + add + delimiter.matchedLength();
+            length = end - start + add + endMatch.capturedLength();
             setCurrentBlockState(0);
         } else {
             // No= multi-line string
@@ -221,7 +227,7 @@ PySyntaxHighlighter::matchMultiline(const QString &text,
         }
         // Apply formatting and look for next
         setFormat(start, length, style);
-        start = delimiter.indexIn(text, start + length);
+        start = delimiter.match(text, start + length).capturedStart();
     }
     // Return True if still inside a multi-line string, False otherwise
     if (currentBlockState() == inState) {

--- a/Gui/ScriptTextEdit.h
+++ b/Gui/ScriptTextEdit.h
@@ -34,6 +34,7 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QTextEdit>
 #include <QPlainTextEdit>
 #include <QSyntaxHighlighter>
+#include <QRegularExpression>
 CLANG_DIAG_ON(deprecated)
 CLANG_DIAG_ON(uninitialized)
 
@@ -59,7 +60,7 @@ public:
 private:
 
     virtual void highlightBlock(const QString &text) OVERRIDE FINAL;
-    bool matchMultiline(const QString &text, const QRegExp &delimiter, const int inState, const QTextCharFormat &style);
+    bool matchMultiline(const QString &text, const QRegularExpression &delimiter, const int inState, const QTextCharFormat &style);
 
     std::unique_ptr<PySyntaxHighlighterPrivate> _imp;
 };

--- a/Gui/SequenceFileDialog.cpp
+++ b/Gui/SequenceFileDialog.cpp
@@ -783,13 +783,13 @@ SequenceFileDialog::createMenuActions()
 {
     QAction *goHomeAction =  new QAction(this);
 
-    goHomeAction->setShortcut(Qt::CTRL + Qt::Key_H + Qt::SHIFT);
+    goHomeAction->setShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_H);
     QObject::connect( goHomeAction, SIGNAL(triggered()), this, SLOT(goHome()) );
     addAction(goHomeAction);
 
 
     QAction *goToParent =  new QAction(this);
-    goToParent->setShortcut(Qt::CTRL + Qt::UpArrow);
+    goToParent->setShortcut(Qt::CTRL | Qt::Key_Up);
     QObject::connect( goToParent, SIGNAL(triggered()), this, SLOT(parentFolder()) );
     addAction(goToParent);
 

--- a/Gui/SequenceFileDialog.h
+++ b/Gui/SequenceFileDialog.h
@@ -47,7 +47,6 @@ CLANG_DIAG_OFF(uninitialized)
 #include <QStringList>
 #include <QDir>
 #include <QUrl>
-#include <QRegExp>
 #include <QLatin1Char>
 #include <QSize>
 #include <QComboBox>

--- a/Gui/SplashScreen.cpp
+++ b/Gui/SplashScreen.cpp
@@ -112,7 +112,7 @@ SplashScreen::paintEvent(QPaintEvent*)
 {
     QStyleOption opt;
 
-    opt.init(this);
+    opt.initFrom(this);
     QPainter p(this);
 
     style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
@@ -165,7 +165,7 @@ LoadProjectSplashScreen::paintEvent(QPaintEvent* /*e*/)
 {
     QStyleOption opt;
 
-    opt.init(this);
+    opt.initFrom(this);
     QPainter p(this);
 
     style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);

--- a/Gui/TabWidget.cpp
+++ b/Gui/TabWidget.cpp
@@ -1330,7 +1330,7 @@ TabWidget::paintEvent(QPaintEvent* e)
         QString text = tr("(Viewer Pane)");
         QFontMetrics fm(f);
         QPointF pos(width() / 2., height() / 2.);
-        pos.rx() -= (fm.width(text) / 2.);
+        pos.rx() -= (fm.horizontalAdvance(text) / 2.);
         pos.ry() -= (fm.height() / 2.);
         p.drawText(pos, text);
     }

--- a/Gui/TableModelView.cpp
+++ b/Gui/TableModelView.cpp
@@ -925,8 +925,7 @@ ExpandingLineEdit::updateMinimumWidth()
     QStyleOptionFrame opt;
     initStyleOption(&opt);
 
-    int minWidth = style()->sizeFromContents(QStyle::CT_LineEdit, &opt, QSize(width, 0).
-                                             expandedTo( QApplication::globalStrut() ), this).width();
+    int minWidth = style()->sizeFromContents(QStyle::CT_LineEdit, &opt, QSize(width, 0), this).width();
     setMinimumWidth(minWidth);
 }
 

--- a/Gui/ViewerGL.cpp
+++ b/Gui/ViewerGL.cpp
@@ -82,6 +82,7 @@ GCC_DIAG_UNUSED_PRIVATE_FIELD_ON
 #include "Gui/ViewerTab.h"
 
 #include <QOpenGLContext>
+#include <QRegularExpression>
 
 
 #define USER_ROI_BORDER_TICK_SIZE 15.f
@@ -1069,7 +1070,7 @@ NATRON_NAMESPACE_ANONYMOUS_ENTER
 static QStringList
 explode(const QString& str)
 {
-    QRegExp rx( QString::fromUtf8("(\\ |\\-|\\.|\\/|\\t|\\n)") ); //RegEx for ' ' '/' '.' '-' '\t' '\n'
+    QRegularExpression rx( QString::fromUtf8("(\\ |\\-|\\.|\\/|\\t|\\n)") ); //RegEx for ' ' '/' '.' '-' '\t' '\n'
     QStringList ret;
     int startIndex = 0;
 

--- a/Gui/ViewerGL.cpp
+++ b/Gui/ViewerGL.cpp
@@ -2065,6 +2065,16 @@ ViewerGL::mouseMoveEvent(QMouseEvent* e)
     }
 } // mouseMoveEvent
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+static constexpr QPointingDevice::PointerType kTabletPointerCursor = QPointingDevice::PointerType::Cursor;
+static constexpr QPointingDevice::PointerType kTabletPointerEraser = QPointingDevice::PointerType::Eraser;
+static constexpr QPointingDevice::PointerType kTabletPointerPen = QPointingDevice::PointerType::Pen;
+#else
+static constexpr QTabletEvent::PointerType kTabletPointerCursor = QTabletEvent::Cursor;
+static constexpr QTabletEvent::PointerType kTabletPointerEraser = QTabletEvent::Eraser;
+static constexpr QTabletEvent::PointerType kTabletPointerPen = QTabletEvent::Pen;
+#endif
+
 void
 ViewerGL::tabletEvent(QTabletEvent* e)
 {
@@ -2077,13 +2087,13 @@ ViewerGL::tabletEvent(QTabletEvent* e)
     switch ( e->type() ) {
     case QEvent::TabletPress: {
         switch ( e->pointerType() ) {
-        case QTabletEvent::Cursor:
+        case kTabletPointerCursor:
             _imp->pointerTypeOnPress  = ePenTypeCursor;
             break;
-        case QTabletEvent::Eraser:
+        case kTabletPointerEraser:
             _imp->pointerTypeOnPress  = ePenTypeEraser;
             break;
-        case QTabletEvent::Pen:
+        case kTabletPointerPen:
         default:
             _imp->pointerTypeOnPress  = ePenTypePen;
             break;

--- a/Gui/ViewerTab.cpp
+++ b/Gui/ViewerTab.cpp
@@ -319,7 +319,6 @@ ViewerTab::ViewerTab(const std::list<NodeGuiPtr> & existingNodesContext,
     _imp->refreshButton->setFixedSize(buttonSize);
     _imp->refreshButton->setIconSize(buttonIconSize);
     {
-        QKeySequence seq(Qt::CTRL + Qt::SHIFT);
         std::list<std::string> refreshActions;
         refreshActions.push_back(kShortcutIDActionRefresh);
         refreshActions.push_back(kShortcutIDActionRefreshWithStats);
@@ -338,7 +337,6 @@ ViewerTab::ViewerTab(const std::list<NodeGuiPtr> & existingNodesContext,
     _imp->pauseButton->setChecked(false);
     _imp->pauseButton->setDown(false);
     {
-        QKeySequence seq(Qt::CTRL + Qt::SHIFT);
         std::list<std::string> actions;
         actions.push_back(kShortcutIDActionPauseViewerInputA);
         actions.push_back(kShortcutIDActionPauseViewer);

--- a/global.pri
+++ b/global.pri
@@ -390,6 +390,16 @@ win32-g++ {
       shiboken:  PKGCONFIG += shiboken2
       pyside:    PKGCONFIG += pyside2
     }
+    equals(QT_MAJOR_VERSION, 6) {
+      shiboken:  INCLUDEPATH += $$system(pkg-config --variable=includedir shiboken6)
+      PYSIDE_INCLUDEDIR = $$system(pkg-config --variable=includedir pyside6)
+      pyside:    INCLUDEPATH += $$PYSIDE_INCLUDEDIR
+      pyside:    INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtCore
+      pyside:    INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtGui
+      pyside:    INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtWidgets
+      shiboken:  PKGCONFIG += shiboken6
+      pyside:    PKGCONFIG += pyside6
+    }
     equals(QT_MAJOR_VERSION, 4) {
       shiboken:  PKGCONFIG += shiboken-py$$PYV
     	pyside:    PKGCONFIG += pyside-py$$PYV
@@ -440,6 +450,18 @@ unix {
             pyside:   PKGCONFIG += pyside2
             # add QtCore to includes
             PYSIDE_INCLUDEDIR = $$system(pkg-config --variable=includedir pyside2)
+            pyside:   INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtCore
+            pyside:   INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtGui
+            pyside:   INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtWidgets
+        }
+    }
+
+    equals(QT_MAJOR_VERSION, 6) {
+        system(pkg-config --exists pyside6) {
+            shiboken: PKGCONFIG += shiboken6
+            pyside:   PKGCONFIG += pyside6
+            # add QtCore to includes
+            PYSIDE_INCLUDEDIR = $$system(pkg-config --variable=includedir pyside6)
             pyside:   INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtCore
             pyside:   INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtGui
             pyside:   INCLUDEPATH += $$PYSIDE_INCLUDEDIR/QtWidgets

--- a/libs/libmv/libmv/logging/logging.h
+++ b/libs/libmv/libmv/logging/logging.h
@@ -35,8 +35,10 @@ true ? (void) 0 : google::LogMessageVoidify() & LOG(severity)
 #endif
 
 #define LG LIBMV_LOG(INFO)
-#define V0 LIBMV_LOG(INFO)
-#define V1 LIBMV_LOG(INFO)
-#define V2 LIBMV_LOG(INFO)
+
+// V0, V1 and V2 used to be defined here as aliases for LG. Nothing in libmv or
+// in Natron ever used them, and Qt6 names a template parameter V2 in
+// qnumeric.h, so any translation unit including this header before QtCore
+// failed to compile.
 
 #endif  // LIBMV_LOGGING_LOGGING_H

--- a/libs/qhttpserver/src/qhttprequest.h
+++ b/libs/qhttpserver/src/qhttprequest.h
@@ -46,7 +46,7 @@ class QHTTPSERVER_API QHttpRequest : public QObject
     Q_PROPERTY(HeaderHash headers READ headers)
     Q_PROPERTY(QString remoteAddress READ remoteAddress)
     Q_PROPERTY(quint16 remotePort READ remotePort)
-    Q_PROPERTY(QString method READ method)
+    Q_PROPERTY(HttpMethod method READ method)
     Q_PROPERTY(QUrl url READ url)
     Q_PROPERTY(QString path READ path)
     Q_PROPERTY(QString httpVersion READ httpVersion)


### PR DESCRIPTION
Steps 2 through 4 and step 6 of
`Documentation/source/maintainers/qt6-migration.rst`: the tree builds and runs
against Qt6 with Qt5 still working, and CI builds both.

Stacked on #1084, whose four commits are the first four here. The ten new
ones start at `qmake: add a Qt6 path matching CMake's NATRON_QT6`.

There is already a Qt6 PR, #1019 by @YakoYakoYokuYoku, open against RB-2.7.
This one came from the audit in the migration chapter rather than from that
branch and targets RB-2.6, so they are two separate attempts at the same
goal. Fold this into #1019, rebase it to RB-2.7, or close it, whichever suits
you.

Following the doc's preference order (unchanged API, then a `QtCompat.h`
shim, then a local `#if`):

- qmake gets a `QT_MAJOR_VERSION` path mirroring CMake's `NATRON_QT6`.
- `QtCompat::MutexLock` type-erases QMutex and QRecursiveMutex. Qt6 stopped
  QRecursiveMutex deriving from QMutex and made QMutexLocker a template, so a
  deferred locker holding either kind by branch has no single type left.
- `QWidget::nativeEvent` goes through a `NativeEventResult` typedef. That
  parameter is `long*` on Qt5 and `qintptr*` on Qt6, distinct types on 64-bit
  Windows, and naming the wrong one does not fail to compile, it stops
  overriding, which would silently kill the DDE file association handling.
- The Engine typesystem declares `PyList`. PySide2 declared the CPython types
  in `typesystem_core_common.xml` and PySide6 declares none. It is not
  cosmetic: it generates the `PyList_Check(pyArgs[0])` discriminator that
  separates `App.render(list)` from `App.render(Effect,int,int,int)`. Checked
  by regenerating the Qt5 bindings and getting a byte-identical 98-file tree.
- libmv's `logging.h` defined `V0`, `V1` and `V2`, and Qt6 names a template
  parameter `V2` in `qnumeric.h`. All three were dead tree-wide against 186
  uses of `LG`, so they are deleted rather than worked around per file.
- CI builds and tests Windows against both toolkits.

What is verified, on Windows/MinGW with Qt 6.11, PySide6, Shiboken6 and
Python 3.14: `objdump -p` confirms the Qt6 modules link rather than an
accidental Qt5. Both toolkits load the same 40 plugins, run the unit tests to
the same result, and render a byte-identical PNG, so the OFX host, the
reader/writer pipeline, colour management and the render engine come out
pixel-exact under Qt6. The Qt5 build was re-checked after every commit.

What is not: the GUI was driven by hand under Qt6 far enough to see it launch
and draw, connect nodes in the node graph and render, but the file dialog
wildcard filtering, the Ctrl+Alt+N view shortcuts, the dope sheet, the curve
editor, tablet input and multi-monitor were not exercised. Linux and macOS
are untouched here and their CI jobs stay Qt5.

The qmake Qt6 path is written to match CMake but is unproven, because MSYS2's
Qt6 qmake cannot configure a two-line hello-world `.pro` either: it dies in
`mkspecs/features/toolchain.prf` probing the compiler, before any project
file is read. CMake builds Qt6 completely.

Four are late additions, found by building this under Qt6 on Linux, which as
far as I can tell had not been done before. Two of them are debug-only:

- Qt6 made QVariant's debug operator a hidden friend template constrained to
  `std::is_same_v<T, QVariant>`. T deduces to the derived class for anything
  inheriting QVariant, the constraint fails, and the derived-to-base conversion
  Qt5 relied on is never considered, so `Variant` no longer streams and
  KnobUndoCommand.cpp does not compile. Variant gets its own operator that
  forwards to the base.
- `QFontMetrics::width` survived in TabWidget.cpp behind `#ifdef DEBUG`.
  horizontalAdvance replaces it and exists from Qt 5.11, so Qt5 is unchanged.

Neither is reachable from a release build: CMakeLists.txt defines
QT_NO_DEBUG_OUTPUT there, and qDebug() becomes a QNoDebug whose templated
operator<< swallows any type. That is also a gap in the CI job this PR adds,
which builds RelWithDebInfo only and would not have caught either one. A debug
leg on that matrix would close it; say so and I will add one.

The other two are not Qt6-only but surfaced there:

- Xlib defines `Status` as a macro and Qt6's qtextstream.h refuses to compile
  when it is already defined, so OSGLContext_x11.cpp now includes Qt before
  X11. Qt5 tolerated it, and the file is behind `__NATRON_LINUX__`, so no
  other platform ever saw it.
- Qt's PySide6 wheels are stable-ABI builds whose imported target propagates
  Py_LIMITED_API, which has no PyTuple_GET_ITEM, PyList_SET_ITEM or
  PyRun_String. The typesystem glue calls all three, so the definition is
  filtered off the target. It is a no-op against a source-built shiboken, and
  it is what lets the bindings build against the wheels at all.

CI on the fork, all three legs green, the Qt6 one included:
https://github.com/lockewerks/Natron/actions/runs/33893630367
That run installs `mingw-w64-x86_64-natron-build-deps-qt6` from this repo's
own published package repo at the version RB-2.6 already pins, 20250524-1, so
the new matrix leg needs nothing published to go green here.
